### PR TITLE
Streak reminder deep-link to perks + tabbed quests card

### DIFF
--- a/src/screens/application/hook/useInitApplication.tsx
+++ b/src/screens/application/hook/useInitApplication.tsx
@@ -263,6 +263,11 @@ export const useInitApplication = () => {
           key = push.source || 'inactive';
           break;
 
+        case 'spin':
+          // The spin reminder is now the daily streak/quests reminder -> perks dashboard.
+          routeName = ROUTES.SCREENS.PERKS;
+          break;
+
         case 'hiveuri':
           if (push.hiveUri) {
             linkProcessor.handleLink(push.hiveUri);

--- a/src/screens/perks/children/questsCard.tsx
+++ b/src/screens/perks/children/questsCard.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { View, Text } from 'react-native';
+import React, { useState } from 'react';
+import { View, Text, TouchableOpacity } from 'react-native';
 import { useIntl } from 'react-intl';
 import EStyleSheet from 'react-native-extended-stylesheet';
 import { QUEST_CATALOG } from '@ecency/sdk';
@@ -27,6 +27,7 @@ const QuestsCard = () => {
   const intl = useIntl();
   const username = useAppSelector(selectCurrentAccountName);
   const { data } = useGetQuestsQuery(username);
+  const [tier, setTier] = useState<string>('daily');
 
   const progressByTier: Record<string, any> = {
     daily: byId(data?.daily),
@@ -35,8 +36,9 @@ const QuestsCard = () => {
   };
 
   const streak = data?.streak;
+  const tierEntries = QUEST_CATALOG.filter((q) => q.tier === tier && q.id !== 'spin');
 
-  const _renderQuest = (tier: string, entry: any) => {
+  const _renderQuest = (entry: any) => {
     const item = progressByTier[tier][entry.id];
     const progress = item?.progress ?? 0;
     const { goal } = entry;
@@ -87,18 +89,21 @@ const QuestsCard = () => {
         </View>
       )}
 
-      {TIERS.map((tier) => {
-        const entries = QUEST_CATALOG.filter((q) => q.tier === tier && q.id !== 'spin');
-        if (entries.length === 0) {
-          return null;
-        }
-        return (
-          <View key={tier}>
-            <Text style={styles.sectionLabel}>{intl.formatMessage({ id: `perks.${tier}` })}</Text>
-            {entries.map((entry) => _renderQuest(tier, entry))}
-          </View>
-        );
-      })}
+      <View style={styles.tabRow}>
+        {TIERS.map((t) => (
+          <TouchableOpacity
+            key={t}
+            style={[styles.tab, t === tier && styles.tabActive]}
+            onPress={() => setTier(t)}
+          >
+            <Text style={[styles.tabText, t === tier && styles.tabTextActive]}>
+              {intl.formatMessage({ id: `perks.${t}` })}
+            </Text>
+          </TouchableOpacity>
+        ))}
+      </View>
+
+      {tierEntries.map((entry) => _renderQuest(entry))}
     </View>
   );
 };

--- a/src/screens/perks/styles/perksStyles.ts
+++ b/src/screens/perks/styles/perksStyles.ts
@@ -49,6 +49,9 @@ export default EStyleSheet.create({
   tabActive: {
     borderBottomWidth: 2,
     borderBottomColor: '$primaryBlue',
+    // pull down by the row's 1px border so the indicator sits on it (replaces the
+    // separator under the active tab instead of floating above it)
+    marginBottom: -1,
   },
   tabText: {
     fontSize: 13,

--- a/src/screens/perks/styles/perksStyles.ts
+++ b/src/screens/perks/styles/perksStyles.ts
@@ -34,6 +34,31 @@ export default EStyleSheet.create({
     marginBottom: 4,
     fontFamily: '$primaryFont',
   },
+  tabRow: {
+    flexDirection: 'row',
+    marginTop: 14,
+    marginBottom: 4,
+    borderBottomWidth: 1,
+    borderBottomColor: '$borderColor',
+  },
+  tab: {
+    paddingVertical: 8,
+    paddingHorizontal: 14,
+    marginRight: 4,
+  },
+  tabActive: {
+    borderBottomWidth: 2,
+    borderBottomColor: '$primaryBlue',
+  },
+  tabText: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: '$primaryDarkGray',
+    fontFamily: '$primaryFont',
+  },
+  tabTextActive: {
+    color: '$primaryBlue',
+  },
   streakBadge: {
     flexDirection: 'row',
     alignItems: 'center',


### PR DESCRIPTION
## What

Two mobile follow-ups for the quests feature:

1. **Reminder deep-link (#11):** the spin reminder is now the daily **streak/quests** reminder (enotify, deployed). Handle its tap in `_pushNavigate` (`useInitApplication.tsx`) → opens the **Perks** screen. It was previously unhandled, so this is purely additive.
2. **Tabbed quests card:** the Perks dashboard's quests card showed Daily/Weekly/Monthly stacked in one long list — switched it to a **tabbed** layout (Daily | Weekly | Monthly), matching the website.

No new types/SDK changes. Pairs with ecency/enotify-py#13 (deployed) and ecency/vision-next#838 (web deep-link).