### PR TITLE
Perks dashboard: quests tracker + ways to use points

### DIFF
--- a/src/components/header/container/headerContainer.tsx
+++ b/src/components/header/container/headerContainer.tsx
@@ -45,10 +45,8 @@ const HeaderContainer = ({
   };
 
   const _handleOnBoostPress = () => {
-    // navigate to boost plus screen;
-    navigation.navigate(ROUTES.SCREENS.REDEEM, {
-      redeemType: 'boost_plus',
-    });
+    // open the perks dashboard (quests + ways to spend points)
+    navigation.navigate(ROUTES.SCREENS.PERKS);
   };
 
   return (

--- a/src/config/locales/en-US.json
+++ b/src/config/locales/en-US.json
@@ -1,4 +1,27 @@
 {
+  "perks": {
+    "header": "Perks",
+    "quests_title": "Quests",
+    "quests_subtitle": "Complete daily goals and keep your streak",
+    "streak": "{n}-day streak",
+    "daily": "Daily",
+    "weekly": "Weekly",
+    "monthly": "Monthly",
+    "checkin": "Check in",
+    "post": "Publish a post",
+    "comment": "Leave comments",
+    "vote": "Curate posts",
+    "reblog": "Reblog a post",
+    "spend_title": "Use your points",
+    "spin": "Daily spin",
+    "spin_desc": "Spin the wheel for points",
+    "boost_plus": "Boost Plus",
+    "boost_plus_desc": "Promote your account",
+    "promote": "Promote a post",
+    "promote_desc": "Get more eyes on your post",
+    "account_boost": "Account boost",
+    "account_boost_desc": "Boost any account"
+  },
   "waves": {
     "for_you": "For you",
     "following": "Following"

--- a/src/constants/routeNames.ts
+++ b/src/constants/routeNames.ts
@@ -12,6 +12,7 @@ const ROUTES = {
     EDITOR: `Editor${SCREEN_SUFFIX}`,
     FOLLOWS: `Follows${SCREEN_SUFFIX}`,
     SPIN_GAME: `SpinGame${SCREEN_SUFFIX}`,
+    PERKS: `Perks${SCREEN_SUFFIX}`,
     FEED: `Feed${SCREEN_SUFFIX}`,
     LOGIN: `Login${SCREEN_SUFFIX}`,
     KEYCHAIN: `Keychain${SCREEN_SUFFIX}`,

--- a/src/navigation/stackNavigator.tsx
+++ b/src/navigation/stackNavigator.tsx
@@ -21,6 +21,7 @@ import {
   SearchResult,
   Settings,
   SpinGame,
+  Perks,
   Transfer,
   TradeScreen,
   Voters,
@@ -64,6 +65,7 @@ const MainStackNavigator = () => {
       <MainStack.Screen name={ROUTES.SCREENS.REDEEM} component={Redeem} />
       <MainStack.Screen name={ROUTES.SCREENS.AI_IMAGE_GENERATOR} component={AiImageGenerator} />
       <MainStack.Screen name={ROUTES.SCREENS.SPIN_GAME} component={SpinGame} />
+      <MainStack.Screen name={ROUTES.SCREENS.PERKS} component={Perks} />
       <MainStack.Screen name={ROUTES.SCREENS.ACCOUNT_BOOST} component={AccountBoost} />
       <MainStack.Screen name={ROUTES.SCREENS.COMMUNITY} component={Community} />
       <MainStack.Screen name={ROUTES.SCREENS.COMMUNITIES} component={Communities} />

--- a/src/providers/queries/pointQueries.ts
+++ b/src/providers/queries/pointQueries.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQuery } from '@tanstack/react-query';
-import { getPointsQueryOptions } from '@ecency/sdk';
+import { getPointsQueryOptions, getQuestsQueryOptions } from '@ecency/sdk';
 import { useAppSelector, useAppDispatch } from '../../hooks';
 import {
   deletePointActivityCache,
@@ -30,6 +30,17 @@ export const useGetPointsQuery = (username?: string, filter = 0) => {
   });
 
   return queryResult;
+};
+
+/**
+ * Read-only daily/weekly/monthly quest progress for the perks dashboard.
+ * Aggregates the user's existing points activity (no minting).
+ */
+export const useGetQuestsQuery = (username?: string) => {
+  return useQuery({
+    ...getQuestsQueryOptions(username),
+    enabled: !!username,
+  });
 };
 
 export const useUserActivityMutation = () => {

--- a/src/screens/index.ts
+++ b/src/screens/index.ts
@@ -39,6 +39,7 @@ import PollWizardScreen from './pollWizard';
 import { BotComments } from './botComments';
 import { AiImageGenerator } from './aiImageGenerator';
 import { DappBrowser } from './dappBrowser';
+import { Perks } from './perks/screen/perksScreen';
 
 export {
   Bookmarks,
@@ -61,6 +62,7 @@ export {
   SearchResult,
   Settings,
   SpinGame,
+  Perks,
   HiveSigner,
   Transfer,
   TradeScreen,

--- a/src/screens/perks/children/questsCard.tsx
+++ b/src/screens/perks/children/questsCard.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+import { useIntl } from 'react-intl';
+import EStyleSheet from 'react-native-extended-stylesheet';
+import { QUEST_CATALOG } from '@ecency/sdk';
+
+import { Icon } from '../../../components';
+import { useAppSelector } from '../../../hooks';
+import { selectCurrentAccountName } from '../../../redux/selectors';
+import { useGetQuestsQuery } from '../../../providers/queries/pointQueries';
+import styles from '../styles/perksStyles';
+
+// Map the shared SDK catalog icon hints to MaterialCommunityIcons names.
+const ICONS: Record<string, string> = {
+  'check-circle': 'progress-check',
+  pencil: 'pencil-outline',
+  comment: 'comment-outline',
+  'chevron-up-circle': 'chevron-up-circle-outline',
+  repeat: 'repeat',
+};
+
+const TIERS = ['daily', 'weekly', 'monthly'] as const;
+
+const byId = (arr?: { id: string }[]) =>
+  Object.fromEntries((arr || []).map((q) => [q.id, q]));
+
+const QuestsCard = () => {
+  const intl = useIntl();
+  const username = useAppSelector(selectCurrentAccountName);
+  const { data } = useGetQuestsQuery(username);
+
+  const progressByTier: Record<string, any> = {
+    daily: byId(data?.daily),
+    weekly: byId(data?.weekly),
+    monthly: byId(data?.monthly),
+  };
+
+  const streak = data?.streak;
+
+  const _renderQuest = (tier: string, entry: any) => {
+    const item = progressByTier[tier][entry.id];
+    const progress = item?.progress ?? 0;
+    const { goal } = entry;
+    const completed = progress >= goal;
+    const pct = goal > 0 ? Math.min(100, Math.round((progress / goal) * 100)) : 0;
+
+    return (
+      <View key={`${tier}-${entry.id}`} style={styles.questRow}>
+        <View style={styles.iconWrap}>
+          <Icon
+            iconType="MaterialCommunityIcons"
+            name={completed ? 'check-circle' : ICONS[entry.icon] || 'star-outline'}
+            size={18}
+            color={EStyleSheet.value(completed ? '$primaryGreen' : '$primaryBlue')}
+          />
+        </View>
+        <View style={styles.questBody}>
+          <View style={styles.rowHeader}>
+            <Text style={styles.questTitle}>
+              {intl.formatMessage({ id: `perks.${entry.i18nKey}` })}
+            </Text>
+            <Text style={styles.questCount}>{`${progress}/${goal}`}</Text>
+          </View>
+          <View style={styles.track}>
+            <View style={[styles.fill, completed && styles.fillDone, { width: `${pct}%` }]} />
+          </View>
+        </View>
+      </View>
+    );
+  };
+
+  return (
+    <View style={styles.card}>
+      <Text style={styles.cardTitle}>{intl.formatMessage({ id: 'perks.quests_title' })}</Text>
+      <Text style={styles.cardSubtitle}>
+        {intl.formatMessage({ id: 'perks.quests_subtitle' })}
+      </Text>
+
+      {!!streak && streak.current > 0 && (
+        <View style={styles.streakBadge}>
+          <Icon
+            iconType="MaterialCommunityIcons"
+            name="fire"
+            size={16}
+            color={EStyleSheet.value('$white')}
+          />
+          <Text style={styles.streakText}>
+            {intl.formatMessage({ id: 'perks.streak' }, { n: streak.current })}
+          </Text>
+        </View>
+      )}
+
+      {TIERS.map((tier) => {
+        const entries = QUEST_CATALOG.filter((q) => q.tier === tier && q.id !== 'spin');
+        if (entries.length === 0) {
+          return null;
+        }
+        return (
+          <View key={tier}>
+            <Text style={styles.sectionLabel}>{intl.formatMessage({ id: `perks.${tier}` })}</Text>
+            {entries.map((entry) => _renderQuest(tier, entry))}
+          </View>
+        );
+      })}
+    </View>
+  );
+};
+
+export default QuestsCard;

--- a/src/screens/perks/children/questsCard.tsx
+++ b/src/screens/perks/children/questsCard.tsx
@@ -21,8 +21,7 @@ const ICONS: Record<string, string> = {
 
 const TIERS = ['daily', 'weekly', 'monthly'] as const;
 
-const byId = (arr?: { id: string }[]) =>
-  Object.fromEntries((arr || []).map((q) => [q.id, q]));
+const byId = (arr?: { id: string }[]) => Object.fromEntries((arr || []).map((q) => [q.id, q]));
 
 const QuestsCard = () => {
   const intl = useIntl();
@@ -72,9 +71,7 @@ const QuestsCard = () => {
   return (
     <View style={styles.card}>
       <Text style={styles.cardTitle}>{intl.formatMessage({ id: 'perks.quests_title' })}</Text>
-      <Text style={styles.cardSubtitle}>
-        {intl.formatMessage({ id: 'perks.quests_subtitle' })}
-      </Text>
+      <Text style={styles.cardSubtitle}>{intl.formatMessage({ id: 'perks.quests_subtitle' })}</Text>
 
       {!!streak && streak.current > 0 && (
         <View style={styles.streakBadge}>

--- a/src/screens/perks/children/spendOptions.tsx
+++ b/src/screens/perks/children/spendOptions.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { View, Text, TouchableOpacity } from 'react-native';
+import { useIntl } from 'react-intl';
+import EStyleSheet from 'react-native-extended-stylesheet';
+
+import { Icon } from '../../../components';
+import RootNavigation from '../../../navigation/rootNavigation';
+import ROUTES from '../../../constants/routeNames';
+import styles from '../styles/perksStyles';
+
+const OPTIONS: { id: string; icon: string; route: string; params?: any }[] = [
+  { id: 'spin', icon: 'gift-outline', route: ROUTES.SCREENS.SPIN_GAME },
+  {
+    id: 'boost_plus',
+    icon: 'fire',
+    route: ROUTES.SCREENS.REDEEM,
+    params: { redeemType: 'boost_plus' },
+  },
+  {
+    id: 'promote',
+    icon: 'bullhorn-outline',
+    route: ROUTES.SCREENS.REDEEM,
+    params: { redeemType: 'promote' },
+  },
+  { id: 'account_boost', icon: 'rocket-launch-outline', route: ROUTES.SCREENS.ACCOUNT_BOOST },
+];
+
+const SpendOptions = () => {
+  const intl = useIntl();
+
+  const _navigate = (route: string, params?: any) => {
+    RootNavigation.navigate({ name: route, params });
+  };
+
+  return (
+    <View style={styles.card}>
+      <Text style={styles.cardTitle}>{intl.formatMessage({ id: 'perks.spend_title' })}</Text>
+      {OPTIONS.map((opt, index) => (
+        <TouchableOpacity
+          key={opt.id}
+          style={[styles.spendRow, index === OPTIONS.length - 1 && { borderBottomWidth: 0 }]}
+          onPress={() => _navigate(opt.route, opt.params)}
+        >
+          <View style={styles.iconWrap}>
+            <Icon
+              iconType="MaterialCommunityIcons"
+              name={opt.icon}
+              size={18}
+              color={EStyleSheet.value('$primaryBlue')}
+            />
+          </View>
+          <View style={styles.spendBody}>
+            <Text style={styles.spendTitle}>{intl.formatMessage({ id: `perks.${opt.id}` })}</Text>
+            <Text style={styles.spendDesc}>
+              {intl.formatMessage({ id: `perks.${opt.id}_desc` })}
+            </Text>
+          </View>
+          <Icon
+            iconType="MaterialIcons"
+            name="chevron-right"
+            size={22}
+            color={EStyleSheet.value('$iconColor')}
+          />
+        </TouchableOpacity>
+      ))}
+    </View>
+  );
+};
+
+export default SpendOptions;

--- a/src/screens/perks/screen/perksScreen.tsx
+++ b/src/screens/perks/screen/perksScreen.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { ScrollView } from 'react-native';
+import { gestureHandlerRootHOC } from 'react-native-gesture-handler';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useIntl } from 'react-intl';
+
+import { BasicHeader } from '../../../components';
+import QuestsCard from '../children/questsCard';
+import SpendOptions from '../children/spendOptions';
+import styles from '../styles/perksStyles';
+
+const PerksScreen = gestureHandlerRootHOC(() => {
+  const intl = useIntl();
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <BasicHeader title={intl.formatMessage({ id: 'perks.header' })} />
+      <ScrollView contentContainerStyle={styles.scroll} showsVerticalScrollIndicator={false}>
+        <QuestsCard />
+        <SpendOptions />
+      </ScrollView>
+    </SafeAreaView>
+  );
+});
+
+export { PerksScreen as Perks };

--- a/src/screens/perks/styles/perksStyles.ts
+++ b/src/screens/perks/styles/perksStyles.ts
@@ -1,0 +1,123 @@
+import EStyleSheet from 'react-native-extended-stylesheet';
+
+export default EStyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '$primaryBackgroundColor',
+  },
+  scroll: {
+    padding: 16,
+  },
+  card: {
+    backgroundColor: '$primaryLightBackground',
+    borderRadius: 12,
+    padding: 16,
+    marginBottom: 16,
+  },
+  cardTitle: {
+    fontSize: 16,
+    fontWeight: 'bold',
+    color: '$primaryDarkText',
+    fontFamily: '$primaryFont',
+  },
+  cardSubtitle: {
+    fontSize: 13,
+    color: '$primaryDarkGray',
+    marginTop: 2,
+    fontFamily: '$primaryFont',
+  },
+  sectionLabel: {
+    fontSize: 12,
+    fontWeight: 'bold',
+    color: '$primaryDarkGray',
+    marginTop: 14,
+    marginBottom: 4,
+    fontFamily: '$primaryFont',
+  },
+  streakBadge: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    alignSelf: 'flex-start',
+    backgroundColor: '$primaryLightBlue',
+    borderRadius: 20,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    marginTop: 10,
+  },
+  streakText: {
+    color: '$white',
+    fontWeight: 'bold',
+    marginLeft: 6,
+    fontFamily: '$primaryFont',
+  },
+  questRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 10,
+  },
+  iconWrap: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '$primaryGrayBackground',
+    marginRight: 12,
+  },
+  questBody: {
+    flex: 1,
+  },
+  rowHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  questTitle: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '$primaryDarkText',
+    fontFamily: '$primaryFont',
+  },
+  questCount: {
+    fontSize: 12,
+    color: '$primaryDarkGray',
+    fontFamily: '$primaryFont',
+  },
+  track: {
+    height: 6,
+    borderRadius: 3,
+    backgroundColor: '$borderColor',
+    marginTop: 6,
+    overflow: 'hidden',
+  },
+  fill: {
+    height: 6,
+    borderRadius: 3,
+    backgroundColor: '$primaryBlue',
+  },
+  fillDone: {
+    backgroundColor: '$primaryGreen',
+  },
+  spendRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 14,
+    borderBottomWidth: 1,
+    borderBottomColor: '$borderColor',
+  },
+  spendBody: {
+    flex: 1,
+    marginLeft: 12,
+  },
+  spendTitle: {
+    fontSize: 15,
+    fontWeight: '600',
+    color: '$primaryDarkText',
+    fontFamily: '$primaryFont',
+  },
+  spendDesc: {
+    fontSize: 12,
+    color: '$primaryDarkGray',
+    fontFamily: '$primaryFont',
+  },
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1271,9 +1271,9 @@
     xss "^1.0.9"
 
 "@ecency/sdk@^2.3.1":
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/@ecency/sdk/-/sdk-2.3.1.tgz#84843f31bc2db4c7d05008ab8a3a1dda24e0801a"
-  integrity sha512-nfZD/6EDampHJRI3ZbbaByL6SbhJIEQW3R+er1gOL4qT0XRfMDpprnNXX3lRZ6AUsmjwwNIAJ223scgUFwSP6Q==
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/@ecency/sdk/-/sdk-2.3.2.tgz#f418ef34ea62de617c2b9ac34239ba2d18f5a0a5"
+  integrity sha512-sFukBaRiTyh5OJTmL/YpHerstFEyHHE4xRi91GMY9oldBcyOrJOpH0c6K/NHjEC+4uczmkinMxQgUreBYq2AuQ==
   dependencies:
     "@noble/ciphers" "^2.1.1"
     "@noble/curves" "^2.0.1"


### PR DESCRIPTION
## What

Turns the header **flame icon** into a **Perks dashboard** (instead of jumping straight to Boost Plus). The dashboard shows:

- A **Quests tracker** — daily / weekly / monthly progress with a check-in streak, read-only (surfaces the points the app already awards: check-in, post, comment, vote, reblog). No new points are minted.
- **Ways to use points** — Spin, Boost Plus, Promote, Account boost (each opens the existing flow).

## Changes

- `useGetQuestsQuery` wrapper over the SDK's `getQuestsQueryOptions`.
- New `Perks` screen + `QuestsCard` + `SpendOptions` + styles; registered route `PERKS` and repointed the header flame (`_handleOnBoostPress` → `PERKS`).
- Bumps `@ecency/sdk` 2.3.1 → **2.3.2** (adds the quests module + shared `QUEST_CATALOG` used here, so web and mobile render the same quest set).
- en-US strings under `perks.*`.

## Notes

- Quest progress comes from the live `/private-api/quests` endpoint (already deployed); Boost Plus is now one tap deeper (via the dashboard) rather than the flame's direct target.
- Phase 0 of the quests feature; backend + web shipped separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new Perks dashboard displaying quest progress across daily, weekly, and monthly tiers with streak tracking and point rewards.
  * Added spend options for points including spin, boost plus, promote, and account boost features.
  * Updated the header boost button to navigate to the perks dashboard.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ecency/ecency-mobile/pull/3204?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->