### PR TITLE
feat(vote): drag slider + keyboard-free keypad in upvote popover

### DIFF
--- a/src/components/upvotePopover/children/percentKeypad.tsx
+++ b/src/components/upvotePopover/children/percentKeypad.tsx
@@ -1,0 +1,112 @@
+import React, { useState } from 'react';
+import { View, Text, TouchableOpacity } from 'react-native';
+
+import { Icon } from '../../icon';
+import styles from './upvoteStyles';
+import {
+  appendDigit,
+  backspaceBuffer,
+  commitPercent,
+  parseBufferPercent,
+} from './percentKeypadUtils';
+
+// IconView is an untyped class component; alias to keep the runtime component
+// while satisfying TS for the iconType/name/size props.
+const KeyIcon = Icon as unknown as React.ComponentType<any>;
+
+/*
+ * Keyboard-free numeric keypad shown inside the vote popover when the user taps
+ * the NN% label, giving exact value entry like the vision-next web input —
+ * without ever raising the OS keyboard (which would be occluded by this
+ * Modal-hosted popover). Vote weight is whole-percent on chain, so an integer
+ * keypad has full precision parity with typing.
+ *
+ * Every keypress commits live through onChange(ratio 0..1) so the $ estimate and
+ * (hidden) fill stay in sync; the check key clamps to the floor and calls
+ * onDone() to return to the slider row. The actual vote still only fires from
+ * the up/down icons after the keypad is dismissed.
+ */
+
+interface PercentKeypadProps {
+  // Current value in the 0..1 range.
+  value: number;
+  // Lower bound (0..1): 0 when a vote exists (allows removal), else 0.01.
+  minValue: number;
+  // Pre-formatted "$x.xx" estimate from the container, kept in sync via onChange.
+  amount: string;
+  color: string;
+  onChange: (value: number) => void;
+  onDone: () => void;
+}
+
+const PercentKeypad = ({
+  value,
+  minValue,
+  amount,
+  color,
+  onChange,
+  onDone,
+}: PercentKeypadProps) => {
+  const minPercent = Math.round(minValue * 100);
+  const [buffer, setBuffer] = useState(String(Math.round(value * 100)));
+
+  // Each edit commits the live (upper-clamped) value so the $ estimate and fill
+  // stay in sync; the lower bound is only enforced when the user taps Done.
+  const _emit = (buf: string) => onChange(parseBufferPercent(buf) / 100);
+
+  const _pressDigit = (digit: number) => {
+    const next = appendDigit(buffer, digit);
+    setBuffer(next);
+    _emit(next);
+  };
+
+  const _backspace = () => {
+    const next = backspaceBuffer(buffer);
+    setBuffer(next);
+    _emit(next);
+  };
+
+  const _done = () => {
+    onChange(commitPercent(buffer, minPercent) / 100);
+    onDone();
+  };
+
+  const _renderDigit = (digit: number) => (
+    <TouchableOpacity
+      key={digit}
+      style={styles.keypadKey}
+      onPress={() => _pressDigit(digit)}
+      activeOpacity={0.6}
+    >
+      <Text style={styles.keypadKeyText}>{digit}</Text>
+    </TouchableOpacity>
+  );
+
+  return (
+    <View style={styles.keypadWrapper}>
+      <View style={styles.keypadHeader}>
+        <Text style={[styles.keypadValue, { color }]}>{`${buffer === '' ? 0 : buffer}%`}</Text>
+        <Text style={styles.keypadAmount}>{`$${amount}`}</Text>
+      </View>
+
+      <View style={styles.keypadRow}>{[1, 2, 3].map(_renderDigit)}</View>
+      <View style={styles.keypadRow}>{[4, 5, 6].map(_renderDigit)}</View>
+      <View style={styles.keypadRow}>{[7, 8, 9].map(_renderDigit)}</View>
+      <View style={styles.keypadRow}>
+        <TouchableOpacity style={styles.keypadKey} onPress={_backspace} activeOpacity={0.6}>
+          <KeyIcon iconType="MaterialIcons" name="backspace" style={styles.keypadIcon} size={20} />
+        </TouchableOpacity>
+        {_renderDigit(0)}
+        <TouchableOpacity
+          style={[styles.keypadKey, styles.keypadDoneKey, { backgroundColor: color }]}
+          onPress={_done}
+          activeOpacity={0.8}
+        >
+          <KeyIcon iconType="AntDesign" name="check" style={styles.keypadDoneIcon} size={20} />
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+};
+
+export default PercentKeypad;

--- a/src/components/upvotePopover/children/percentKeypad.tsx
+++ b/src/components/upvotePopover/children/percentKeypad.tsx
@@ -78,6 +78,8 @@ const PercentKeypad = ({
       style={styles.keypadKey}
       onPress={() => _pressDigit(digit)}
       activeOpacity={0.6}
+      accessibilityRole="button"
+      accessibilityLabel={String(digit)}
     >
       <Text style={styles.keypadKeyText}>{digit}</Text>
     </TouchableOpacity>
@@ -94,7 +96,13 @@ const PercentKeypad = ({
       <View style={styles.keypadRow}>{[4, 5, 6].map(_renderDigit)}</View>
       <View style={styles.keypadRow}>{[7, 8, 9].map(_renderDigit)}</View>
       <View style={styles.keypadRow}>
-        <TouchableOpacity style={styles.keypadKey} onPress={_backspace} activeOpacity={0.6}>
+        <TouchableOpacity
+          style={styles.keypadKey}
+          onPress={_backspace}
+          activeOpacity={0.6}
+          accessibilityRole="button"
+          accessibilityLabel="Delete"
+        >
           <KeyIcon iconType="MaterialIcons" name="backspace" style={styles.keypadIcon} size={20} />
         </TouchableOpacity>
         {_renderDigit(0)}
@@ -102,6 +110,8 @@ const PercentKeypad = ({
           style={[styles.keypadKey, styles.keypadDoneKey, { backgroundColor: color }]}
           onPress={_done}
           activeOpacity={0.8}
+          accessibilityRole="button"
+          accessibilityLabel="Apply percentage"
         >
           <KeyIcon iconType="AntDesign" name="check" style={styles.keypadDoneIcon} size={20} />
         </TouchableOpacity>

--- a/src/components/upvotePopover/children/percentKeypad.tsx
+++ b/src/components/upvotePopover/children/percentKeypad.tsx
@@ -32,7 +32,8 @@ interface PercentKeypadProps {
   value: number;
   // Lower bound (0..1): 0 when a vote exists (allows removal), else 0.01.
   minValue: number;
-  // Pre-formatted "$x.xx" estimate from the container, kept in sync via onChange.
+  // Raw numeric estimate string from the container (e.g. "0.001", "1.23") — no
+  // "$" prefix; this component renders the "$" itself, so callers must not add it.
   amount: string;
   color: string;
   onChange: (value: number) => void;

--- a/src/components/upvotePopover/children/percentKeypadUtils.test.ts
+++ b/src/components/upvotePopover/children/percentKeypadUtils.test.ts
@@ -1,0 +1,78 @@
+import {
+  appendDigit,
+  backspaceBuffer,
+  commitPercent,
+  parseBufferPercent,
+} from './percentKeypadUtils';
+
+describe('percentKeypadUtils', () => {
+  describe('parseBufferPercent', () => {
+    it('treats an empty buffer as 0', () => {
+      expect(parseBufferPercent('')).toBe(0);
+    });
+
+    it('parses a normal value', () => {
+      expect(parseBufferPercent('73')).toBe(73);
+    });
+
+    it('clamps above 100 to 100', () => {
+      expect(parseBufferPercent('150')).toBe(100);
+    });
+
+    it('returns 0 for non-numeric input', () => {
+      expect(parseBufferPercent('abc')).toBe(0);
+    });
+  });
+
+  describe('appendDigit', () => {
+    it('appends to build a multi-digit value', () => {
+      expect(appendDigit('7', 3)).toBe('73');
+    });
+
+    it('drops a leading zero so "0" + 7 reads as 7', () => {
+      expect(appendDigit('0', 7)).toBe('7');
+    });
+
+    it('starts from empty', () => {
+      expect(appendDigit('', 5)).toBe('5');
+    });
+
+    it('caps the result at 100', () => {
+      expect(appendDigit('100', 5)).toBe('100');
+      expect(appendDigit('99', 9)).toBe('100');
+    });
+  });
+
+  describe('backspaceBuffer', () => {
+    it('removes the last digit', () => {
+      expect(backspaceBuffer('73')).toBe('7');
+    });
+
+    it('empties a single-digit buffer', () => {
+      expect(backspaceBuffer('7')).toBe('');
+    });
+
+    it('is a no-op-safe on empty', () => {
+      expect(backspaceBuffer('')).toBe('');
+    });
+  });
+
+  describe('commitPercent', () => {
+    it('raises a below-minimum value to the floor (fresh vote, min 1%)', () => {
+      expect(commitPercent('0', 1)).toBe(1);
+      expect(commitPercent('', 1)).toBe(1);
+    });
+
+    it('allows 0 when a vote exists and can be removed (min 0)', () => {
+      expect(commitPercent('0', 0)).toBe(0);
+    });
+
+    it('keeps an in-range value', () => {
+      expect(commitPercent('45', 1)).toBe(45);
+    });
+
+    it('still clamps the upper bound on commit', () => {
+      expect(commitPercent('150', 1)).toBe(100);
+    });
+  });
+});

--- a/src/components/upvotePopover/children/percentKeypadUtils.ts
+++ b/src/components/upvotePopover/children/percentKeypadUtils.ts
@@ -1,0 +1,35 @@
+/*
+ * Pure helpers for the vote-percent keypad (percentKeypad.tsx). Kept separate so
+ * the digit-buffer / clamping behaviour can be unit-tested without rendering.
+ *
+ * A "buffer" is the raw string of typed digits (e.g. "7", "73", ""). Percent is
+ * a whole number 0..100 (the on-chain vote weight is whole-percent, so there is
+ * no sub-percent state to track).
+ */
+
+export const MAX_PERCENT = 100;
+
+// Parse a digit buffer to a whole percent, clamped to the UPPER bound only.
+// The lower bound is intentionally not applied here so the user can transit
+// through 0 while typing (e.g. "0" then "7" -> 7); it is enforced on commit.
+export const parseBufferPercent = (buffer: string): number => {
+  const n = buffer === '' ? 0 : parseInt(buffer, 10);
+  if (Number.isNaN(n)) {
+    return 0;
+  }
+  return Math.min(MAX_PERCENT, Math.max(0, n));
+};
+
+// Append a digit, dropping a leading zero ("0" + 7 -> "7") and capping at 100.
+// Returns the normalised buffer string.
+export const appendDigit = (buffer: string, digit: number): string => {
+  const raw = buffer === '0' ? String(digit) : `${buffer}${digit}`;
+  return String(parseBufferPercent(raw));
+};
+
+export const backspaceBuffer = (buffer: string): string => buffer.slice(0, -1);
+
+// Final value when the user commits (Done): enforce the lower bound (1% for a
+// fresh vote, 0 when a vote already exists and can be removed).
+export const commitPercent = (buffer: string, minPercent: number): number =>
+  Math.max(minPercent, parseBufferPercent(buffer));

--- a/src/components/upvotePopover/children/upvoteStyles.ts
+++ b/src/components/upvotePopover/children/upvoteStyles.ts
@@ -52,11 +52,107 @@ export default EStyleSheet.create({
   percent: {
     fontWeight: 'bold',
     color: '$primaryDarkGray',
-    marginRight: 5,
   },
   slider: {
     flex: 1,
     marginHorizontal: 10,
+  },
+  // Custom drag-anywhere vote slider (replaces native Slider)
+  voteSliderRow: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginHorizontal: 8,
+  },
+  voteSliderTrack: {
+    flex: 1,
+    height: 28,
+    borderRadius: 14,
+    backgroundColor: '$primaryLightBackground',
+    justifyContent: 'center',
+  },
+  voteSliderFill: {
+    position: 'absolute',
+    left: 0,
+    top: 0,
+    bottom: 0,
+    borderRadius: 14,
+  },
+  voteSliderThumb: {
+    position: 'absolute',
+    width: 18,
+    height: 18,
+    borderRadius: 9,
+    borderWidth: 3,
+    backgroundColor: '$pureWhite',
+    shadowColor: 'black',
+    shadowOffset: { width: 0, height: 1 },
+    shadowRadius: 2,
+    shadowOpacity: 0.3,
+    elevation: 3,
+  },
+  // Tappable NN% label (opens the keyboard-free keypad)
+  percentButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginRight: 5,
+  },
+  percentEditIcon: {
+    color: '$primaryDarkGray',
+    marginLeft: 3,
+  },
+  // Keyboard-free numeric keypad (percentKeypad.tsx) shown while editing
+  popoverKeypad: {
+    borderRadius: 24,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    backgroundColor: '$primaryBackgroundColor',
+  },
+  keypadWrapper: {
+    flex: 1,
+    paddingVertical: 2,
+  },
+  keypadHeader: {
+    flexDirection: 'row',
+    alignItems: 'baseline',
+    justifyContent: 'space-between',
+    paddingHorizontal: 8,
+    paddingBottom: 6,
+  },
+  keypadValue: {
+    fontSize: 22,
+    fontWeight: 'bold',
+  },
+  keypadAmount: {
+    fontSize: 12,
+    fontWeight: 'bold',
+    color: '$primaryDarkGray',
+  },
+  keypadRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  },
+  keypadKey: {
+    flex: 1,
+    height: 40,
+    marginHorizontal: 4,
+    marginVertical: 3,
+    borderRadius: 12,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '$primaryLightBackground',
+  },
+  keypadKeyText: {
+    fontSize: 20,
+    fontWeight: '600',
+    color: '$primaryBlack',
+  },
+  keypadIcon: {
+    color: '$primaryBlack',
+  },
+  keypadDoneKey: {},
+  keypadDoneIcon: {
+    color: '$pureWhite',
   },
   popoverWrapper: {
     flex: 1,

--- a/src/components/upvotePopover/children/voteSlider.tsx
+++ b/src/components/upvotePopover/children/voteSlider.tsx
@@ -1,0 +1,99 @@
+import React, { useRef, useState } from 'react';
+import { View, PanResponder, GestureResponderEvent } from 'react-native';
+
+import styles from './upvoteStyles';
+
+/*
+ * Custom voting slider inspired by the vision-next web "input-vote" control.
+ *
+ * Replaces the thin native @react-native-community/slider (a ~16px thumb on a
+ * 2px track, which many users struggled to grab precisely) with a fat
+ * drag-anywhere fill bar: tapping or dragging anywhere along the track sets the
+ * value from the finger's absolute X position, giving the whole bar height as a
+ * touch target. A colored fill (blue for upvote, red for downvote) grows from
+ * the left and a thumb sits at the fill edge as an affordance.
+ *
+ * This handles the easy/coarse case. For an exact value, the popover's NN%
+ * label is tappable and opens a keyboard-free numeric keypad (see
+ * percentKeypad.tsx) — the chain rounds vote weight to whole percent, so the
+ * keypad gives full precision parity with the web without ever raising the OS
+ * keyboard (which would otherwise be occluded by this Modal-hosted popover).
+ *
+ * Built on PanResponder rather than react-native-gesture-handler because the
+ * popover renders inside a React Native Modal, where gesture-handler needs its
+ * own GestureHandlerRootView; PanResponder works there with no extra setup.
+ */
+
+interface VoteSliderProps {
+  // Current value in the 0..1 range (matches the legacy native slider contract).
+  value: number;
+  // Lower bound — 0 when a vote already exists (so it can be reduced/removed),
+  // otherwise 0.01 (1%) to keep the on-chain weight non-zero.
+  minValue?: number;
+  color: string;
+  onValueChange: (value: number) => void;
+}
+
+const THUMB_SIZE = 18;
+
+const VoteSlider = ({ value, minValue = 0, color, onValueChange }: VoteSliderProps) => {
+  // Measured track width drives the thumb's pixel position so it stays fully
+  // visible at both ends; widthRef mirrors it for the (memoised) PanResponder.
+  const [trackWidth, setTrackWidth] = useState(0);
+  const widthRef = useRef(1);
+  const minRef = useRef(minValue);
+  minRef.current = minValue;
+  const onChangeRef = useRef(onValueChange);
+  onChangeRef.current = onValueChange;
+
+  const _ratioFromX = (locationX: number) => {
+    const ratio = locationX / (widthRef.current || 1);
+    return Math.min(1, Math.max(minRef.current, ratio));
+  };
+
+  const panResponder = useRef(
+    PanResponder.create({
+      onStartShouldSetPanResponder: () => true,
+      onMoveShouldSetPanResponder: () => true,
+      // Keep the gesture even if an ancestor scroll view wants it.
+      onPanResponderTerminationRequest: () => false,
+      onPanResponderGrant: (evt: GestureResponderEvent) => {
+        onChangeRef.current(_ratioFromX(evt.nativeEvent.locationX));
+      },
+      onPanResponderMove: (evt: GestureResponderEvent) => {
+        onChangeRef.current(_ratioFromX(evt.nativeEvent.locationX));
+      },
+    }),
+  ).current;
+
+  const clamped = Math.min(1, Math.max(0, value));
+  const fillWidth = clamped * trackWidth;
+  // Center the thumb on the fill edge, clamped so it never overflows the track.
+  const thumbLeft = Math.min(trackWidth - THUMB_SIZE, Math.max(0, fillWidth - THUMB_SIZE / 2));
+
+  return (
+    <View style={styles.voteSliderRow}>
+      <View
+        style={styles.voteSliderTrack}
+        onLayout={(e) => {
+          widthRef.current = e.nativeEvent.layout.width;
+          setTrackWidth(e.nativeEvent.layout.width);
+        }}
+        {...panResponder.panHandlers}
+      >
+        <View
+          pointerEvents="none"
+          style={[styles.voteSliderFill, { width: fillWidth, backgroundColor: color }]}
+        />
+        {trackWidth > 0 && (
+          <View
+            pointerEvents="none"
+            style={[styles.voteSliderThumb, { left: thumbLeft, borderColor: color }]}
+          />
+        )}
+      </View>
+    </View>
+  );
+};
+
+export default VoteSlider;

--- a/src/components/upvotePopover/children/voteSlider.tsx
+++ b/src/components/upvotePopover/children/voteSlider.tsx
@@ -32,11 +32,21 @@ interface VoteSliderProps {
   minValue?: number;
   color: string;
   onValueChange: (value: number) => void;
+  // Spoken label for the adjustable control (e.g. "Upvote weight").
+  accessibilityLabel?: string;
 }
 
 const THUMB_SIZE = 18;
+// Step applied per VoiceOver/TalkBack increment/decrement swipe.
+const ACCESSIBILITY_STEP = 0.05;
 
-const VoteSlider = ({ value, minValue = 0, color, onValueChange }: VoteSliderProps) => {
+const VoteSlider = ({
+  value,
+  minValue = 0,
+  color,
+  onValueChange,
+  accessibilityLabel = 'Vote weight',
+}: VoteSliderProps) => {
   // Measured track width drives the thumb's pixel position so it stays fully
   // visible at both ends; widthRef mirrors it for the (memoised) PanResponder.
   const [trackWidth, setTrackWidth] = useState(0);
@@ -73,6 +83,15 @@ const VoteSlider = ({ value, minValue = 0, color, onValueChange }: VoteSliderPro
     }),
   ).current;
 
+  // VoiceOver/TalkBack adjust the value via increment/decrement swipes rather
+  // than the (gesture-only) PanResponder, so map those to a stepped change.
+  const _onAccessibilityAction = (event: { nativeEvent: { actionName: string } }) => {
+    const delta =
+      event.nativeEvent.actionName === 'increment' ? ACCESSIBILITY_STEP : -ACCESSIBILITY_STEP;
+    const next = Math.round((value + delta) * 100) / 100;
+    onValueChange(Math.min(1, Math.max(minValue, next)));
+  };
+
   const clamped = Math.min(1, Math.max(0, value));
   const fillWidth = clamped * trackWidth;
   // Center the thumb on the fill edge, clamped so it never overflows the track.
@@ -86,6 +105,16 @@ const VoteSlider = ({ value, minValue = 0, color, onValueChange }: VoteSliderPro
           widthRef.current = e.nativeEvent.layout.width;
           setTrackWidth(e.nativeEvent.layout.width);
         }}
+        accessible
+        accessibilityRole="adjustable"
+        accessibilityLabel={accessibilityLabel}
+        accessibilityValue={{
+          min: Math.round(minValue * 100),
+          max: 100,
+          now: Math.round(clamped * 100),
+        }}
+        accessibilityActions={[{ name: 'increment' }, { name: 'decrement' }]}
+        onAccessibilityAction={_onAccessibilityAction}
         {...panResponder.panHandlers}
       >
         <View

--- a/src/components/upvotePopover/children/voteSlider.tsx
+++ b/src/components/upvotePopover/children/voteSlider.tsx
@@ -40,14 +40,21 @@ const VoteSlider = ({ value, minValue = 0, color, onValueChange }: VoteSliderPro
   // Measured track width drives the thumb's pixel position so it stays fully
   // visible at both ends; widthRef mirrors it for the (memoised) PanResponder.
   const [trackWidth, setTrackWidth] = useState(0);
-  const widthRef = useRef(1);
+  // 0 = not yet measured (onLayout hasn't fired). Mirrors trackWidth for the
+  // memoised PanResponder; see _ratioFromX for the pre-layout guard.
+  const widthRef = useRef(0);
   const minRef = useRef(minValue);
   minRef.current = minValue;
   const onChangeRef = useRef(onValueChange);
   onChangeRef.current = onValueChange;
 
   const _ratioFromX = (locationX: number) => {
-    const ratio = locationX / (widthRef.current || 1);
+    // Ignore touches before the track is measured — dividing by a sentinel
+    // width would otherwise snap the first touch straight to 100%.
+    if (!widthRef.current) {
+      return minRef.current;
+    }
+    const ratio = locationX / widthRef.current;
     return Math.min(1, Math.max(minRef.current, ratio));
   };
 

--- a/src/components/upvotePopover/container/upvotePopover.tsx
+++ b/src/components/upvotePopover/container/upvotePopover.tsx
@@ -584,7 +584,12 @@ const UpvotePopover = forwardRef(({}, ref) => {
             />
           ) : (
             <Fragment>
-              <TouchableOpacity onPress={_upvoteContent} style={styles.upvoteButton}>
+              <TouchableOpacity
+                onPress={_upvoteContent}
+                style={styles.upvoteButton}
+                accessibilityRole="button"
+                accessibilityLabel="Upvote"
+              >
                 <Icon
                   size={20}
                   style={[styles.upvoteIcon, { color: '#007ee5' }]}
@@ -599,11 +604,14 @@ const UpvotePopover = forwardRef(({}, ref) => {
                 minValue={_minSliderVal}
                 value={sliderValue}
                 onValueChange={_onSliderValueChange}
+                accessibilityLabel={isDownVoted ? 'Downvote weight' : 'Upvote weight'}
               />
               <TouchableOpacity
                 style={styles.percentButton}
                 onPress={() => setIsEditingPercent(true)}
                 hitSlop={{ top: 12, bottom: 12, left: 8, right: 8 }}
+                accessibilityRole="button"
+                accessibilityLabel={`Edit vote percentage, currently ${_percent}`}
               >
                 <Text style={styles.percent}>{_percent}</Text>
                 <Icon
@@ -613,7 +621,12 @@ const UpvotePopover = forwardRef(({}, ref) => {
                   name="edit"
                 />
               </TouchableOpacity>
-              <TouchableOpacity onPress={_downvoteContent} style={styles.upvoteButton}>
+              <TouchableOpacity
+                onPress={_downvoteContent}
+                style={styles.upvoteButton}
+                accessibilityRole="button"
+                accessibilityLabel="Downvote"
+              >
                 <Icon
                   size={20}
                   style={[styles.upvoteIcon, { color: '#ec8b88' }]}

--- a/src/components/upvotePopover/container/upvotePopover.tsx
+++ b/src/components/upvotePopover/container/upvotePopover.tsx
@@ -3,9 +3,9 @@ import * as Sentry from '@sentry/react-native';
 import get from 'lodash/get';
 
 // Services and Actions
-import { View, TouchableOpacity, Text, useWindowDimensions } from 'react-native';
+import { View, TouchableOpacity, Text, useWindowDimensions, Platform } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import Popover, { PopoverPlacement as Placement, Rect } from 'react-native-popover-view';
-import Slider from '@react-native-community/slider';
 import { useIntl } from 'react-intl';
 import { useVote, votingPower as sdkVotingPower, votingRshares, votingValue } from '@ecency/sdk';
 import {
@@ -46,6 +46,8 @@ import {
 import styles from '../children/upvoteStyles';
 
 import { PayoutDetailsContent } from '../children/payoutDetailsContent';
+import VoteSlider from '../children/voteSlider';
+import PercentKeypad from '../children/percentKeypad';
 import showLoginAlert from '../../../utils/showLoginAlert';
 
 // Transport-level failure signatures. The SDK broadcasts votes in 'async' mode,
@@ -135,6 +137,7 @@ const UpvotePopover = forwardRef(({}, ref) => {
   const intl = useIntl();
   const dispatch = useAppDispatch();
   const deviceWidth = useWindowDimensions().width;
+  const safeAreaInsets = useSafeAreaInsets();
 
   const onVotingStartRef = useRef<any>(null);
   const sourceRef = useRef<any>(null);
@@ -163,6 +166,7 @@ const UpvotePopover = forwardRef(({}, ref) => {
   const [postType, setPostType] = useState<PostTypes>(PostTypes.POST);
   const [showPopover, setShowPopover] = useState(false);
   const [showPayoutDetails, setShowPayoutDetails] = useState(false);
+  const [isEditingPercent, setIsEditingPercent] = useState(false);
 
   const [isVoted, setIsVoted] = useState<any>(null);
   const [isDownVoted, setIsDownVoted] = useState<any>(null);
@@ -178,16 +182,19 @@ const UpvotePopover = forwardRef(({}, ref) => {
   };
 
   const _formatEstimate = (value: number) => {
-    if (Number.isNaN(value)) {
-      return '0.00';
+    if (Number.isNaN(value) || value <= 0) {
+      return '0.000';
     } else if (value >= 1) {
       return value.toFixed(2);
     }
-    // Always emit a plain decimal so parseFloat downstream never produces NaN.
-    // toPrecision used to emit "1e-7"-style scientific notation for very small
-    // values; toFixed avoids that. 6 decimals for tiny values keeps a useful
-    // signal without relying on a non-numeric sentinel like "<0.001".
-    return value.toFixed(value < 0.001 ? 6 : 4);
+    // Cap at 3 decimals and floor sub-0.001 values at "0.001": a 6-decimal
+    // string like "0.000428" is too wide and crowds the slider. Stay a plain
+    // numeric string so parseFloat(amount) downstream never produces NaN — no
+    // non-numeric "<0.001" sentinel.
+    if (value < 0.001) {
+      return '0.001';
+    }
+    return value.toFixed(3);
   };
 
   useImperativeHandle(ref, () => ({
@@ -238,6 +245,7 @@ const UpvotePopover = forwardRef(({}, ref) => {
       setPostType(resolvedPostType);
       setContent(_content);
       setShowPayoutDetails(_showPayoutDetails || false);
+      setIsEditingPercent(false);
 
       // Pre-measure source element position before showing popover.
       // This avoids the expensive synchronous layout pass that react-native-popover-view
@@ -268,6 +276,11 @@ const UpvotePopover = forwardRef(({}, ref) => {
     if (currentAccount && Object.entries(currentAccount).length !== 0 && globalProps) {
       setAmount(_formatEstimate(_estimateVoteValue(currentAccount, globalProps, value)));
     }
+  };
+
+  const _onSliderValueChange = (value: number) => {
+    setSliderValue(value);
+    _calculateEstimatedAmount(value);
   };
 
   const _upvoteContent = async () => {
@@ -487,6 +500,7 @@ const UpvotePopover = forwardRef(({}, ref) => {
   const _closePopover = () => {
     setShowPopover(false);
     sourceRectRef.current = null;
+    setIsEditingPercent(false);
 
     setTimeout(() => {
       setShowPayoutDetails(false);
@@ -509,6 +523,27 @@ const UpvotePopover = forwardRef(({}, ref) => {
 
   const _sliderWidth = deviceWidth - 24;
   const _sliderStyle = { ...styles.popoverSlider, width: _sliderWidth };
+  const _keypadStyle = { ...styles.popoverKeypad, width: _sliderWidth };
+
+  let _popoverStyle: any = _sliderStyle;
+  if (showPayoutDetails) {
+    _popoverStyle = styles.popoverDetails;
+  } else if (isEditingPercent) {
+    _popoverStyle = _keypadStyle;
+  }
+
+  // The keypad is much taller than the pill, so while editing allow the popover
+  // to flip BELOW the button when there isn't room above (placement=[TOP] alone
+  // never flips and the library clips the overflowing bottom row — Done key).
+  const _placement = isEditingPercent ? [Placement.TOP, Placement.BOTTOM] : [Placement.TOP];
+
+  // On Android the Modal-hosted popover spans under the translucent status bar,
+  // so a high-anchored keypad can clamp beneath the clock/battery. Inset the
+  // display area by the safe-area top there (iOS handles its own safe area).
+  const _displayAreaInsets =
+    Platform.OS === 'android'
+      ? { top: safeAreaInsets.top, left: 0, right: 0, bottom: 0 }
+      : undefined;
 
   // Use pre-measured rect to avoid expensive synchronous layout pass
   const _fromProp = sourceRectRef.current
@@ -523,7 +558,7 @@ const UpvotePopover = forwardRef(({}, ref) => {
   return (
     <Fragment>
       <Popover
-        popoverStyle={showPayoutDetails ? styles.popoverDetails : _sliderStyle}
+        popoverStyle={_popoverStyle}
         arrowSize={showPayoutDetails ? undefined : { width: 0, height: 0 }}
         backgroundStyle={styles.overlay}
         isVisible={showPopover}
@@ -531,12 +566,22 @@ const UpvotePopover = forwardRef(({}, ref) => {
           _closePopover();
         }}
         from={_fromProp}
-        placement={[Placement.TOP]}
+        placement={_placement}
+        displayAreaInsets={_displayAreaInsets}
         offset={12}
       >
         <View style={styles.popoverWrapper}>
           {showPayoutDetails ? (
             <PayoutDetailsContent content={content} />
+          ) : isEditingPercent ? (
+            <PercentKeypad
+              value={sliderValue}
+              minValue={_minSliderVal}
+              amount={amount}
+              color={sliderColor}
+              onChange={_onSliderValueChange}
+              onDone={() => setIsEditingPercent(false)}
+            />
           ) : (
             <Fragment>
               <TouchableOpacity onPress={_upvoteContent} style={styles.upvoteButton}>
@@ -549,20 +594,25 @@ const UpvotePopover = forwardRef(({}, ref) => {
                 />
               </TouchableOpacity>
               <Text style={styles.amount}>{_amount}</Text>
-              <Slider
-                style={styles.slider}
-                minimumTrackTintColor={sliderColor}
-                maximumTrackTintColor="#b1b1b1"
-                thumbTintColor="#007ee5"
-                minimumValue={_minSliderVal}
-                maximumValue={1}
+              <VoteSlider
+                color={sliderColor}
+                minValue={_minSliderVal}
                 value={sliderValue}
-                onValueChange={(value) => {
-                  setSliderValue(value);
-                  _calculateEstimatedAmount(value);
-                }}
+                onValueChange={_onSliderValueChange}
               />
-              <Text style={styles.percent}>{_percent}</Text>
+              <TouchableOpacity
+                style={styles.percentButton}
+                onPress={() => setIsEditingPercent(true)}
+                hitSlop={{ top: 12, bottom: 12, left: 8, right: 8 }}
+              >
+                <Text style={styles.percent}>{_percent}</Text>
+                <Icon
+                  size={11}
+                  style={styles.percentEditIcon}
+                  iconType="MaterialIcons"
+                  name="edit"
+                />
+              </TouchableOpacity>
               <TouchableOpacity onPress={_downvoteContent} style={styles.upvoteButton}>
                 <Icon
                   size={20}

--- a/src/utils/showLoginAlert.ts
+++ b/src/utils/showLoginAlert.ts
@@ -1,25 +1,13 @@
-import { Alert } from 'react-native';
 import ROUTES from '../constants/routeNames';
 import RootNavigation from '../navigation/rootNavigation';
 
-const showLoginAlert = ({ intl }) => {
-  return Alert.alert(
-    intl.formatMessage({ id: 'login.not_loggedin_alert' }),
-    intl.formatMessage({ id: 'login.not_loggedin_alert_desc' }),
-    [
-      {
-        text: intl.formatMessage({ id: 'login.cancel' }),
-        onPress: () => console.log('Cancel Pressed'),
-        style: 'cancel',
-      },
-      {
-        text: intl.formatMessage({ id: 'login.login' }),
-        onPress: () => {
-          RootNavigation.navigate({ name: ROUTES.SCREENS.LOGIN });
-        },
-      },
-    ],
-  );
+// Previously this popped a "Please login first" confirm dialog with a Login
+// button. Per product preference, gated actions (upvote, reblog, write, feed
+// tabs, etc.) now take the user straight to the Login screen instead of an
+// intermediate alert. The optional intl arg is kept so existing call sites
+// — showLoginAlert({ intl }) — keep compiling without changes.
+const showLoginAlert = (_props?: { intl?: any }) => {
+  RootNavigation.navigate({ name: ROUTES.SCREENS.LOGIN });
 };
 
 export default showLoginAlert;


### PR DESCRIPTION
## Summary

Rebuilds the upvote popover's voting UX (inspired by the vision-next web slider) and streamlines the logged-out path. The voting slider was hard to use precisely; this makes it a big touch target with an exact-entry option.

### Slider + keypad
- Replaces the native `@react-native-community/slider` with a **drag-anywhere fill bar** — tap or drag anywhere sets the value (PanResponder, so the whole bar is the touch target).
- The percentage is now **tappable** and opens a **keyboard-free numeric keypad** inside the popover for exact entry. No OS keyboard on purpose: the Modal-hosted popover can't reliably accommodate it (Android `keyboardDidShow` height is unreliable and would occlude the field). Vote weight is whole-percent on chain, so the keypad keeps full precision parity.
- All vote logic (SDK `useVote`, optimistic cache, network-error handling) is unchanged.

### Robustness (from an iOS/Android review)
- Popover flips to **BOTTOM** while editing when there's no room above, so the keypad's Done key can't be clipped (the popover content is `overflow:hidden` with no scroll).
- **Android `displayAreaInsets`** (safe-area top) so a high-anchored keypad clears the translucent status bar.
- Compact keypad to reduce the open/close reposition delta.

### Estimate formatting
- Caps the estimate at 3 decimals and floors tiny values at `0.001` — a 6-decimal string like `$0.000428` was too wide and crowded the slider. Stays a plain numeric string so `parseFloat(amount)` downstream never produces `NaN`.

### Login
- `showLoginAlert` now navigates **straight to the Login screen** instead of an intermediate "login first" confirm dialog. Shared util, so all gated actions (upvote, reblog, write, feed tabs, uploads, deep links) skip the prompt.

## Tests
- 15 new unit tests for the keypad clamp utils (`percentKeypadUtils`).
- Verified on the iOS simulator: build, popover open, slider render, tap-to-position, keypad open + exact entry, and the new estimate format.

## Follow-ups
- Recommend an Android device pass for the popover BOTTOM-flip and status-bar inset (verified via source review, not yet on a physical Android device).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Custom drag-adjustable vote slider with accessibility actions
  * Keyboard-free numeric keypad for exact vote percentages (0–100) and an in-popover edit flow
  * Improved estimate formatting for small amounts

* **Style**
  * Updated popover, slider, and keypad styling to support the new UI and safe-area/flipping behavior

* **Tests**
  * Added unit tests covering keypad utility logic

* **Bug Fixes**
  * Login now navigates directly to the login screen when required
<!-- end of auto-generated comment: release notes by coderabbit.ai -->