### PR TITLE
ci(i18n): on-demand label-triggered Crowdin sync (no more per-language commits)

### DIFF
--- a/.github/workflows/crowdin-download.yml
+++ b/.github/workflows/crowdin-download.yml
@@ -3,13 +3,15 @@ name: Crowdin Download
 # Pulls the latest translations from Crowdin on demand and batches them into a
 # single pull request, instead of Crowdin auto-pushing one commit per language.
 #
-# Trigger: add the "sync-translations" label to any open PR. The label is removed
-# automatically after the run, so re-adding it later triggers a fresh pull.
-# (Fork PRs cannot trigger this — they have no access to secrets. Label a PR from
-# a branch in this repo.)
+# Triggers:
+#   - add the "sync-translations" label to any same-repo PR (auto-removed after
+#     the run, so re-adding it triggers a fresh pull), or
+#   - run manually from the Actions tab (workflow_dispatch).
+# Fork PRs are skipped — they have no access to the Crowdin secret.
 on:
   pull_request:
     types: [labeled]
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -17,7 +19,10 @@ permissions:
 
 jobs:
   download:
-    if: github.event.label.name == 'sync-translations'
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.label.name == 'sync-translations' &&
+       github.event.pull_request.head.repo.fork == false)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout base branch
@@ -26,6 +31,7 @@ jobs:
           ref: development
 
       - name: Remove trigger label
+        if: github.event_name == 'pull_request'
         continue-on-error: true
         uses: actions/github-script@v7
         with:
@@ -43,10 +49,14 @@ jobs:
           upload_sources: false
           upload_translations: false
           download_translations: true
+          # Use the development checkout above as the base for l10n/crowdin.
+          # Without this the action checks out the trigger PR's head ref, which
+          # fails (or bases the translations PR on unrelated feature changes).
+          skip_ref_checkout: true
           localization_branch_name: l10n/crowdin
           create_pull_request: true
           pull_request_title: 'chore(i18n): sync translations from Crowdin'
-          pull_request_body: 'Batched translation update pulled from Crowdin via the `sync-translations` label.'
+          pull_request_body: 'Batched translation update pulled from Crowdin.'
           pull_request_base_branch_name: development
           commit_message: 'chore(i18n): sync translations from Crowdin'
           github_user_name: 'github-actions[bot]'

--- a/.github/workflows/crowdin-download.yml
+++ b/.github/workflows/crowdin-download.yml
@@ -49,6 +49,9 @@ jobs:
           upload_sources: false
           upload_translations: false
           download_translations: true
+          # Strings live under a Crowdin branch (created by the old GitHub
+          # integration); without this the CLI can't match files to crowdin.yml.
+          crowdin_branch_name: development
           # Use the development checkout above as the base for l10n/crowdin.
           # Without this the action checks out the trigger PR's head ref, which
           # fails (or bases the translations PR on unrelated feature changes).

--- a/.github/workflows/crowdin-download.yml
+++ b/.github/workflows/crowdin-download.yml
@@ -1,0 +1,57 @@
+name: Crowdin Download
+
+# Pulls the latest translations from Crowdin on demand and batches them into a
+# single pull request, instead of Crowdin auto-pushing one commit per language.
+#
+# Trigger: add the "sync-translations" label to any open PR. The label is removed
+# automatically after the run, so re-adding it later triggers a fresh pull.
+# (Fork PRs cannot trigger this — they have no access to secrets. Label a PR from
+# a branch in this repo.)
+on:
+  pull_request:
+    types: [labeled]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  download:
+    if: github.event.label.name == 'sync-translations'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout base branch
+        uses: actions/checkout@v4
+        with:
+          ref: development
+
+      - name: Remove trigger label
+        continue-on-error: true
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              name: 'sync-translations',
+            });
+
+      - name: Download translations from Crowdin
+        uses: crowdin/github-action@v2
+        with:
+          upload_sources: false
+          upload_translations: false
+          download_translations: true
+          localization_branch_name: l10n/crowdin
+          create_pull_request: true
+          pull_request_title: 'chore(i18n): sync translations from Crowdin'
+          pull_request_body: 'Batched translation update pulled from Crowdin via the `sync-translations` label.'
+          pull_request_base_branch_name: development
+          commit_message: 'chore(i18n): sync translations from Crowdin'
+          github_user_name: 'github-actions[bot]'
+          github_user_email: '41898282+github-actions[bot]@users.noreply.github.com'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CROWDIN_PROJECT_ID: "340925"
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}

--- a/.github/workflows/crowdin-upload.yml
+++ b/.github/workflows/crowdin-upload.yml
@@ -23,6 +23,9 @@ jobs:
           upload_sources: true
           upload_translations: false
           download_translations: false
+          # Upload into the same Crowdin branch the translations live under, so
+          # sources don't fork off into a separate branchless copy.
+          crowdin_branch_name: development
         env:
           CROWDIN_PROJECT_ID: "340925"
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}

--- a/.github/workflows/crowdin-upload.yml
+++ b/.github/workflows/crowdin-upload.yml
@@ -1,0 +1,28 @@
+name: Crowdin Upload Sources
+
+# Pushes new/changed English source strings to Crowdin whenever the base locale
+# changes on development. One-way (repo -> Crowdin); creates no commits in the repo.
+on:
+  push:
+    branches: [development]
+    paths:
+      - 'src/config/locales/en-US.json'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Upload sources to Crowdin
+        uses: crowdin/github-action@v2
+        with:
+          upload_sources: true
+          upload_translations: false
+          download_translations: false
+        env:
+          CROWDIN_PROJECT_ID: "340925"
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}


### PR DESCRIPTION
## What

Replaces Crowdin's GitHub integration — which auto-pushed **one commit per language** straight onto `development` — with two CI workflows we control.

- **`crowdin-upload.yml`** — on push to `development` touching `src/config/locales/en-US.json`, uploads new English source strings to Crowdin. One-way (repo → Crowdin); **no commits back to the repo**. Also runnable manually (`workflow_dispatch`).
- **`crowdin-download.yml`** — add the **`sync-translations`** label to any open PR to pull the latest translations into a **single batched PR** (branch `l10n/crowdin`). The label auto-removes after each run, so re-adding it triggers a fresh pull. Squash-merge that PR for one tidy commit instead of hundreds.

Crowdin project **340925** (Ecency Mobile). Auth via the existing org secret `CROWDIN_PERSONAL_TOKEN`; project ID is hard-coded (it isn't sensitive). The `sync-translations` label has been created on this repo.

## Required after merge

1. In the Crowdin project (Ecency Mobile) → **disconnect the GitHub integration**, so it stops auto-pushing per-language commits (otherwise the new CI and the old integration double up).
2. Nothing else — the token is already an org secret.

## Notes

- The label trigger needs a PR from a branch **in this repo** (fork PRs have no secret access).
- The generated `l10n/crowdin` PR is opened with `GITHUB_TOKEN`, so other PR checks won't auto-run on it — merge normally.
- Good opportunity to also fill the ~42 locales currently stuck on English fallbacks via Crowdin AI pre-translation.
