### PR TITLE
Add Ecency source badge on post view + make Sentry CI uploads resilient

### DIFF
--- a/.github/scripts/sentry-retry.sh
+++ b/.github/scripts/sentry-retry.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+#
+# Run a sentry-cli command with bounded retries so a transient Sentry API
+# error (e.g. HTTP 500) does not fail the release build on the first attempt.
+#
+# Used by .github/workflows/build-ios.yml and build-android.yml. The steps
+# that call this set `continue-on-error: true`, so a sustained Sentry outage
+# degrades gracefully (warning + missing source maps for that release) instead
+# of blocking the build.
+#
+# Usage: bash .github/scripts/sentry-retry.sh <command> [args...]
+# Override attempts with SENTRY_RETRY_MAX (default 3).
+set -u
+
+attempt=1
+max="${SENTRY_RETRY_MAX:-3}"
+
+until "$@"; do
+  if [ "$attempt" -ge "$max" ]; then
+    echo "::warning::Sentry command failed after ${max} attempts: $*"
+    exit 1
+  fi
+  echo "Sentry attempt ${attempt} failed; retrying in $((attempt * 15))s..."
+  sleep "$((attempt * 15))"
+  attempt=$((attempt + 1))
+done

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -156,34 +156,24 @@ jobs:
           ./gradlew assembleRelease
 
       # Source maps are only used for error symbolication, so a transient Sentry
-      # API error (e.g. HTTP 500) must not block the release build. Retry, then
-      # warn and continue if Sentry stays unavailable.
+      # API error (e.g. HTTP 500) must not block the release build. The shared
+      # retry helper retries transient failures; continue-on-error lets a
+      # sustained Sentry outage degrade gracefully instead of failing the build.
       - name: Upload source maps to Sentry (Android)
         continue-on-error: true
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: |
-          retry() {
-            local attempt=1 max=3
-            until "$@"; do
-              if [ "$attempt" -ge "$max" ]; then
-                echo "::warning::Sentry command failed after $max attempts: $*"
-                return 1
-              fi
-              echo "Sentry attempt $attempt failed; retrying in $((attempt * 15))s..."
-              sleep $((attempt * 15))
-              attempt=$((attempt + 1))
-            done
-          }
+          retry="$GITHUB_WORKSPACE/.github/scripts/sentry-retry.sh"
           BUNDLE_PATH=android/app/src/main/assets/index.android.bundle
           MAP_PATH=android/app/src/main/assets/index.android.bundle.map
-          retry npx sentry-cli releases new "$SENTRY_RELEASE" --org ecency --project ecency-mobile
-          retry npx sentry-cli releases files "$SENTRY_RELEASE" upload-sourcemaps \
+          bash "$retry" npx sentry-cli releases new "$SENTRY_RELEASE" --org ecency --project ecency-mobile
+          bash "$retry" npx sentry-cli releases files "$SENTRY_RELEASE" upload-sourcemaps \
             --dist "$SENTRY_DIST" \
             --org ecency --project ecency-mobile \
             --rewrite \
             "$BUNDLE_PATH" "$MAP_PATH"
-          retry npx sentry-cli releases finalize "$SENTRY_RELEASE" --org ecency --project ecency-mobile
+          bash "$retry" npx sentry-cli releases finalize "$SENTRY_RELEASE" --org ecency --project ecency-mobile
 
       - name: Upload APK application
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -155,19 +155,35 @@ jobs:
           cd android
           ./gradlew assembleRelease
 
+      # Source maps are only used for error symbolication, so a transient Sentry
+      # API error (e.g. HTTP 500) must not block the release build. Retry, then
+      # warn and continue if Sentry stays unavailable.
       - name: Upload source maps to Sentry (Android)
+        continue-on-error: true
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: |
+          retry() {
+            local attempt=1 max=3
+            until "$@"; do
+              if [ "$attempt" -ge "$max" ]; then
+                echo "::warning::Sentry command failed after $max attempts: $*"
+                return 1
+              fi
+              echo "Sentry attempt $attempt failed; retrying in $((attempt * 15))s..."
+              sleep $((attempt * 15))
+              attempt=$((attempt + 1))
+            done
+          }
           BUNDLE_PATH=android/app/src/main/assets/index.android.bundle
           MAP_PATH=android/app/src/main/assets/index.android.bundle.map
