### PR TITLE
fixed null exception while parsing media urls from reply modal

### DIFF
--- a/src/screens/editor/container/editorContainer.tsx
+++ b/src/screens/editor/container/editorContainer.tsx
@@ -166,7 +166,7 @@ class EditorContainer extends Component<EditorContainerProps, any> {
           if (_draft && !!_draft.body) {
             const _mediaUrls = navigationParams.replyMediaUrls;
             _draftBody =
-              _mediaUrls.length > 0 ? `${_draft.body}\n\n ![](${_mediaUrls[0]})` : _draft.body;
+              _mediaUrls?.length > 0 ? `${_draft.body}\n\n ![](${_mediaUrls[0]})` : _draft.body;
           }
         }
 


### PR DESCRIPTION
### What does this PR?
while assessing comment issue recently reported, I encountered another small bug related to editor expansion from quick reply to full editor