### PR TITLE
Mobile leaderboard: badge for completing all daily quests

### DIFF
--- a/src/components/leaderboard/view/leaderboardStyles.ts
+++ b/src/components/leaderboard/view/leaderboardStyles.ts
@@ -18,6 +18,9 @@ export default EStyleSheet.create({
   rewardText: {
     color: '$primaryBlue',
   },
+  questBadge: {
+    marginLeft: 6,
+  },
   columnTitleWrapper: {
     flexDirection: 'row',
     marginTop: 10,

--- a/src/components/leaderboard/view/leaderboardView.tsx
+++ b/src/components/leaderboard/view/leaderboardView.tsx
@@ -2,8 +2,10 @@ import React, { PureComponent, Fragment } from 'react';
 import { View, FlatList, Text } from 'react-native';
 import { injectIntl } from 'react-intl';
 import get from 'lodash/get';
+import EStyleSheet from 'react-native-extended-stylesheet';
 
 // Components
+import { Icon } from '../../icon';
 import { UserListItem, ListPlaceHolder } from '../../basicUIElements';
 import { FilterBar } from '../../filterBar';
 import FILTER_OPTIONS, { VALUE } from '../../../constants/options/leaderboard';
@@ -37,6 +39,17 @@ class LeaderboardView extends PureComponent {
         handleOnPress={() => handleOnUserPress(get(item, '_id'))}
         rightTextStyle={styles.rewardText}
         rightTooltipText={intl.formatMessage({ id: 'leaderboard.tooltip_earn' })}
+        rightItemRenderer={() =>
+          get(item, 'quests_done') ? (
+            <Icon
+              style={styles.questBadge}
+              name="check-circle"
+              iconType="MaterialCommunityIcons"
+              color={EStyleSheet.value('$primaryGreen')}
+              size={18}
+            />
+          ) : null
+        }
       />
     );
   };

--- a/src/components/leaderboard/view/leaderboardView.tsx
+++ b/src/components/leaderboard/view/leaderboardView.tsx
@@ -21,7 +21,7 @@ class LeaderboardView extends PureComponent {
 
   // Component Functions
   _renderItem = ({ item, index }) => {
-    const { handleOnUserPress, intl } = this.props;
+    const { handleOnUserPress, intl, selectedIndex } = this.props;
 
     return (
       <UserListItem
@@ -40,7 +40,7 @@ class LeaderboardView extends PureComponent {
         rightTextStyle={styles.rewardText}
         rightTooltipText={intl.formatMessage({ id: 'leaderboard.tooltip_earn' })}
         rightItemRenderer={() =>
-          get(item, 'quests_done') ? (
+          selectedIndex === 0 && get(item, 'quests_done') ? (
             <Icon
               style={styles.questBadge}
               name="check-circle"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1271,9 +1271,9 @@
     xss "^1.0.9"
 
 "@ecency/sdk@^2.3.1":
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/@ecency/sdk/-/sdk-2.3.2.tgz#f418ef34ea62de617c2b9ac34239ba2d18f5a0a5"
-  integrity sha512-sFukBaRiTyh5OJTmL/YpHerstFEyHHE4xRi91GMY9oldBcyOrJOpH0c6K/NHjEC+4uczmkinMxQgUreBYq2AuQ==
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/@ecency/sdk/-/sdk-2.3.3.tgz#cc2dfe5d07804d1d918822df70904d54af6f51a1"
+  integrity sha512-waEfxldig+Drwnh4+n34x38JkBjNkzPGrOhxBv3Nt+50SH5myULTdgli1wZMd8bzzZggXBl6EnwpGNUTkUpCYw==
   dependencies:
     "@noble/ciphers" "^2.1.1"
     "@noble/curves" "^2.0.1"


### PR DESCRIPTION
## What

Shows a green ✓ on **leaderboard** rows for users who completed **all** their daily quests today — matching the web (ecency/vision-next#839). Recognition only, no points.

## Changes

- Render the badge via `UserListItem`'s `rightItemRenderer` slot when `item.quests_done` is true (a small `questBadge` style).
- Bump `@ecency/sdk` 2.3.2 → **2.3.3** for the new `LeaderBoardItem.quests_done` field (deps unchanged).

The `quests_done` flag is computed server-side on the esync leaderboard query (ecency/esync-py#4, deployed). Prettier-checked against the repo config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added visual indicators to the leaderboard displaying quest completion status for users with a distinctive icon.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ecency/ecency-mobile/pull/3209?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->