-          npx sentry-cli releases new "$SENTRY_RELEASE" --org ecency --project ecency-mobile
-          npx sentry-cli releases files "$SENTRY_RELEASE" upload-sourcemaps \
+          retry npx sentry-cli releases new "$SENTRY_RELEASE" --org ecency --project ecency-mobile
+          retry npx sentry-cli releases files "$SENTRY_RELEASE" upload-sourcemaps \
             --dist "$SENTRY_DIST" \
             --org ecency --project ecency-mobile \
             --rewrite \
             "$BUNDLE_PATH" "$MAP_PATH"
-          npx sentry-cli releases finalize "$SENTRY_RELEASE" --org ecency --project ecency-mobile
+          retry npx sentry-cli releases finalize "$SENTRY_RELEASE" --org ecency --project ecency-mobile
 
       - name: Upload APK application
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -240,18 +240,34 @@ jobs:
           cp ios/main.jsbundle $RUNNER_TEMP/js/main.jsbundle
           cp ios/main.jsbundle.map $RUNNER_TEMP/js/main.jsbundle.map
 
+      # Source maps are only used for error symbolication, so a transient Sentry
+      # API error (e.g. HTTP 500) must not block the release build. Retry, then
+      # warn and continue if Sentry stays unavailable.
       - name: Upload source maps to Sentry (iOS)
+        continue-on-error: true
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: |
-          npx sentry-cli releases new "$SENTRY_RELEASE" --org ecency --project ecency-mobile
-          npx sentry-cli releases files "$SENTRY_RELEASE" upload-sourcemaps \
+          retry() {
+            local attempt=1 max=3
+            until "$@"; do
+              if [ "$attempt" -ge "$max" ]; then
+                echo "::warning::Sentry command failed after $max attempts: $*"
+                return 1
+              fi
+              echo "Sentry attempt $attempt failed; retrying in $((attempt * 15))s..."
+              sleep $((attempt * 15))
+              attempt=$((attempt + 1))
+            done
+          }
+          retry npx sentry-cli releases new "$SENTRY_RELEASE" --org ecency --project ecency-mobile
+          retry npx sentry-cli releases files "$SENTRY_RELEASE" upload-sourcemaps \
             --dist "$SENTRY_DIST" \
             --org ecency --project ecency-mobile \
             --rewrite \
             --strip-common-prefix \
             $RUNNER_TEMP/js/main.jsbundle $RUNNER_TEMP/js/main.jsbundle.map
-          npx sentry-cli releases finalize "$SENTRY_RELEASE" --org ecency --project ecency-mobile
+          retry npx sentry-cli releases finalize "$SENTRY_RELEASE" --org ecency --project ecency-mobile
 
       - name: Build archive
         run: |
@@ -265,10 +281,23 @@ jobs:
           clean archive
 
       - name: Upload iOS dSYMs to Sentry
+        continue-on-error: true
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: |
-          npx sentry-cli debug-files upload \
+          retry() {
+            local attempt=1 max=3
+            until "$@"; do
+              if [ "$attempt" -ge "$max" ]; then
+                echo "::warning::Sentry command failed after $max attempts: $*"
+                return 1
+              fi
+              echo "Sentry attempt $attempt failed; retrying in $((attempt * 15))s..."
+              sleep $((attempt * 15))
+              attempt=$((attempt + 1))
+            done
+          }
+          retry npx sentry-cli debug-files upload \
             --org ecency \
             --project ecency-mobile \
             --include-sources \

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -241,33 +241,23 @@ jobs:
           cp ios/main.jsbundle.map $RUNNER_TEMP/js/main.jsbundle.map
 
       # Source maps are only used for error symbolication, so a transient Sentry
