### PR TITLE
fixed all three methods for key upgrade

### DIFF
--- a/src/providers/hive/dhive.ts
+++ b/src/providers/hive/dhive.ts
@@ -35,6 +35,7 @@ import { getName, getAvatar, parseReputation } from '../../utils/user';
 import AUTH_TYPE from '../../constants/authType';
 import { SERVER_LIST } from '../../constants/options/api';
 import { b64uEnc } from '../../utils/b64';
+import { delay } from '../../utils/editor';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 global.Buffer = global.Buffer || require('buffer').Buffer;
@@ -159,10 +160,12 @@ let _cachedSheetNames: typeof import('../../navigation/sheets').SheetNames | nul
 
 const getSheetDeps = async () => {
   if (!_cachedSheetManager || !_cachedSheetNames) {
-    const [actionSheetModule, sheetsModule] = await Promise.all([
-      import('react-native-actions-sheet'),
-      import('../../navigation/sheets'),
-    ]);
+    // Use require here to avoid Metro's async import() wrapper
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const actionSheetModule = require('react-native-actions-sheet');
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const sheetsModule = require('../../navigation/sheets');
+
     _cachedSheetManager = actionSheetModule.SheetManager;
     _cachedSheetNames = sheetsModule.SheetNames;
   }
@@ -224,6 +227,7 @@ const _executeHiveAuthFallback = async (
     // is called from the sheet component. The result is passed as hide()'s payload.
     // This ensures the caller receives the result AFTER the sheet and its reanimated
     // animations are fully hidden — no component tree conflicts.
+    await delay(500); // NOTE: this hack makes sure first upgrade sheet is closed before showing the second one,
     const response = await Promise.race([
       SheetManager.show(SheetNames.HIVE_AUTH_BROADCAST, {
         payload: { operations },

--- a/src/providers/sdk/mobilePlatformAdapter.ts
+++ b/src/providers/sdk/mobilePlatformAdapter.ts
@@ -54,10 +54,12 @@ let _authUpgradeUseHiveSigner = false;
 
 const getSheetDeps = async () => {
   if (!_cachedSheetManager || !_cachedSheetNames) {
-    const [actionSheetModule, sheetsModule] = await Promise.all([
-      import('react-native-actions-sheet'),
-      import('../../navigation/sheets'),
-    ]);
+    // Use require here to avoid Metro's async import() wrapper
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const actionSheetModule = require('react-native-actions-sheet');
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const sheetsModule = require('../../navigation/sheets');
+
     _cachedSheetManager = actionSheetModule.SheetManager;
     _cachedSheetNames = sheetsModule.SheetNames;
   }


### PR DESCRIPTION
The primary issues for hive auth sheet not appearing is the sheets malfunction when trigger one after the other, a hack is to added some delay to make sure second is only triggered after first is down.

However a more better solution is to declare second sheet as dependant on other in sheet manager, may next iteration we will do that if required


https://github.com/user-attachments/assets/cb294a3e-c4e0-4b19-b3eb-60ddc01a6468


https://github.com/user-attachments/assets/57c2dba5-ade5-4e80-bab8-4170490c8836


https://github.com/user-attachments/assets/fff1a489-4740-4524-994b-e299ef25e5ac

