### PR TITLE
Perks quests card: type-safe tier, empty state, dark-theme streak text

### DIFF
--- a/src/config/locales/en-US.json
+++ b/src/config/locales/en-US.json
@@ -3,6 +3,7 @@
     "header": "Perks",
     "quests_title": "Quests",
     "quests_subtitle": "Complete daily goals and keep your streak",
+    "quests_empty": "No quests here yet — check back soon.",
     "streak": "{n}-day streak",
     "daily": "Daily",
     "weekly": "Weekly",

--- a/src/screens/perks/children/questsCard.tsx
+++ b/src/screens/perks/children/questsCard.tsx
@@ -27,9 +27,9 @@ const QuestsCard = () => {
   const intl = useIntl();
   const username = useAppSelector(selectCurrentAccountName);
   const { data } = useGetQuestsQuery(username);
-  const [tier, setTier] = useState<string>('daily');
+  const [tier, setTier] = useState<(typeof TIERS)[number]>('daily');
 
-  const progressByTier: Record<string, any> = {
+  const progressByTier: Record<(typeof TIERS)[number], any> = {
     daily: byId(data?.daily),
     weekly: byId(data?.weekly),
     monthly: byId(data?.monthly),
@@ -81,7 +81,7 @@ const QuestsCard = () => {
             iconType="MaterialCommunityIcons"
             name="fire"
             size={16}
-            color={EStyleSheet.value('$white')}
+            color={EStyleSheet.value('$primaryBlack')}
           />
           <Text style={styles.streakText}>
             {intl.formatMessage({ id: 'perks.streak' }, { n: streak.current })}
@@ -103,7 +103,11 @@ const QuestsCard = () => {
         ))}
       </View>
 
-      {tierEntries.map((entry) => _renderQuest(entry))}
+      {tierEntries.length > 0 ? (
+        tierEntries.map((entry) => _renderQuest(entry))
+      ) : (
+        <Text style={styles.questsEmpty}>{intl.formatMessage({ id: 'perks.quests_empty' })}</Text>
+      )}
     </View>
   );
 };

--- a/src/screens/perks/styles/perksStyles.ts
+++ b/src/screens/perks/styles/perksStyles.ts
@@ -73,7 +73,10 @@ export default EStyleSheet.create({
     marginTop: 10,
   },
   streakText: {
-    color: '$white',
+    // $primaryBlack adapts per theme (dark text in light mode, light in dark),
+    // so it stays readable on the $primaryLightBlue badge in both themes —
+    // unlike $white, which inverts to dark navy and vanishes in dark mode.
+    color: '$primaryBlack',
     fontWeight: 'bold',
     marginLeft: 6,
     fontFamily: '$primaryFont',
@@ -109,6 +112,13 @@ export default EStyleSheet.create({
   questCount: {
     fontSize: 12,
     color: '$primaryDarkGray',
+    fontFamily: '$primaryFont',
+  },
+  questsEmpty: {
+    fontSize: 13,
+    color: '$primaryDarkGray',
+    textAlign: 'center',
+    paddingVertical: 16,
     fontFamily: '$primaryFont',
   },
   track: {


### PR DESCRIPTION
Addresses the two greptile P2 suggestions left on #3207's `questsCard.tsx`, plus a dark-theme color bug.

**1. Type-safe `tier`** — `useState<string>` → `useState<(typeof TIERS)[number]>` (and `progressByTier` keyed by the same union). An out-of-range tier can no longer slip in and make `progressByTier[tier]` undefined / throw in `_renderQuest`.

**2. Empty state** — when the selected tier has no quests, the area below the tabs rendered nothing. Now shows a short centered message (`perks.quests_empty`) instead of a silent blank.

**3. Streak text/icon readable in both themes** — the streak badge text + fire icon used `$white`, which is `#FFFFFF` in light theme but inverts to `#1e2835` (dark navy) in dark theme — so it showed as **black text** on the badge in dark mode. Switched to `$primaryBlack`, a theme-adaptive foreground token (`#3c4449` in light, `#fcfcfc` in dark), so it stays clearly visible on the `$primaryLightBlue` badge in **both** light and dark themes.

New locale key `perks.quests_empty` (en-US only; Crowdin to propagate).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Updated streak indicator colors for enhanced visual consistency
  * Added empty state messaging for the quests section when no quests are available

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ecency/ecency-mobile/pull/3208?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->