### PR TITLE
Stop the announcement banner from signing server-provided ops

### DIFF
--- a/src/providers/queries/announcementsQueries.ts
+++ b/src/providers/queries/announcementsQueries.ts
@@ -8,6 +8,7 @@ import { SheetManager } from 'react-native-actions-sheet';
 import { useAppSelector, useLinkProcessor } from '../../hooks';
 import { updateAnnoucementsMeta } from '../../redux/actions/cacheActions';
 import { getPostUrl } from '../../utils/post';
+import { resolveAnnouncementAction } from '../../utils/announcementAction';
 import { delay } from '../../utils/editor';
 import { ButtonTypes } from '../../components/actionModal/container/actionModalContainer';
 import parseVersionNumber from '../../utils/parseVersionNumber';
@@ -71,13 +72,13 @@ export const useAnnouncementsQuery = () => {
     };
 
     const _onActionPress = () => {
-      if (data.ops) {
-        linkProcessor.handleLink(data.ops);
-      } else if (data.button_link) {
-        const _url = data.button_link.startsWith('https://')
-          ? data.button_link
-          : getPostUrl(data.button_link);
-        linkProcessor.handleLink(_url);
+      // Deliberately ignore the server-provided `ops` (hive://sign/op/...) blob:
+      // a banner tap must never sign an arbitrary server operation. Proposal
+      // voting happens through the in-app, user-reviewed flow on the linked page.
+      const action = resolveAnnouncementAction(data, getPostUrl);
+
+      if (action.type === 'open-link') {
+        linkProcessor.handleLink(action.url);
       }
 
       // mark as processed

--- a/src/utils/announcementAction.test.ts
+++ b/src/utils/announcementAction.test.ts
@@ -1,0 +1,38 @@
+import { resolveAnnouncementAction } from './announcementAction';
+
+const toUrl = (link: string) => `https://ecency.com${link}`;
+
+describe('resolveAnnouncementAction', () => {
+  it('ignores the server ops blob and falls through to button_link', () => {
+    expect(
+      resolveAnnouncementAction(
+        { ops: 'hive://sign/op/abc', button_link: '/proposals/379' },
+        toUrl,
+      ),
+    ).toEqual({ type: 'open-link', url: 'https://ecency.com/proposals/379' });
+  });
+
+  it('returns none when only ops is present (ops is never signed from a banner)', () => {
+    expect(resolveAnnouncementAction({ ops: 'hive://sign/op/abc' }, toUrl)).toEqual({
+      type: 'none',
+    });
+  });
+
+  it('uses an absolute https button_link as-is', () => {
+    expect(resolveAnnouncementAction({ button_link: 'https://ecency.com/mobile' }, toUrl)).toEqual({
+      type: 'open-link',
+      url: 'https://ecency.com/mobile',
+    });
+  });
+
+  it('converts a relative button_link via toUrl', () => {
+    expect(resolveAnnouncementAction({ button_link: '/created/x' }, toUrl)).toEqual({
+      type: 'open-link',
+      url: 'https://ecency.com/created/x',
+    });
+  });
+
+  it('returns none for an empty announcement', () => {
+    expect(resolveAnnouncementAction({}, toUrl)).toEqual({ type: 'none' });
+  });
+});

--- a/src/utils/announcementAction.ts
+++ b/src/utils/announcementAction.ts
@@ -1,0 +1,32 @@
+export interface AnnouncementActionData {
+  button_link?: string;
+  ops?: string;
+}
+
+export type AnnouncementAction = { type: 'open-link'; url: string } | { type: 'none' };
+
+/**
+ * Decide what an announcement's primary button does.
+ *
+ * The server-provided `ops` (`hive://sign/op/...`) blob is intentionally ignored:
+ * a banner tap must never sign an arbitrary server-supplied operation. We only
+ * open `button_link` (e.g. a proposal page, where voting happens through the
+ * in-app, user-reviewed flow) — or do nothing when there is no link.
+ *
+ * Note: proposal voting is NOT triggered inline here. The announcement is shown
+ * above the navigation container (from app init), whereas the vote/signing flow
+ * requires navigation context — so an inline vote can't run from this surface.
+ */
+export const resolveAnnouncementAction = (
+  data: AnnouncementActionData,
+  toUrl: (link: string) => string,
+): AnnouncementAction => {
+  if (data?.button_link) {
+    const url = data.button_link.startsWith('https://')
+      ? data.button_link
+      : toUrl(data.button_link);
+    return { type: 'open-link', url };
+  }
+
+  return { type: 'none' };
+};


### PR DESCRIPTION
Removes the announcement banner's ability to sign the server-provided `ops` (`hive://sign/op/...`) blob — the safety goal behind dropping `hive://` from this surface.

### What
- `_onActionPress` no longer decodes/signs `data.ops`. It now only opens `button_link` (for a proposal announcement that's the proposal page, where voting happens through the in-app, user-reviewed flow).
- New pure helper `resolveAnnouncementAction` (+ unit tests) encodes the decision and guards against re-introducing `ops`-signing (a test asserts an `ops`-only announcement does nothing).

### Why not inline voting (as on web)?
The announcement is shown from app init — its hook (`useAnnouncementsQuery`) and the ACTION_MODAL sheet both render **above** the `NavigationContainer`. The vote/signing path (`useProposalVoteMutation` → `useActiveKeyOperation`) calls `useNavigation()` at hook-body level, which requires navigation context. Calling it from this surface throws at startup (caught in review). So a true single-tap inline vote isn't feasible here without a larger restructure; the native `ProposalVoteRequest` card in the feed already provides in-app voting within nav context.

### Scope
The general `hive://` signing path (dApp browser, QR, deep links) is untouched — those are user-initiated and reviewed. Only the announcement auto-sign path is removed.

Companion: vision-next #876 (web inline vote), vision-api #23 (`proposal_ids`, merged). The server `ops` field can stay for older app versions and be retired later.