### PR TITLE
Similar entries (read next) on post screen

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@babel/preset-typescript": "^7.26.0",
     "@babel/runtime": "^7.26.7",
     "@ecency/render-helper": "^2.5.4",
-    "@ecency/sdk": "^2.2.16",
+    "@ecency/sdk": "^2.2.21",
     "@esteemapp/react-native-autocomplete-input": "^4.2.1",
     "@esteemapp/react-native-multi-slider": "^1.1.0",
     "@native-html/iframe-plugin": "^2.6.1",

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -33,6 +33,7 @@ import { PercentBar } from './percentBar';
 import { PinAnimatedInput } from './pinAnimatedInput';
 import { PostCard } from './postCard';
 import { PostDisplay } from './postView';
+import { SimilarEntries } from './similarEntries';
 import { PostOptionsModal } from './postOptionsModal';
 import { PostForm } from './postForm';
 import { PostHeaderDescription, PostBody, Tags } from './postElements';
@@ -204,6 +205,7 @@ export {
   PostCard,
   PostCardPlaceHolder,
   PostDisplay,
+  SimilarEntries,
   PostOptionsModal,
   PostForm,
   PostHeaderDescription,

--- a/src/components/postView/view/postDisplayView.tsx
+++ b/src/components/postView/view/postDisplayView.tsx
@@ -25,6 +25,7 @@ import { PostTypes } from '../../../constants/postTypes';
 import { useUserActivityMutation } from '../../../providers/queries/pointQueries';
 import { PointActivityIds } from '../../../providers/ecency/ecency.types';
 import { PostComments } from '../../postComments';
+import { SimilarEntries } from '../../similarEntries';
 import { UpvoteButton } from '../../postCard/children/upvoteButton';
 import UpvotePopover from '../../upvotePopover';
 import { PostPoll } from '../../postPoll';
@@ -417,6 +418,7 @@ const PostDisplayView = ({
                   />
                 </View>
               )}
+              {!postBodyLoading && <SimilarEntries post={post} />}
             </View>
           )}
         </View>

--- a/src/components/similarEntries/children/similarEntryItem.tsx
+++ b/src/components/similarEntries/children/similarEntryItem.tsx
@@ -1,0 +1,77 @@
+import React, { useMemo } from 'react';
+import { Text, TouchableOpacity, View } from 'react-native';
+import { Image as ExpoImage } from 'expo-image';
+import { useNavigation } from '@react-navigation/native';
+import { catchPostImage } from '@ecency/render-helper';
+
+import ROUTES from '../../../constants/routeNames';
+import { getTimeFromNow } from '../../../utils/time';
+import { Icon } from '../../icon';
+import styles from '../styles/similarEntries.styles';
+
+interface SimilarEntry {
+  author: string;
+  permlink: string;
+  title?: string;
+  img_url?: string;
+  created_at?: string;
+}
+
+interface Props {
+  entry: SimilarEntry;
+}
+
+const SimilarEntryItem = ({ entry }: Props) => {
+  const navigation = useNavigation();
+
+  const thumbnail = useMemo(() => {
+    if (!entry.img_url) return null;
+    return catchPostImage(entry.img_url, 400, 200, 'match');
+  }, [entry.img_url]);
+
+  const relativeDate = useMemo(
+    () => (entry.created_at ? getTimeFromNow(entry.created_at) : ''),
+    [entry.created_at],
+  );
+
+  const _onPress = () => {
+    navigation.navigate({
+      name: ROUTES.SCREENS.POST,
+      params: {
+        author: entry.author,
+        permlink: entry.permlink,
+      },
+      key: `${entry.author}/${entry.permlink}`,
+    } as never);
+  };
+
+  return (
+    <TouchableOpacity activeOpacity={0.8} onPress={_onPress} style={styles.card}>
+      {thumbnail ? (
+        <ExpoImage
+          source={{ uri: thumbnail }}
+          style={styles.image}
+          contentFit="cover"
+          transition={150}
+        />
+      ) : (
+        <View style={styles.placeholderImage}>
+          <Icon name="image" iconType="MaterialIcons" size={32} color="#999" />
+        </View>
+      )}
+      <View style={styles.body}>
+        <Text numberOfLines={2} style={styles.cardTitle}>
+          {entry.title || ''}
+        </Text>
+        <View style={styles.meta}>
+          <Text numberOfLines={1} style={styles.author}>
+            @{entry.author}
+          </Text>
+          {!!relativeDate && <Text style={styles.date}>{relativeDate}</Text>}
+        </View>
+      </View>
+    </TouchableOpacity>
+  );
+};
+
+export default SimilarEntryItem;

