### PR TITLE
Engine tokens multi send

### DIFF
--- a/src/containers/transferContainer.ts
+++ b/src/containers/transferContainer.ts
@@ -322,14 +322,34 @@ class TransferContainer extends Component {
       if (tokenLayer === TokenLayers.ENGINE) {
         const amountStr = data.amount.split(' ')[0];
         switch (transferType) {
-          case TransferTypes.TRANSFER:
-            await mutations.transferEngine.mutateAsync({
-              to: data.destination,
-              symbol: fundType,
-              quantity: amountStr,
-              memo: data.memo,
-            });
+          case TransferTypes.TRANSFER: {
+            const destinations = data.destination
+              .trim()
+              .split(/[\s,]+/)
+              .filter(Boolean);
+            if (destinations.length === 0) {
+              throw new Error('No valid transfer destinations provided');
+            }
+            if (destinations.length > 50) {
+              throw new Error(`Too many recipients (${destinations.length}), max is 50`);
+            }
+            if (destinations.length === 1) {
+              await mutations.transferEngine.mutateAsync({
+                to: destinations[0],
+                symbol: fundType,
+                quantity: amountStr,
+                memo: data.memo,
+              });
+            } else {
+              await mutations.multiEngineTransfer.mutateAsync({
+                destinations,
+                symbol: fundType,
+                quantity: amountStr,
+                memo: data.memo,
+              });
+            }
             break;
+          }
           case TransferTypes.STAKE:
             await mutations.stakeEngine.mutateAsync({
               to: data.destination || from,

--- a/src/hooks/useTransferMutations.ts
+++ b/src/hooks/useTransferMutations.ts
@@ -26,6 +26,8 @@ import {
 import { useAuthContext } from '../providers/sdk';
 import { selectCurrentAccount } from '../redux/selectors';
 import type { RootState } from '../redux/store/store';
+import { getEngineActionOpArray } from '../providers/hive-engine/hiveEngineActions';
+import { EngineActions } from '../providers/hive-engine/hiveEngine.types';
 
 /**
  * Bundles all transfer-related SDK mutation hooks into a single object.
@@ -162,6 +164,39 @@ export function useTransferMutations() {
   const unstakeEngine = useUnstakeEngineTokenMutation();
   const undelegateEngine = useUndelegateEngineTokenMutation();
 
+  // Multi-recipient ENGINE token transfer — single broadcast for all destinations
+  const multiEngineTransfer = useBroadcastMutation(
+    ['wallet', 'multi-transfer-engine'],
+    username || '',
+    ({
+      destinations,
+      symbol,
+      quantity,
+      memo,
+    }: {
+      destinations: string[];
+      symbol: string;
+      quantity: string;
+      memo: string;
+    }) =>
+      destinations.flatMap((dest) =>
+        getEngineActionOpArray(
+          EngineActions.TRANSFER,
+          requireUsername(),
+          dest,
+          `${quantity} ${symbol}`,
+          symbol,
+          memo,
+        ),
+      ),
+    (_data, { destinations }) => {
+      runPostBroadcastInvalidation(destinations, 'multiEngineTransfer');
+    },
+    authContext,
+    'active',
+    { broadcastMode: 'async' },
+  );
+
   // SPK layer
   const transferSpk = useTransferSpkMutation();
   const transferLarynx = useTransferLarynxMutation();
@@ -211,6 +246,7 @@ export function useTransferMutations() {
     multiTransfer,
     // ENGINE
     transferEngine,
+    multiEngineTransfer,
     stakeEngine,
     delegateEngine,
     unstakeEngine,

--- a/src/screens/transfer/screen/transferScreen.tsx
+++ b/src/screens/transfer/screen/transferScreen.tsx
@@ -173,7 +173,8 @@ const TransferView = ({
         setUsersResult([]);
         return;
       }
-      if (usernames.length > 5) {
+      const maxUsernames = allowMultipleDest ? 50 : 5;
+      if (usernames.length > maxUsernames) {
         dispatch(toastNotification(intl.formatMessage({ id: 'transfer.too_many_usernames' })));
         setIsUsernameValid(false);
         setUsersResult([]);
@@ -224,7 +225,7 @@ const TransferView = ({
 
       setIsUsernameValid(validationResults.every((result) => result));
     }, 300),
-    [recurrentTransfers],
+    [recurrentTransfers, allowMultipleDest],
   );
 
   // --- Validate prefilled destination on mount ---
@@ -380,7 +381,10 @@ const TransferView = ({
   // --- HiveSigner Path ---
   let path;
   if (hsTransfer) {
-    const destinations = destination.trim().split(/[\s,]+/);
+    const destinations = destination
+      .trim()
+      .split(/[\s,]+/)
+      .filter(Boolean);
 
     if (isEngineToken) {
       if (transferType === TransferTypes.TRANSFER && destinations.length > 1) {

--- a/src/screens/transfer/screen/transferScreen.tsx
+++ b/src/screens/transfer/screen/transferScreen.tsx
@@ -128,7 +128,8 @@ const TransferView = ({
 
   const allowMultipleDest =
     (tokenLayer === TokenLayers.HIVE && transferType === TransferTypes.TRANSFER) ||
-    (tokenLayer === TokenLayers.POINTS && transferType === TransferTypes.ECENCY_POINT_TRANSFER);
+    (tokenLayer === TokenLayers.POINTS && transferType === TransferTypes.ECENCY_POINT_TRANSFER) ||
+    (tokenLayer === TokenLayers.ENGINE && transferType === TransferTypes.TRANSFER);
 
   const showMemo =
     transferType === TransferTypes.ECENCY_POINT_TRANSFER ||
@@ -382,19 +383,44 @@ const TransferView = ({
     const destinations = destination.trim().split(/[\s,]+/);
 
     if (isEngineToken) {
-      const json = getEngineActionJSON(
-        transferType as EngineActions,
-        destination,
-        `${amount} ${fundType}`,
-        fundType,
-        memo,
-      );
-      path = `sign/custom-json?authority=active&required_auths=%5B%22${get(
-        selectedAccount,
-        'name',
-      )}%22%5D&required_posting_auths=%5B%5D&id=ssc-mainnet-hive&json=${encodeURIComponent(
-        JSON.stringify(json),
-      )}`;
+      if (transferType === TransferTypes.TRANSFER && destinations.length > 1) {
+        path = hiveuri
+          .encodeOps(
+            destinations.map((receiver) => [
+              'custom_json',
+              {
+                required_auths: [selectedAccount.name],
+                required_posting_auths: [],
+                id: 'ssc-mainnet-hive',
+                json: JSON.stringify(
+                  getEngineActionJSON(
+                    EngineActions.TRANSFER,
+                    receiver,
+                    `${amount} ${fundType}`,
+                    fundType,
+                    memo,
+                  ),
+                ),
+              },
+            ]),
+          )
+          .replace('hive://', '');
+        path += '?authority=active';
+      } else {
+        const json = getEngineActionJSON(
+          transferType as EngineActions,
+          destination,
+          `${amount} ${fundType}`,
+          fundType,
+          memo,
+        );
+        path = `sign/custom-json?authority=active&required_auths=%5B%22${get(
+          selectedAccount,
+          'name',
+        )}%22%5D&required_posting_auths=%5B%5D&id=ssc-mainnet-hive&json=${encodeURIComponent(
+          JSON.stringify(json),
+        )}`;
+      }
     } else if (isSpkToken) {
       const json = getSpkActionJSON(Number(amount), destination, memo);
       path = `sign/custom-json?authority=active&required_auths=%5B%22${

--- a/src/utils/transactionOpsBuilder.test.ts
+++ b/src/utils/transactionOpsBuilder.test.ts
@@ -173,6 +173,37 @@ describe('buildTransferOpsArray', () => {
       expect(ops[0][0]).toBe('engine_op');
     });
 
+    it('ENGINE layer TRANSFER splits multi-recipient by comma/space', () => {
+      const ops = buildTransferOpsArray(TransferTypes.TRANSFER, {
+        ...baseData,
+        to: 'bob, charlie dave',
+        tokenLayer: TokenLayers.ENGINE,
+      });
+      expect(ops).toHaveLength(3);
+      ops.forEach((op) => expect(op[0]).toBe('engine_op'));
+    });
+
+    it('ENGINE layer TRANSFER throws for empty recipients', () => {
+      expect(() =>
+        buildTransferOpsArray(TransferTypes.TRANSFER, {
+          ...baseData,
+          to: '',
+          tokenLayer: TokenLayers.ENGINE,
+        }),
+      ).toThrow('No valid recipients');
+    });
+
+    it('ENGINE layer TRANSFER throws for too many recipients (>50)', () => {
+      const many = Array(51).fill('user').join(',');
+      expect(() =>
+        buildTransferOpsArray(TransferTypes.TRANSFER, {
+          ...baseData,
+          to: many,
+          tokenLayer: TokenLayers.ENGINE,
+        }),
+      ).toThrow('Too many recipients');
+    });
+
     it('routes SPK layer to custom_json', () => {
       const ops = buildTransferOpsArray(TransferTypes.TRANSFER, {
         ...baseData,

--- a/src/utils/transactionOpsBuilder.test.ts
+++ b/src/utils/transactionOpsBuilder.test.ts
@@ -181,6 +181,8 @@ describe('buildTransferOpsArray', () => {
       });
       expect(ops).toHaveLength(3);
       ops.forEach((op) => expect(op[0]).toBe('engine_op'));
+      // Mocked engine op shape: ['engine_op', action, from, to, amount, symbol, memo]
+      expect(ops.map((op) => op[3])).toEqual(['bob', 'charlie', 'dave']);
     });
 
     it('ENGINE layer TRANSFER throws for empty recipients', () => {

--- a/src/utils/transactionOpsBuilder.ts
+++ b/src/utils/transactionOpsBuilder.ts
@@ -32,6 +32,21 @@ export const buildTransferOpsArray = (
 
   // check layer and build appropriate operation
   if (tokenLayer === TokenLayers.ENGINE) {
+    if (transferType === TransferTypes.TRANSFER) {
+      const destinations = to
+        .trim()
+        .split(/[\s,]+/)
+        .filter(Boolean);
+      if (destinations.length === 0) {
+        throw new Error(`No valid recipients in: ${to}`);
+      }
+      if (destinations.length > MAX_RECIPIENTS) {
+        throw new Error(`Too many recipients (${destinations.length}), max is ${MAX_RECIPIENTS}`);
+      }
+      return destinations.flatMap((dest) =>
+        getEngineActionOpArray(EngineActions.TRANSFER, from, dest, amount, fundType, memo),
+      );
+    }
     return getEngineActionOpArray(transferType as EngineActions, from, to, amount, fundType, memo);
   } else if (tokenLayer === TokenLayers.SPK) {
     return buildActiveCustomJsonOpArr(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ENGINE token transfers now support multiple recipients (up to 50) in a single transaction with input validation and per-recipient ops for reliable bulk distributions.
* **Integration**
  * Transfer mutation for multi-recipient ENGINE transfers is now available to consumers.
* **Tests**
  * Added coverage for multi-recipient ENGINE transfers, including recipient limits and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->