### PR TITLE
patched render helper for post line break

### DIFF
--- a/patches/@ecency+render-helper+2.3.17.patch
+++ b/patches/@ecency+render-helper+2.3.17.patch
@@ -1,0 +1,58 @@
+diff --git a/node_modules/@ecency/render-helper/src/methods/a.method.ts b/node_modules/@ecency/render-helper/src/methods/a.method.ts
+index c80e09c..af4474a 100644
+--- a/node_modules/@ecency/render-helper/src/methods/a.method.ts
++++ b/node_modules/@ecency/render-helper/src/methods/a.method.ts
+@@ -147,6 +147,13 @@ export function a(el: HTMLElement | null, forApp: boolean, webp: boolean): void
+       el.setAttribute('href', h)
+       el.setAttribute('data-is-inline', '' + isInline)
+     }
++    
++    // Add <br/> before non-inline markdown-post-link to ensure it renders on a new line
++    if (!isInline && el.parentNode) {
++      const br = el.ownerDocument.createElement('br')
++      el.parentNode.insertBefore(br, el)
++    }
++    
+     return
+   }
+ 
+@@ -236,6 +243,12 @@ export function a(el: HTMLElement | null, forApp: boolean, webp: boolean): void
+         el.setAttribute('data-is-inline', '' + isInline)
+       }
+ 
++      // Add <br/> before non-inline markdown-post-link to ensure it renders on a new line
++      if (!isInline && el.parentNode) {
++        const br = el.ownerDocument.createElement('br')
++        el.parentNode.insertBefore(br, el)
++      }
++
+       return
+     }
+   }
+@@ -315,6 +328,12 @@ export function a(el: HTMLElement | null, forApp: boolean, webp: boolean): void
+         el.setAttribute('data-is-inline', '' + isInline)
+       }
+ 
++      // Add <br/> before non-inline markdown-post-link to ensure it renders on a new line
++      if (!isInline && el.parentNode) {
++        const br = el.ownerDocument.createElement('br')
++        el.parentNode.insertBefore(br, el)
++      }
++
+       return
+     }
+   }
+@@ -420,6 +439,13 @@ export function a(el: HTMLElement | null, forApp: boolean, webp: boolean): void
+       el.setAttribute('href', h)
+       el.setAttribute('data-is-inline', '' + isInline)
+     }
++    
++    // Add <br/> before non-inline markdown-post-link to ensure it renders on a new line
++    if (!isInline && el.parentNode) {
++      const br = el.ownerDocument.createElement('br')
++      el.parentNode.insertBefore(br, el)
++    }
++    
+     return
+   }
+ 


### PR DESCRIPTION
### What does this PR?
test patch for checking misaligned post link preview, no need to make it part of @ecency/render-helper yet.

### Screenshots/Video
**BEFORE**
<img width="253" height="545" alt="Screenshot 2025-12-05 at 18 29 23" src="https://github.com/user-attachments/assets/9dc135a6-330b-46b6-988a-8056edb2db36" />

**AFTER**
<img width="276" height="629" alt="Screenshot 2025-12-05 at 19 24 30" src="https://github.com/user-attachments/assets/a1d77336-da46-4512-9e68-49464319a362" />

