### PR TITLE
Side menu: emphasize core navigation over utility group

### DIFF
--- a/src/components/sideMenu/view/sideMenuStyles.ts
+++ b/src/components/sideMenu/view/sideMenuStyles.ts
@@ -73,6 +73,13 @@ export default EStyleSheet.create({
     flex: 1,
     textAlign: 'left',
   },
+  // Core navigation entries: larger + bolder + darker than utility entries
+  // so the primary actions read above the footer group.
+  listItemTextMain: {
+    color: '$primaryBlack',
+    fontWeight: 'bold',
+    fontSize: 15,
+  },
   buttonText: {
     fontSize: 18,
     fontFamily: '$primaryFont',

--- a/src/components/sideMenu/view/sideMenuView.tsx
+++ b/src/components/sideMenu/view/sideMenuView.tsx
@@ -151,7 +151,9 @@ const SideMenuView = ({
           {item.item.username && (
             <UserAvatar noAction username={item.item.username} style={styles.otherUserAvatar} />
           )}
-          <Text style={styles.listItemText}>
+          <Text
+            style={[styles.listItemText, item.item.group === 'main' && styles.listItemTextMain]}
+          >
             {intl.formatMessage({ id: `side_menu.${item.item.id}` })}
           </Text>
         </View>


### PR DESCRIPTION
Follow-up to #3205. The divider separates core navigation from utility entries, but every row had identical text weight. This gives the two groups a clear typographic hierarchy.

**Change:** core (`main`-group) entries — Profile, Bookmarks, Drafts, Communities, Explore — now render **bold, 15px, `$primaryBlack`**, while the utility group below the divider (QR, Refer & Earn, Docs, Settings, Logout) keeps the existing 14px / weight-500 / `$primaryDarkGray`.

Implemented via a `listItemTextMain` style applied when `item.group === 'main'`; utility rows are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced side menu visual hierarchy with distinct styling for primary navigation items. Core navigation entries now feature adjusted text color, increased font weight, and modified font size to provide better visual differentiation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ecency/ecency-mobile/pull/3207?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->