--- a/src/components/similarEntries/container/similarEntries.tsx
+++ b/src/components/similarEntries/container/similarEntries.tsx
@@ -1,0 +1,74 @@
+import React, { useMemo } from 'react';
+import { FlatList, Text, View } from 'react-native';
+import { useIntl } from 'react-intl';
+import { useQuery } from '@tanstack/react-query';
+import { getSimilarEntriesQueryOptions, SIMILAR_ENTRIES_MIN_RENDER } from '@ecency/sdk';
+
+import SimilarEntryItem from '../children/similarEntryItem';
+import styles from '../styles/similarEntries.styles';
+
+interface Post {
+  author: string;
+  permlink: string;
+  depth?: number;
+  parent_author?: string;
+  json_metadata?: {
+    tags?: string[];
+  };
+}
+
+interface Props {
+  post?: Post | null;
+}
+
+interface SdkSimilarRow {
+  author?: string;
+  permlink?: string;
+  title?: string;
+  img_url?: string;
+  created_at?: string;
+}
+
+const SimilarEntries = ({ post }: Props) => {
+  const intl = useIntl();
+
+  // Top-level posts only — skip comments / wave replies.
+  const isTopLevel = !!post && !post.parent_author && (post.depth ?? 0) === 0;
+
+  const { data: raw } = useQuery({
+    ...getSimilarEntriesQueryOptions({
+      author: post?.author ?? '',
+      permlink: post?.permlink ?? '',
+      json_metadata: { tags: post?.json_metadata?.tags },
+    }),
+    enabled: isTopLevel && !!post?.author && !!post?.permlink,
+  });
+
+  const entries = useMemo(() => {
+    if (!Array.isArray(raw)) return [];
+    return (raw as SdkSimilarRow[]).filter(
+      (r) => r && typeof r.author === 'string' && typeof r.permlink === 'string',
+    );
+  }, [raw]);
+
+  if (!isTopLevel) return null;
+  if (entries.length < SIMILAR_ENTRIES_MIN_RENDER) return null;
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.header}>
+        <Text style={styles.title}>{intl.formatMessage({ id: 'similar_entries.title' })}</Text>
+      </View>
+      <FlatList
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        data={entries}
+        keyExtractor={(it) => `${it.author}/${it.permlink}`}
+        renderItem={({ item }) => <SimilarEntryItem entry={item as any} />}
+        contentContainerStyle={styles.list}
+      />
+    </View>
+  );
+};
+
+export default SimilarEntries;

--- a/src/components/similarEntries/container/similarEntries.tsx
+++ b/src/components/similarEntries/container/similarEntries.tsx
@@ -44,11 +44,13 @@ const SimilarEntries = ({ post }: Props) => {
     enabled: isTopLevel && !!post?.author && !!post?.permlink,
   });
 
+  // Mobile shows a tighter strip than web (2 cards instead of 3) — keeps the
+  // post body above the fold on small screens. SDK still caps at 3.
   const entries = useMemo(() => {
     if (!Array.isArray(raw)) return [];
-    return (raw as SdkSimilarRow[]).filter(
-      (r) => r && typeof r.author === 'string' && typeof r.permlink === 'string',
-    );
+    return (raw as SdkSimilarRow[])
+      .filter((r) => r && typeof r.author === 'string' && typeof r.permlink === 'string')
+      .slice(0, 2);
   }, [raw]);
 
   if (!isTopLevel) return null;

--- a/src/components/similarEntries/container/similarEntries.tsx
+++ b/src/components/similarEntries/container/similarEntries.tsx
@@ -2,10 +2,30 @@ import React, { useMemo } from 'react';
 import { FlatList, Text, View } from 'react-native';
 import { useIntl } from 'react-intl';
 import { useQuery } from '@tanstack/react-query';
