### PR TITLE
disabled media auto play in webview

### DIFF
--- a/src/components/postElements/body/view/postBodyView.js
+++ b/src/components/postElements/body/view/postBodyView.js
@@ -521,6 +521,7 @@ const PostBody = ({
         scalesPageToFit={false}
         zoomable={false}
         onLoadEnd={_handleLoadEnd}
+        mediaPlaybackRequiresUserAction={true}
       />
     </Fragment>
   );


### PR DESCRIPTION
there is a draw back of dabblr video always showing loading indicator but plays as soon play button is pressed, but I believe it is less of a problem then having all videos being played at once...

I would call this a hack, a more suitable solution if we plan on using unified system of modal player for all videos is to replace all iframes with video thumbnail under markdown video link, there are other systems that rely on iframe including vimeo but they do not seem cause the problem like dabblr is causing

### Screenshots/Video
https://user-images.githubusercontent.com/6298342/136916071-4cfe948a-5f65-4e60-9a71-665868e45e37.mov
