### PR TITLE
3Speak player and copy/paste images

### DIFF
--- a/src/components/markdownEditor/children/editorToolbar.tsx
+++ b/src/components/markdownEditor/children/editorToolbar.tsx
@@ -1,5 +1,16 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { Keyboard, View, ViewStyle, Platform, ScrollView } from 'react-native';
+import {
+  AppState,
+  Keyboard,
+  View,
+  ViewStyle,
+  Platform,
+  ScrollView,
+  TouchableOpacity,
+  Text,
+} from 'react-native';
+import Clipboard from '@react-native-clipboard/clipboard';
+import { useIntl } from 'react-intl';
 import {
   Gesture,
   GestureDetector,
@@ -66,6 +77,7 @@ export const EditorToolbar = ({
 }: Props) => {
   const navigation = useNavigation();
   const insets = useSafeAreaInsets();
+  const intl = useIntl();
 
   const currentAccount = useAppSelector(selectCurrentAccount);
   const pollDraft = useAppSelector(
@@ -81,6 +93,8 @@ export const EditorToolbar = ({
   const [isExtensionVisible, setIsExtensionVisible] = useState(false);
   const [isKeyboardVisible, setKeyboardVisible] = useState(false);
   const [keyboardHeight, setKeyboardHeight] = useState(0);
+  const [hasClipboardImage, setHasClipboardImage] = useState(false);
+  const dismissedClipboardRef = useRef(false);
 
   useEffect(() => {
     const keyboardDidShowListener = Keyboard.addListener('keyboardDidShow', (e) => {
@@ -98,6 +112,35 @@ export const EditorToolbar = ({
       keyboardDidHideListener.remove();
       keyboardDidShowListener.remove();
     };
+  }, []);
+
+  // iOS-only: detect images in the clipboard so we can offer a quick paste
+  // affordance without keeping a dedicated toolbar icon. Re-checks on mount
+  // and whenever the app returns to the foreground (typical copy → switch
+  // back flow). Once dismissed, stays dismissed for this composer instance.
+  useEffect(() => {
+    if (Platform.OS !== 'ios') {
+      return;
+    }
+    const checkClipboard = async () => {
+      if (dismissedClipboardRef.current) {
+        return;
+      }
+      try {
+        const has = await Clipboard.hasImage();
+        setHasClipboardImage(has);
+      } catch {
+        setHasClipboardImage(false);
+      }
+    };
+    checkClipboard();
+    const sub = AppState.addEventListener('change', (state) => {
+      if (state === 'active') {
+        dismissedClipboardRef.current = false;
+        checkClipboard();
+      }
+    });
+    return () => sub.remove();
   }, []);
 
   const _prepareExtensionToggle = (revealWhenReady, onReady) => {
@@ -140,7 +183,14 @@ export const EditorToolbar = ({
   };
 
   const _pasteImageFromClipboard = () => {
+    setHasClipboardImage(false);
+    dismissedClipboardRef.current = true;
     uploadsGalleryModalRef.current?.pasteImageFromClipboard?.();
+  };
+
+  const _dismissClipboardChip = () => {
+    setHasClipboardImage(false);
+    dismissedClipboardRef.current = true;
   };
 
   const _showAiAssist = () => {
@@ -310,9 +360,37 @@ export const EditorToolbar = ({
     paddingBottom: !isKeyboardVisible ? insets.bottom : 0,
   };
 
+  const _renderClipboardChip = () => {
+    if (!hasClipboardImage || isPreviewActive || isExtensionVisible) {
+      return null;
+    }
+    return (
+      <View style={styles.clipboardChipWrapper}>
+        <TouchableOpacity
+          activeOpacity={0.8}
+          onPress={_pasteImageFromClipboard}
+          style={styles.clipboardChip}
+        >
+          <Text style={styles.clipboardChipText}>
+            {intl.formatMessage({ id: 'editor.clipboard_image_detected' })} ·{' '}
+            {intl.formatMessage({ id: 'editor.paste_image' })}
+          </Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          onPress={_dismissClipboardChip}
+          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+          style={styles.clipboardChipClose}
+        >
+          <Text style={styles.clipboardChipText}>×</Text>
+        </TouchableOpacity>
+      </View>
+    );
+  };
+
   return (
     <View style={_keyboardAdjustedStyle}>
       {_renderExtension()}
+      {_renderClipboardChip()}
 
       {!isPreviewActive && (
         <View style={_buttonsContainerStyle}>
@@ -365,22 +443,13 @@ export const EditorToolbar = ({
 
             <IconButton
               onPress={_showImageUploads}
+              onLongPress={Platform.OS === 'ios' ? _pasteImageFromClipboard : undefined}
               style={styles.rightIcons}
               size={18}
               iconStyle={styles.icon}
               iconType="FontAwesome"
               name="image"
             />
-            {Platform.OS === 'ios' && (
-              <IconButton
-                onPress={_pasteImageFromClipboard}
-                style={styles.rightIcons}
-                size={20}
-                iconStyle={styles.icon}
-                iconType="MaterialCommunityIcons"
-                name="content-paste"
-              />
-            )}
             <IconButton
               onPress={_showAiImageGenerator}
               style={styles.rightIcons}

--- a/src/components/markdownEditor/children/editorToolbar.tsx
+++ b/src/components/markdownEditor/children/editorToolbar.tsx
@@ -136,7 +136,6 @@ export const EditorToolbar = ({
     checkClipboard();
     const sub = AppState.addEventListener('change', (state) => {
       if (state === 'active') {
-        dismissedClipboardRef.current = false;
         checkClipboard();
       }
     });
@@ -380,6 +379,8 @@ export const EditorToolbar = ({
           onPress={_dismissClipboardChip}
           hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
           style={styles.clipboardChipClose}
+          accessibilityRole="button"
+          accessibilityLabel={intl.formatMessage({ id: 'alert.cancel' })}
         >
           <Text style={styles.clipboardChipText}>×</Text>
         </TouchableOpacity>

--- a/src/components/markdownEditor/styles/editorToolbarStyles.ts
+++ b/src/components/markdownEditor/styles/editorToolbarStyles.ts
@@ -105,4 +105,29 @@ export default EStyleSheet.create({
     fontWeight: '800',
     lineHeight: 10,
   },
+  clipboardChipWrapper: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    alignSelf: 'flex-start',
+    marginHorizontal: 12,
+    marginTop: 6,
+    marginBottom: 4,
+    paddingLeft: 12,
+    paddingRight: 4,
+    paddingVertical: 6,
+    borderRadius: 16,
+    backgroundColor: '$primaryLightBackground',
+  } as ViewStyle,
+  clipboardChip: {
+    flexShrink: 1,
+  } as ViewStyle,
+  clipboardChipClose: {
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+  } as ViewStyle,
+  clipboardChipText: {
+    color: '$primaryDarkText',
+    fontSize: 12,
+    fontWeight: '600',
+  },
 });

--- a/src/components/postHtmlRenderer/postHtmlRenderer.tsx
+++ b/src/components/postHtmlRenderer/postHtmlRenderer.tsx
@@ -334,12 +334,32 @@ export const PostHtmlRenderer = memo(
           if (isComment) {
             return <VideoThumb contentWidth={contentWidth} uri={thumbUri} onPress={_onPress} />;
           } else {
+            // For non-YouTube embeds (e.g. 3Speak), route taps to the fullscreen
+            // player so the play button is reliably reachable.
+            if (!parsedTnode.youtubeId) {
+              return (
+                <TouchableOpacity
+                  activeOpacity={0.9}
+                  onPress={_onPress}
+                  style={{ width: contentWidth }}
+                >
+                  <View pointerEvents="none">
+                    <VideoPlayer
+                      mode="uri"
+                      contentWidth={contentWidth}
+                      uri={parsedTnode.videoHref}
+                      disableAutoplay={true}
+                      thumbnailUrl={thumbUri}
+                    />
+                  </View>
+                </TouchableOpacity>
+              );
+            }
             return (
               <View style={{ width: contentWidth }}>
                 <VideoPlayer
-                  mode={parsedTnode.youtubeId ? 'youtube' : 'uri'}
+                  mode="youtube"
                   contentWidth={contentWidth}
-                  uri={parsedTnode.videoHref}
                   youtubeVideoId={parsedTnode.youtubeId}
                   startTime={parsedTnode.startTime}
                   disableAutoplay={true}
@@ -549,16 +569,40 @@ export const PostHtmlRenderer = memo(
           );
         } else {
           const isSpeakEmbed = /3speak\.tv/i.test(iframeProps.source.uri || '');
+          // For 3Speak embeds, route taps to the fullscreen player so the play
+          // button is reliably reachable; the inline WebView's iframe controls
+          // are not always tappable on device.
+          if (isSpeakEmbed) {
+            const _onPress = () => {
+              if (handleVideoPress) {
+                handleVideoPress(iframeProps.source.uri, _metadataThumbUrl);
+              }
+            };
+            return (
+              <TouchableOpacity
+                activeOpacity={0.9}
+                onPress={_onPress}
+                style={[
+                  styles.embeddedVideoWrapper,
+                  { width: contentWidth, maxWidth: contentWidth },
+                ]}
+              >
+                <View pointerEvents="none">
+                  <VideoPlayer
+                    mode="uri"
+                    uri={iframeProps.source.uri}
+                    contentWidth={contentWidth}
+                    thumbnailUrl={_metadataThumbUrl}
+                  />
+                </View>
+              </TouchableOpacity>
+            );
+          }
           return (
             <View
               style={[styles.embeddedVideoWrapper, { width: contentWidth, maxWidth: contentWidth }]}
             >
-              <VideoPlayer
-                mode="uri"
-                uri={iframeProps.source.uri}
-                contentWidth={contentWidth}
-                thumbnailUrl={isSpeakEmbed ? _metadataThumbUrl : undefined}
-              />
+              <VideoPlayer mode="uri" uri={iframeProps.source.uri} contentWidth={contentWidth} />
             </View>
           );
         }

--- a/src/components/postHtmlRenderer/postHtmlRenderer.tsx
+++ b/src/components/postHtmlRenderer/postHtmlRenderer.tsx
@@ -335,12 +335,19 @@ export const PostHtmlRenderer = memo(
             return <VideoThumb contentWidth={contentWidth} uri={thumbUri} onPress={_onPress} />;
           } else {
             // For non-YouTube embeds (e.g. 3Speak), route taps to the fullscreen
-            // player so the play button is reliably reachable.
+            // player so the play button is reliably reachable. Forward the
+            // embed-specific poster (parsed from the <img class="video-thumbnail">)
+            // rather than the first metadata image used by _handleOnLinkPress.
             if (!parsedTnode.youtubeId) {
+              const _onVideoPress = () => {
+                if (handleVideoPress && parsedTnode.videoHref) {
+                  handleVideoPress(parsedTnode.videoHref, thumbUri);
+                }
+              };
               return (
                 <TouchableOpacity
                   activeOpacity={0.9}
-                  onPress={_onPress}
+                  onPress={_onVideoPress}
                   style={{ width: contentWidth }}
                 >
                   <View pointerEvents="none">

--- a/src/components/postHtmlRenderer/postHtmlRenderer.tsx
+++ b/src/components/postHtmlRenderer/postHtmlRenderer.tsx
@@ -348,7 +348,6 @@ export const PostHtmlRenderer = memo(
                       mode="uri"
                       contentWidth={contentWidth}
                       uri={parsedTnode.videoHref}
-                      disableAutoplay={true}
                       thumbnailUrl={thumbUri}
                     />
                   </View>

--- a/src/config/locales/en-US.json
+++ b/src/config/locales/en-US.json
@@ -348,6 +348,8 @@
     "reward_power_up": "Stake 100%",
     "open_gallery": "Open Gallery",
     "clipboard_no_image": "No image found in clipboard",
+    "clipboard_image_detected": "Image in clipboard",
+    "paste_image": "Paste image",
     "done": "DONE",
     "setting_beneficiary": "Beneficiary",
     "tag_duplicate": "Tag exists already",

--- a/src/utils/clipboard.ts
+++ b/src/utils/clipboard.ts
@@ -1,6 +1,7 @@
 import Clipboard from '@react-native-clipboard/clipboard';
 import { Platform } from 'react-native';
 import { ImageManipulator, SaveFormat } from 'expo-image-manipulator';
+import RNFetchBlob from 'rn-fetch-blob';
 
 const readFromClipboard = async (): Promise<string> => {
   const clipboardContent = await Clipboard.getString();
@@ -42,11 +43,16 @@ const readImageFromClipboard = async (): Promise<ClipboardImage | null> => {
     return null;
   }
 
-  // Materialize the base64 PNG to a real file URI so the upload pipeline
-  // (FormData + multipart) and HEIC/compress paths can treat it like any picked image.
-  const dataUri = `data:image/png;base64,${base64}`;
-  const rendered = await ImageManipulator.manipulate(dataUri).renderAsync();
+  // expo-image-manipulator on iOS does not reliably accept data: URIs, so
+  // first write the base64 PNG to a temp file and pass the file:// URI.
+  const timestamp = Date.now();
+  const tempPath = `${RNFetchBlob.fs.dirs.CacheDir}/pasted_${timestamp}.png`;
+  await RNFetchBlob.fs.writeFile(tempPath, base64, 'base64');
+  const fileUri = `file://${tempPath}`;
+  const rendered = await ImageManipulator.manipulate(fileUri).renderAsync();
   const result = await rendered.saveAsync({ format: SaveFormat.JPEG, compress: 0.9 });
+  // Best-effort cleanup of the intermediate PNG; ignore failures.
+  RNFetchBlob.fs.unlink(tempPath).catch(() => {});
 
   return {
     path: result.uri,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * iOS clipboard image chip: detects clipboard images, shows localized "paste" chip, can be pasted or dismissed; re-checks when app returns to foreground.
  * iOS image button long-press triggers paste; legacy dedicated paste icon removed.
  * Improved tap handling for embedded videos and 3Speak iframes to open via the video viewer.
  * Clipboard image processing now converts and compresses images before pasting.
  * Added related localization strings for the editor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->