-import { getSimilarEntriesQueryOptions, SIMILAR_ENTRIES_MIN_RENDER } from '@ecency/sdk';
+import { CONFIG } from '@ecency/sdk';
 
 import SimilarEntryItem from '../children/similarEntryItem';
 import styles from '../styles/similarEntries.styles';
+
+// Show the strip only when at least this many results survive filtering.
+// One lone card looks like a glitch; two reads as intentional.
+const MIN_RENDER = 2;
+const MAX_RESULTS = 2;
+
+// 6-month recency window — matches the SDK contract used on web.
+const SINCE_MS = 182 * 24 * 60 * 60 * 1000;
+
+// Overly broad tags worth skipping when something more specific is available.
+const GENERIC_TAGS = new Set([
+  'hive',
+  'blog',
+  'life',
+  'blogger',
+  'dailyblog',
+  'post',
+  'ecency',
+  'esteem',
+]);
 
 interface Post {
   author: string;
@@ -21,40 +41,97 @@ interface Props {
   post?: Post | null;
 }
 
-interface SdkSimilarRow {
-  author?: string;
-  permlink?: string;
+interface SearchApiRow {
+  author: string;
+  permlink: string;
   title?: string;
   img_url?: string;
   created_at?: string;
+  tags?: string[];
+}
+
+interface SearchApiResponse {
+  hits: number;
+  took: number;
+  results: SearchApiRow[];
+}
+
+function buildQuery(post: Post): string {
+  let q = '* type:post';
+
+  const tagsRaw = Array.isArray(post.json_metadata?.tags) ? post.json_metadata!.tags! : [];
+  const cleaned = tagsRaw
+    .filter((t): t is string => typeof t === 'string' && t !== '')
+    .filter((t) => !t.startsWith('hive-'));
+  const specific = cleaned.filter((t) => !GENERIC_TAGS.has(t));
+  const chosen = (specific.length > 0 ? specific : cleaned).slice(0, 2);
+
+  if (chosen.length > 0) {
+    q += ` tag:${chosen.join(',')}`;
+  } else {
+    // Fall back to permlink slug tokens when the post has no tag metadata.
+    const fromPermlink = post.permlink
+      .split('-')
+      .filter((part) => part && !/^-?\d+$/.test(part) && part.length > 2)
+      .slice(0, 2)
+      .join(',');
+    if (fromPermlink) {
+      q += ` tag:${fromPermlink}`;
+    }
+  }
+
+  return q;
 }
 
 const SimilarEntries = ({ post }: Props) => {
   const intl = useIntl();
 
-  // Top-level posts only — skip comments / wave replies.
   const isTopLevel = !!post && !post.parent_author && (post.depth ?? 0) === 0;
 
-  const { data: raw } = useQuery({
-    ...getSimilarEntriesQueryOptions({
-      author: post?.author ?? '',
-      permlink: post?.permlink ?? '',
-      json_metadata: { tags: post?.json_metadata?.tags },
-    }),
-    enabled: isTopLevel && !!post?.author && !!post?.permlink,
+  const query = useMemo(() => (post ? buildQuery(post) : ''), [post]);
+
+  const { data } = useQuery<SearchApiRow[]>({
+    queryKey: ['similar-entries-mobile', post?.author, post?.permlink, query],
+    queryFn: async ({ signal }) => {
+      const sinceMs = Date.now() - SINCE_MS;
+      const since = new Date(sinceMs).toISOString().slice(0, 19);
+
+      const response = await fetch(`${CONFIG.privateApiHost}/search-api/search`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ q: query, sort: 'popularity', hide_low: false, since }),
+        signal,
+      });
+
+      if (!response.ok) {
+        throw new Error(`Similar entries search failed: ${response.status}`);
+      }
+
+      const json = (await response.json()) as SearchApiResponse;
+      return Array.isArray(json.results) ? json.results : [];
+    },
+    enabled: isTopLevel && !!post?.author && !!post?.permlink && query.length > 0,
+    staleTime: 5 * 60 * 1000,
   });
 
-  // Mobile shows a tighter strip than web (2 cards instead of 3) — keeps the
-  // post body above the fold on small screens. SDK still caps at 3.
   const entries = useMemo(() => {
-    if (!Array.isArray(raw)) return [];
-    return (raw as SdkSimilarRow[])
-      .filter((r) => r && typeof r.author === 'string' && typeof r.permlink === 'string')
-      .slice(0, 2);
-  }, [raw]);
+    if (!Array.isArray(data) || !post) return [];
+    const seenAuthors = new Set<string>();
+    const out: SearchApiRow[] = [];
+    for (const r of data) {
+      if (!r || typeof r.author !== 'string' || typeof r.permlink !== 'string') continue;
+      if (r.permlink === post.permlink) continue;
+      if ((r.tags ?? []).indexOf('nsfw') !== -1) continue;
+      if (seenAuthors.has(r.author)) continue;
+      seenAuthors.add(r.author);
+      out.push(r);
+      if (out.length >= MAX_RESULTS) break;
+    }
+    return out;
+  }, [data, post]);
 
   if (!isTopLevel) return null;
