### PR TITLE
Typo: vote_perecent to vote_percent

### DIFF
--- a/src/utils/postParser.js
+++ b/src/utils/postParser.js
@@ -165,7 +165,7 @@ const parseActiveVotes = (post, currentUserName) => {
 
   if (!isEmpty(post.active_votes)) {
     forEach(post.active_votes, value => {
-      post.vote_perecent = value.voter === currentUserName ? value.percent : null;
+      post.vote_percent = value.voter === currentUserName ? value.percent : null;
       value.value = (value.rshares * ratio).toFixed(3);
       value.reputation = getReputation(get(value, 'reputation'));
       value.percent /= 100;


### PR DESCRIPTION
### What does this PR do ?
Just a simple typo fix for a variable that I randomly spotted in postParser.js. I have very little knowledge of the overall esteem codebase, so this should be reviewed but I'm 99% sure this is just a typo.