-      # API error (e.g. HTTP 500) must not block the release build. Retry, then
-      # warn and continue if Sentry stays unavailable.
+      # API error (e.g. HTTP 500) must not block the release build. The shared
+      # retry helper retries transient failures; continue-on-error lets a
+      # sustained Sentry outage degrade gracefully instead of failing the build.
       - name: Upload source maps to Sentry (iOS)
         continue-on-error: true
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: |
-          retry() {
-            local attempt=1 max=3
-            until "$@"; do
-              if [ "$attempt" -ge "$max" ]; then
-                echo "::warning::Sentry command failed after $max attempts: $*"
-                return 1
-              fi
-              echo "Sentry attempt $attempt failed; retrying in $((attempt * 15))s..."
-              sleep $((attempt * 15))
-              attempt=$((attempt + 1))
-            done
-          }
-          retry npx sentry-cli releases new "$SENTRY_RELEASE" --org ecency --project ecency-mobile
-          retry npx sentry-cli releases files "$SENTRY_RELEASE" upload-sourcemaps \
+          retry="$GITHUB_WORKSPACE/.github/scripts/sentry-retry.sh"
+          bash "$retry" npx sentry-cli releases new "$SENTRY_RELEASE" --org ecency --project ecency-mobile
+          bash "$retry" npx sentry-cli releases files "$SENTRY_RELEASE" upload-sourcemaps \
             --dist "$SENTRY_DIST" \
             --org ecency --project ecency-mobile \
             --rewrite \
             --strip-common-prefix \
             $RUNNER_TEMP/js/main.jsbundle $RUNNER_TEMP/js/main.jsbundle.map
-          retry npx sentry-cli releases finalize "$SENTRY_RELEASE" --org ecency --project ecency-mobile
+          bash "$retry" npx sentry-cli releases finalize "$SENTRY_RELEASE" --org ecency --project ecency-mobile
 
       - name: Build archive
         run: |
@@ -285,19 +275,8 @@ jobs:
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: |
-          retry() {
-            local attempt=1 max=3
-            until "$@"; do
-              if [ "$attempt" -ge "$max" ]; then
-                echo "::warning::Sentry command failed after $max attempts: $*"
-                return 1
-              fi
-              echo "Sentry attempt $attempt failed; retrying in $((attempt * 15))s..."
-              sleep $((attempt * 15))
-              attempt=$((attempt + 1))
-            done
-          }
-          retry npx sentry-cli debug-files upload \
+          retry="$GITHUB_WORKSPACE/.github/scripts/sentry-retry.sh"
+          bash "$retry" npx sentry-cli debug-files upload \
             --org ecency \
             --project ecency-mobile \
             --include-sources \

