### PR TITLE
Merge tabbed side-menu entries; bump @ecency/sdk to 2.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@babel/preset-typescript": "^7.26.0",
     "@babel/runtime": "^7.26.7",
     "@ecency/render-helper": "^2.5.6",
-    "@ecency/sdk": "^2.2.21",
+    "@ecency/sdk": "^2.3.1",
     "@esteemapp/react-native-autocomplete-input": "^4.2.1",
     "@esteemapp/react-native-multi-slider": "^1.1.0",
     "@native-html/iframe-plugin": "^2.6.1",

--- a/src/components/sideMenu/view/sideMenuView.tsx
+++ b/src/components/sideMenu/view/sideMenuView.tsx
@@ -100,25 +100,6 @@ const SideMenuView = ({
       return;
     }
 
-    if (item.id === 'favorites') {
-      navigateToRoute({
-        name: ROUTES.SCREENS.BOOKMARKS,
-        params: {
-          showFavorites: true,
-        },
-      });
-      return;
-    }
-
-    if (item.id === 'schedules') {
-      navigateToRoute({
-        name: ROUTES.SCREENS.DRAFTS,
-        params: {
-          showSchedules: true,
-        },
-      });
-      return;
-    }
     // if there is any prevLoggedInUser, show account switch modal
     if (item.id === 'add_account') {
       if (prevLoggedInUsers && prevLoggedInUsers?.length > 0) {

--- a/src/constants/sideMenuItems.ts
+++ b/src/constants/sideMenuItems.ts
@@ -23,22 +23,10 @@ const authMenuItems: MenuItem[] = [
     id: 'bookmarks',
   },
   {
-    name: 'Favorites',
-    route: ROUTES.SCREENS.BOOKMARKS,
-    icon: 'heart',
-    id: 'favorites',
-  },
-  {
     name: 'Drafts',
     route: ROUTES.SCREENS.DRAFTS,
     icon: 'docs',
     id: 'drafts',
-  },
-  {
-    name: 'Schedules',
-    route: ROUTES.SCREENS.DRAFTS,
-    icon: 'clock',
-    id: 'schedules',
   },
   {
     name: 'Communities',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1270,10 +1270,10 @@
     url "^0.11.0"
     xss "^1.0.9"
 
-"@ecency/sdk@^2.2.21":
-  version "2.2.21"
-  resolved "https://registry.yarnpkg.com/@ecency/sdk/-/sdk-2.2.21.tgz#e3cf466366513eafca817808fce0542710ba1afe"
-  integrity sha512-hcpgZoAMGCkcwyV2BNz5+8q9Dlvilkd9ebe9AG76DQB7BZQJepqknAZGDLkxxL/tFm6jq7p0aGtKRTDeBlNbig==
+"@ecency/sdk@^2.3.1":
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/@ecency/sdk/-/sdk-2.3.1.tgz#84843f31bc2db4c7d05008ab8a3a1dda24e0801a"
+  integrity sha512-nfZD/6EDampHJRI3ZbbaByL6SbhJIEQW3R+er1gOL4qT0XRfMDpprnNXX3lRZ6AUsmjwwNIAJ223scgUFwSP6Q==
   dependencies:
     "@noble/ciphers" "^2.1.1"
     "@noble/curves" "^2.0.1"


### PR DESCRIPTION
## Summary

The side menu had two pairs of entries that each open the **same** screen with two tabs:

- **Bookmarks** and **Favorites** → both open the Bookmarks screen (Bookmarks / Favorites tabs)
- **Drafts** and **Schedules** → both open the Drafts screen (Drafts / Schedules tabs)

This collapses each pair into a single entry (**Bookmarks**, **Drafts**). The Favorites and Schedules tabs remain fully reachable via the tab bar inside each screen — only the redundant menu shortcuts are removed.

## Changes

- `src/constants/sideMenuItems.ts` — remove the `favorites` and `schedules` auth menu items.
- `src/components/sideMenu/view/sideMenuView.tsx` — remove the now-dead `favorites` / `schedules` press handlers (they passed `showFavorites` / `showSchedules` to preselect a tab; no longer reachable).
- `package.json` / `yarn.lock` — bump `@ecency/sdk` `^2.2.21` → `^2.3.1`.

## Notes

- The `showFavorites` / `showSchedules` route params are still honored by the Bookmarks/Drafts containers, so any deep links or other callers that pass them keep working.
- `@ecency/sdk` 2.3.1 has the same dependency set as 2.2.21, so no transitive lockfile changes were needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated SDK dependency to version 2.3.1.

* **Refactor**
  * Removed Favorites and Schedules from the side menu navigation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ecency/ecency-mobile/pull/3202?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->