### PR TITLE
nt/manifest-fix

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -11,12 +11,11 @@
     <uses-feature android:name="android.hardware.camera.front" android:required="false" />
 
     <queries>
-    <intent>
-        <action android:name="android.intent.action.VIEW" />
-        <category android:name="android.intent.category.BROWSABLE" />
-        <data android:scheme="https" />
-        <data android:scheme="http" />
-    </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <category android:name="android.intent.category.BROWSABLE" />
+            <data android:scheme="https" />
+        </intent>
     </queries>
 
     <application


### PR DESCRIPTION
Removed http data scheme from queries intent.
we can support http as well though, but I doubt we require that as android production app also do not support http calls there is not point open external links with http.