--- a/src/components/postView/view/postDisplayStyles.ts
+++ b/src/components/postView/view/postDisplayStyles.ts
@@ -68,6 +68,11 @@ export default EStyleSheet.create({
     color: '$primaryDarkGray',
     marginVertical: 12,
   },
+  ecencySourceBadge: {
+    width: 12,
+    height: 12,
+    marginLeft: 3,
+  },
   footerName: {
     color: '$primaryBlack',
     fontWeight: 'bold',

--- a/src/components/postView/view/postDisplayStyles.ts
+++ b/src/components/postView/view/postDisplayStyles.ts
@@ -68,6 +68,11 @@ export default EStyleSheet.create({
     color: '$primaryDarkGray',
     marginVertical: 12,
   },
+  footerSourceRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    flexWrap: 'wrap',
+  },
   ecencySourceBadge: {
     width: 12,
     height: 12,

--- a/src/components/postView/view/postDisplayView.tsx
+++ b/src/components/postView/view/postDisplayView.tsx
@@ -406,21 +406,23 @@ const PostDisplayView = ({
               {!postBodyLoading && (
                 <View style={styles.footer}>
                   <Tags tags={tags} />
-                  <Text style={styles.footerText}>
-                    {intl.formatMessage(
-                      { id: 'post.posted_by' },
-                      {
-                        username: author || post.author,
-                        appname: post?.json_metadata?.app
-                          ? capitalize(post?.json_metadata?.app?.split('/')[0])
-                          : 'Ecency',
-                      },
-                    )}
-                    {formatedTime}
+                  <View style={styles.footerSourceRow}>
+                    <Text style={styles.footerText}>
+                      {intl.formatMessage(
+                        { id: 'post.posted_by' },
+                        {
+                          username: author || post.author,
+                          appname: post?.json_metadata?.app
+                            ? capitalize(post?.json_metadata?.app?.split('/')[0])
+                            : 'Ecency',
+                        },
+                      )}
+                      {formatedTime}
+                    </Text>
                     {isFromEcency && (
                       <Image source={ECENCY_LOGO} style={styles.ecencySourceBadge} />
                     )}
-                  </Text>
+                  </View>
                   <WritePostButton
                     placeholderId="quick_reply.placeholder"
                     onPress={_showQuickReplyModal}

--- a/src/components/postView/view/postDisplayView.tsx
+++ b/src/components/postView/view/postDisplayView.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { View, Text, useWindowDimensions } from 'react-native';
+import { View, Text, Image, useWindowDimensions } from 'react-native';
 import { injectIntl } from 'react-intl';
 import get from 'lodash/get';
 import isEqual from 'lodash/isEqual';
@@ -20,6 +20,7 @@ import { PostReadingMetadata } from '../children/postReadingMetadata';
 
 // Styles
 import styles from './postDisplayStyles';
+import ECENCY_LOGO from '../../../assets/ecency-logo-round.png';
 import { WritePostButton } from '../../atoms';
 import { PostTypes } from '../../../constants/postTypes';
 import { useUserActivityMutation } from '../../../providers/queries/pointQueries';
@@ -310,6 +311,11 @@ const PostDisplayView = ({
 
   const capitalize = (appname) => appname && appname[0].toUpperCase() + appname.slice(1);
 
+  // matches the "via {appname}" label, which defaults to Ecency when no app metadata is set
+  const isFromEcency = (post?.json_metadata?.app?.split('/')[0] || 'ecency')
+    .toLowerCase()
+    .includes('ecency');
+
   const _handleOnPostBodyLoad = useCallback(() => {
     setPostBodyLoading(false);
   }, []);
@@ -411,6 +417,9 @@ const PostDisplayView = ({
                       },
                     )}
                     {formatedTime}
+                    {isFromEcency && (
+                      <Image source={ECENCY_LOGO} style={styles.ecencySourceBadge} />
+                    )}
                   </Text>
                   <WritePostButton
                     placeholderId="quick_reply.placeholder"


### PR DESCRIPTION
Two related-by-area changes bundled per request.

## 1. Ecency source badge (post view)

Appends the circular Ecency logo right after the existing "via {appname}" source label in the post footer, shown **only when the post was published via Ecency** (matching the label's existing default-to-Ecency behavior). Posts from other apps are unchanged.

- `postDisplayView.tsx`: 12×12 inline `<Image>` (existing `ecency-logo-round.png` asset) nested in the footer `Text` so it flows with the line.
- `postDisplayStyles.ts`: `ecencySourceBadge` style (12×12, small left margin).
- Mirrors the equivalent web change on the entry page.

## 2. Resilient Sentry uploads in CI

The recent release build failed because Sentry returned a transient API error (HTTP 500) during source-map upload — even though the app compiled fine. Those upload steps run **before** the archive/IPA/bundle steps, so a Sentry hiccup blocked the entire release.

- `build-ios.yml` (source maps + dSYMs) and `build-android.yml` (source maps): wrapped the `sentry-cli` calls in a bounded retry (3 attempts, linear backoff) and set `continue-on-error: true`.
- Effect: transient Sentry failures self-recover; a sustained outage degrades gracefully (CI warning + missing source maps for that one release) instead of failing the build.

## Testing

- Badge: open an Ecency-published post vs. a post from another app — badge appears only on the former, inline after the source label.
- CI: workflow YAML validated; retry/continue-on-error exercised on the next `development` build.