-  if (entries.length < SIMILAR_ENTRIES_MIN_RENDER) return null;
+  if (entries.length < MIN_RENDER) return null;
 
   return (
     <View style={styles.container}>
@@ -66,7 +143,7 @@ const SimilarEntries = ({ post }: Props) => {
         showsHorizontalScrollIndicator={false}
         data={entries}
         keyExtractor={(it) => `${it.author}/${it.permlink}`}
-        renderItem={({ item }) => <SimilarEntryItem entry={item as any} />}
+        renderItem={({ item }) => <SimilarEntryItem entry={item} />}
         contentContainerStyle={styles.list}
       />
     </View>

--- a/src/components/similarEntries/container/similarEntries.tsx
+++ b/src/components/similarEntries/container/similarEntries.tsx
@@ -12,7 +12,7 @@ import styles from '../styles/similarEntries.styles';
 const MIN_RENDER = 2;
 const MAX_RESULTS = 2;
 
-// 6-month recency window — matches the SDK contract used on web.
+// 6-month recency window — matches the search-api contract used on web.
 const SINCE_MS = 182 * 24 * 60 * 60 * 1000;
 
 // Overly broad tags worth skipping when something more specific is available.
@@ -26,6 +26,16 @@ const GENERIC_TAGS = new Set([
   'ecency',
   'esteem',
 ]);
+
+// Adult-content tags filtered client-side as a backstop to the server-side
+// default filter (server excludes `nsfw`/`dporn` + the broken `is_nsfw` flag).
+// Client-side check guards against any tag-set drift between server and client.
+const ADULT_TAGS = new Set(['nsfw', 'dporn']);
+
+// Hive tags are lowercase alphanumeric, optional hyphens, no spaces or
+// punctuation. Reject anything else so untrusted json_metadata can't inject
+// query operators (e.g. a tag containing a colon or space).
+const SAFE_TAG = /^[a-z0-9][a-z0-9-]{0,49}$/;
 
 interface Post {
   author: string;
@@ -56,31 +66,35 @@ interface SearchApiResponse {
   results: SearchApiRow[];
 }
 
+/**
+ * Returns a query string when there is at least one usable similarity signal
+ * (tags or permlink slug tokens). Returns an empty string when nothing
+ * specific is available, so the caller can disable the query rather than
+ * firing a corpus-wide `* type:post` fetch.
+ */
 function buildQuery(post: Post): string {
-  let q = '* type:post';
-
   const tagsRaw = Array.isArray(post.json_metadata?.tags) ? post.json_metadata!.tags! : [];
   const cleaned = tagsRaw
-    .filter((t): t is string => typeof t === 'string' && t !== '')
+    .filter((t): t is string => typeof t === 'string')
+    .map((t) => t.trim().toLowerCase())
+    .filter((t) => SAFE_TAG.test(t))
     .filter((t) => !t.startsWith('hive-'));
   const specific = cleaned.filter((t) => !GENERIC_TAGS.has(t));
   const chosen = (specific.length > 0 ? specific : cleaned).slice(0, 2);
 
   if (chosen.length > 0) {
-    q += ` tag:${chosen.join(',')}`;
-  } else {
-    // Fall back to permlink slug tokens when the post has no tag metadata.
-    const fromPermlink = post.permlink
-      .split('-')
-      .filter((part) => part && !/^-?\d+$/.test(part) && part.length > 2)
-      .slice(0, 2)
-      .join(',');
-    if (fromPermlink) {
-      q += ` tag:${fromPermlink}`;
-    }
+    return `* type:post tag:${chosen.join(',')}`;
   }
 
-  return q;
+  // Fall back to permlink slug tokens when the post has no tag metadata.
+  const fromPermlink = post.permlink
+    .toLowerCase()
+    .split('-')
+    .filter((part) => SAFE_TAG.test(part) && !/^-?\d+$/.test(part) && part.length > 2)
+    .slice(0, 2)
+    .join(',');
+
+  return fromPermlink ? `* type:post tag:${fromPermlink}` : '';
 }
 
 const SimilarEntries = ({ post }: Props) => {
@@ -117,17 +131,18 @@ const SimilarEntries = ({ post }: Props) => {
   const entries = useMemo(() => {
     if (!Array.isArray(data) || !post) return [];
     const seenAuthors = new Set<string>();
-    const out: SearchApiRow[] = [];
-    for (const r of data) {
-      if (!r || typeof r.author !== 'string' || typeof r.permlink !== 'string') continue;
-      if (r.permlink === post.permlink) continue;
-      if ((r.tags ?? []).indexOf('nsfw') !== -1) continue;
-      if (seenAuthors.has(r.author)) continue;
+    return data.reduce<SearchApiRow[]>((acc, r) => {
+      if (acc.length >= MAX_RESULTS) return acc;
+      if (!r || typeof r.author !== 'string' || typeof r.permlink !== 'string') return acc;
+      // The source post is uniquely identified by (author, permlink); permlinks
+      // alone can collide across authors.
+      if (r.author === post.author && r.permlink === post.permlink) return acc;
+      if ((r.tags ?? []).some((t) => ADULT_TAGS.has(t))) return acc;
+      if (seenAuthors.has(r.author)) return acc;
       seenAuthors.add(r.author);
-      out.push(r);
-      if (out.length >= MAX_RESULTS) break;
-    }
-    return out;
+      acc.push(r);
+      return acc;
+    }, []);
   }, [data, post]);
 
   if (!isTopLevel) return null;
@@ -136,7 +151,9 @@ const SimilarEntries = ({ post }: Props) => {
   return (
     <View style={styles.container}>
       <View style={styles.header}>
-        <Text style={styles.title}>{intl.formatMessage({ id: 'similar_entries.title' })}</Text>
+        <Text style={styles.title}>
+          {intl.formatMessage({ id: 'similar_entries.title', defaultMessage: 'Read next' })}
+        </Text>
       </View>
       <FlatList
         horizontal

--- a/src/components/similarEntries/index.ts
+++ b/src/components/similarEntries/index.ts
@@ -1,0 +1,4 @@
+import SimilarEntries from './container/similarEntries';
+
+export { SimilarEntries };
+export default SimilarEntries;

--- a/src/components/similarEntries/styles/similarEntries.styles.ts
+++ b/src/components/similarEntries/styles/similarEntries.styles.ts
@@ -1,0 +1,69 @@
+import EStyleSheet from 'react-native-extended-stylesheet';
+
+export default EStyleSheet.create({
+  container: {
+    marginTop: 16,
+    marginBottom: 8,
+  },
+  header: {
+    paddingHorizontal: 16,
+    marginBottom: 12,
+  },
+  title: {
+    fontSize: 16,
+    fontWeight: 'bold',
+    color: '$primaryBlack',
+    fontFamily: '$primaryFont',
+  },
+  list: {
+    paddingHorizontal: 12,
+  },
+  card: {
+    width: 200,
+    marginHorizontal: 4,
+    borderRadius: 12,
+    overflow: 'hidden',
+    backgroundColor: '$primaryLightBackground',
+    borderWidth: 0.5,
+    borderColor: '$primaryDarkGray',
+  },
+  image: {
+    width: '100%',
+    height: 100,
+    backgroundColor: '$primaryDarkGray',
+  },
+  placeholderImage: {
+    width: '100%',
+    height: 100,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '$primaryGray',
+  },
+  body: {
+    padding: 10,
+  },
+  cardTitle: {
+    fontSize: 13,
+    color: '$primaryBlack',
+    fontFamily: '$primaryFont',
+    fontWeight: '600',
+    minHeight: 36,
+  },
+  meta: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginTop: 8,
+  },
+  author: {
+    fontSize: 11,
+    color: '$primaryDarkText',
+    fontFamily: '$primaryFont',
+    flex: 1,
+  },
+  date: {
+    fontSize: 11,
+    color: '$iconColor',
+    fontFamily: '$primaryFont',
+    marginLeft: 8,
+  },
+});

--- a/src/config/locales/en-US.json
+++ b/src/config/locales/en-US.json
@@ -327,6 +327,9 @@
     "unsubscribe_confirmation": "Unsubscribe recurrent transfer to {username}?",
     "remaining_executions": "Remaining {executions} transfers"
   },
+  "similar_entries": {
+    "title": "Read next"
+  },
   "comments": {
     "read_more": "Read more comments",
     "more_replies": "replies",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1257,10 +1257,10 @@
     url "^0.11.0"
     xss "^1.0.9"
 
-"@ecency/sdk@^2.2.16":
-  version "2.2.16"
-  resolved "https://registry.yarnpkg.com/@ecency/sdk/-/sdk-2.2.16.tgz#880e59956241f7f17338c258ff0def74d67b307a"
-  integrity sha512-dXbmpfqgog+NI9jXpafziWSVckyMp4/P4bfkwqbWCVEwHvqS/CUrIGbW9enKkEdadThUTtqsZPM752dwF4G6rQ==
+"@ecency/sdk@^2.2.21":
+  version "2.2.21"
+  resolved "https://registry.yarnpkg.com/@ecency/sdk/-/sdk-2.2.21.tgz#e3cf466366513eafca817808fce0542710ba1afe"
+  integrity sha512-hcpgZoAMGCkcwyV2BNz5+8q9Dlvilkd9ebe9AG76DQB7BZQJepqknAZGDLkxxL/tFm6jq7p0aGtKRTDeBlNbig==
   dependencies:
     "@noble/ciphers" "^2.1.1"
     "@noble/curves" "^2.0.1"


### PR DESCRIPTION
## Summary

- Add a horizontal "Read next" strip under the post body that surfaces topically-similar posts (parity with web)
- Queries the search API directly via `@ecency/sdk` `CONFIG.privateApiHost`; **no HiveSense fallback on mobile** — if the search API has no results, the strip is hidden
- Limited to 2 cards to keep the post above the fold; web shows 3
- Only renders for top-level posts (skipped on comments and wave replies)
- Hidden when fewer than 2 usable results are available, so the strip never looks sparse
- Default-on server-side filter (grayed / NSFW / dporn / heavy-flagged) is unchanged; a small client-side backstop also drops `nsfw`/`dporn` tags from the response
- Tags pulled from `json_metadata` are sanitised (lowercase alphanumeric + hyphens) before being injected into the query string

## Files

- `src/components/similarEntries/` — new component (container, item, styles)
- `src/components/postView/view/postDisplayView.tsx` — injects the strip after the post body/tags footer
- `src/components/index.tsx` — barrel export
- `src/config/locales/en-US.json` — `similar_entries.title` string (with `defaultMessage` fallback in code for non-English locales)
- `package.json` — `@ecency/sdk` bumped to ^2.2.21 for the new search-api behaviour

## Test plan

- [ ] Open any top-level post on iOS / Android → strip appears below the body, above comments
- [ ] Each card shows thumbnail (or placeholder), title, author, relative date
- [ ] Tapping a card navigates to that post
- [ ] Strip does NOT appear on comments / wave replies
- [ ] Strip is hidden if fewer than 2 similar posts found
- [ ] Posts in the strip exclude grayed/NSFW/dporn content