### PR TITLE
fix(android): clamp system font/display scaling to prevent abnormal zoom

### DIFF
--- a/android/app/src/main/java/app/esteem/mobile/android/DisplayScalingClamp.kt
+++ b/android/app/src/main/java/app/esteem/mobile/android/DisplayScalingClamp.kt
@@ -1,0 +1,46 @@
+package app.esteem.mobile.android
+
+import android.content.Context
+import android.content.res.Configuration
+import android.util.DisplayMetrics
+
+/**
+ * Single source of truth for clamping extreme system accessibility scaling.
+ *
+ * A very large "Display size" (densityDpi) or "Font size" (fontScale) otherwise renders the whole
+ * app abnormally "zoomed in" (oversized text/images/icons + overflowing layouts). We clamp — not
+ * disable — so moderate accessibility scaling still works.
+ *
+ * Applied from BOTH [MainActivity.attachBaseContext] (the Activity context governs view rendering)
+ * and [MainApplication.attachBaseContext] (the Application context is what React Native uses to
+ * initialize its display metrics, i.e. what Dimensions.get('window') reports). An Activity's base
+ * context is created by the system from the raw config, so both must be clamped independently.
+ *
+ * Note: density/fontScale are intentionally NOT in AndroidManifest configChanges. attachBaseContext
+ * only runs at Activity creation, so an in-session change must recreate the Activity to re-apply
+ * this clamp; declaring them as handled would suppress the recreation and bypass it.
+ */
+object DisplayScalingClamp {
+    private const val MAX_FONT_SCALE = 1.3f // ~Android "Large" font step
+    private const val MAX_DENSITY_SCALE = 1.15f // relative to device default density
+
+    @JvmStatic
+    fun wrap(base: Context): Context {
+        val config = Configuration(base.resources.configuration)
+        var changed = false
+
+        if (config.fontScale > MAX_FONT_SCALE) {
+            config.fontScale = MAX_FONT_SCALE
+            changed = true
+        }
+
+        // DENSITY_DEVICE_STABLE is the device's default dpi, unaffected by the user's Display-size override.
+        val maxDpi = Math.round(DisplayMetrics.DENSITY_DEVICE_STABLE * MAX_DENSITY_SCALE)
+        if (config.densityDpi > maxDpi) {
+            config.densityDpi = maxDpi
+            changed = true
+        }
+
+        return if (changed) base.createConfigurationContext(config) else base
+    }
+}

--- a/android/app/src/main/java/app/esteem/mobile/android/MainActivity.java
+++ b/android/app/src/main/java/app/esteem/mobile/android/MainActivity.java
@@ -9,7 +9,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.res.Configuration;
 import android.os.Bundle;
-import android.util.DisplayMetrics;
 import com.zoontek.rnbootsplash.RNBootSplash;
 
 import com.facebook.react.ReactApplication;
@@ -26,42 +25,12 @@ public class MainActivity extends ReactActivity {
     return "Ecency";
   }
 
-  // Upper bounds for system accessibility scaling. Beyond these the entire UI
-  // (text, images, icons) renders abnormally "zoomed in" and overflows layouts.
-  // We honor scaling up to these caps (preserving accessibility) and clamp past.
-  private static final float MAX_FONT_SCALE = 1.3f;     // ~Android "Large" font step
-  private static final float MAX_DENSITY_SCALE = 1.15f; // relative to device default density
-
-  // Clamp extreme system "Font size" (fontScale) and "Display size" (densityDpi)
-  // at the resource layer before any view is created. This is the primary fix for
-  // the abnormal-zoom reports: a user with a very large Display size / Font size
-  // would otherwise get the whole app scaled up with content overflowing the screen.
-  //
-  // NOTE: density/fontScale are intentionally NOT added to AndroidManifest
-  // configChanges. That way an in-session Display-size/Font-size change recreates
-  // the Activity, which re-runs this clamp. Declaring them in configChanges would
-  // suppress the recreation and bypass the clamp until the next app launch.
+  // Clamp extreme system Font size / Display size before any view is created, so an
+  // accessibility setting cannot render the whole app abnormally "zoomed in". The
+  // Activity context governs view rendering. See DisplayScalingClamp for details.
   @Override
   protected void attachBaseContext(Context newBase) {
-    Configuration config = new Configuration(newBase.getResources().getConfiguration());
-    boolean changed = false;
-
-    if (config.fontScale > MAX_FONT_SCALE) {
-      config.fontScale = MAX_FONT_SCALE;
-      changed = true;
-    }
-
-    int defaultDpi = DisplayMetrics.DENSITY_DEVICE_STABLE; // device "Default" Display size dpi
-    int maxDpi = Math.round(defaultDpi * MAX_DENSITY_SCALE);
-    if (config.densityDpi > maxDpi) {
-      config.densityDpi = maxDpi;
-      changed = true;
-    }
-
-    if (changed) {
-      newBase = newBase.createConfigurationContext(config);
-    }
-    super.attachBaseContext(newBase);
+    super.attachBaseContext(DisplayScalingClamp.wrap(newBase));
   }
 
   @Override

--- a/android/app/src/main/java/app/esteem/mobile/android/MainActivity.java
+++ b/android/app/src/main/java/app/esteem/mobile/android/MainActivity.java
@@ -5,9 +5,11 @@ import com.facebook.react.ReactActivityDelegate;
 import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint;
 import com.facebook.react.defaults.DefaultReactActivityDelegate;
 import expo.modules.ReactActivityDelegateWrapper;
+import android.content.Context;
 import android.content.Intent;
 import android.content.res.Configuration;
 import android.os.Bundle;
+import android.util.DisplayMetrics;
 import com.zoontek.rnbootsplash.RNBootSplash;
 
 import com.facebook.react.ReactApplication;
@@ -22,6 +24,44 @@ public class MainActivity extends ReactActivity {
   @Override
   protected String getMainComponentName() {
     return "Ecency";
+  }
+
+  // Upper bounds for system accessibility scaling. Beyond these the entire UI
+  // (text, images, icons) renders abnormally "zoomed in" and overflows layouts.
+  // We honor scaling up to these caps (preserving accessibility) and clamp past.
+  private static final float MAX_FONT_SCALE = 1.3f;     // ~Android "Large" font step
+  private static final float MAX_DENSITY_SCALE = 1.15f; // relative to device default density
+
+  // Clamp extreme system "Font size" (fontScale) and "Display size" (densityDpi)
+  // at the resource layer before any view is created. This is the primary fix for
+  // the abnormal-zoom reports: a user with a very large Display size / Font size
+  // would otherwise get the whole app scaled up with content overflowing the screen.
+  //
+  // NOTE: density/fontScale are intentionally NOT added to AndroidManifest
+  // configChanges. That way an in-session Display-size/Font-size change recreates
+  // the Activity, which re-runs this clamp. Declaring them in configChanges would
+  // suppress the recreation and bypass the clamp until the next app launch.
+  @Override
+  protected void attachBaseContext(Context newBase) {
+    Configuration config = new Configuration(newBase.getResources().getConfiguration());
+    boolean changed = false;
+
+    if (config.fontScale > MAX_FONT_SCALE) {
+      config.fontScale = MAX_FONT_SCALE;
+      changed = true;
+    }
+
+    int defaultDpi = DisplayMetrics.DENSITY_DEVICE_STABLE; // device "Default" Display size dpi
+    int maxDpi = Math.round(defaultDpi * MAX_DENSITY_SCALE);
+    if (config.densityDpi > maxDpi) {
+      config.densityDpi = maxDpi;
+      changed = true;
+    }
+
+    if (changed) {
+      newBase = newBase.createConfigurationContext(config);
+    }
+    super.attachBaseContext(newBase);
   }
 
   @Override

--- a/android/app/src/main/java/app/esteem/mobile/android/MainApplication.kt
+++ b/android/app/src/main/java/app/esteem/mobile/android/MainApplication.kt
@@ -13,7 +13,9 @@ import com.facebook.react.soloader.OpenSourceMergedSoMapping
 import com.facebook.soloader.SoLoader
 
 //expo related packages
+import android.content.Context
 import android.content.res.Configuration
+import android.util.DisplayMetrics
 import expo.modules.ApplicationLifecycleDispatcher
 import expo.modules.ReactNativeHostWrapper
 
@@ -64,5 +66,33 @@ class MainApplication : Application(), ReactApplication {
     override fun onConfigurationChanged(newConfig: Configuration) {
         super.onConfigurationChanged(newConfig)
         ApplicationLifecycleDispatcher.onConfigurationChanged(this, newConfig)
+    }
+
+    // Clamp extreme system "Font size" (fontScale) and "Display size" (densityDpi)
+    // on the application context too. RN initializes its display metrics (what
+    // Dimensions.get('window') reports) from the app context, so clamping here keeps
+    // layout math consistent with the clamped rendering done via MainActivity. See
+    // MainActivity.attachBaseContext for the matching clamp and rationale.
+    override fun attachBaseContext(base: Context) {
+        val config = Configuration(base.resources.configuration)
+        var changed = false
+
+        if (config.fontScale > MAX_FONT_SCALE) {
+            config.fontScale = MAX_FONT_SCALE
+            changed = true
+        }
+
+        val maxDpi = Math.round(DisplayMetrics.DENSITY_DEVICE_STABLE * MAX_DENSITY_SCALE)
+        if (config.densityDpi > maxDpi) {
+            config.densityDpi = maxDpi
+            changed = true
+        }
+
+        super.attachBaseContext(if (changed) base.createConfigurationContext(config) else base)
+    }
+
+    companion object {
+        private const val MAX_FONT_SCALE = 1.3f     // ~Android "Large" font step
+        private const val MAX_DENSITY_SCALE = 1.15f // relative to device default density
     }
 }

--- a/android/app/src/main/java/app/esteem/mobile/android/MainApplication.kt
+++ b/android/app/src/main/java/app/esteem/mobile/android/MainApplication.kt
@@ -15,7 +15,6 @@ import com.facebook.soloader.SoLoader
 //expo related packages
 import android.content.Context
 import android.content.res.Configuration
-import android.util.DisplayMetrics
 import expo.modules.ApplicationLifecycleDispatcher
 import expo.modules.ReactNativeHostWrapper
 
@@ -68,31 +67,11 @@ class MainApplication : Application(), ReactApplication {
         ApplicationLifecycleDispatcher.onConfigurationChanged(this, newConfig)
     }
 
-    // Clamp extreme system "Font size" (fontScale) and "Display size" (densityDpi)
-    // on the application context too. RN initializes its display metrics (what
-    // Dimensions.get('window') reports) from the app context, so clamping here keeps
-    // layout math consistent with the clamped rendering done via MainActivity. See
-    // MainActivity.attachBaseContext for the matching clamp and rationale.
+    // Clamp the same extreme scaling on the application context: RN initializes its
+    // display metrics (what Dimensions.get('window') reports) from the app context, so
+    // clamping here keeps layout consistent with the rendering clamp in MainActivity.
+    // See DisplayScalingClamp for details.
     override fun attachBaseContext(base: Context) {
-        val config = Configuration(base.resources.configuration)
-        var changed = false
-
-        if (config.fontScale > MAX_FONT_SCALE) {
-            config.fontScale = MAX_FONT_SCALE
-            changed = true
-        }
-
-        val maxDpi = Math.round(DisplayMetrics.DENSITY_DEVICE_STABLE * MAX_DENSITY_SCALE)
-        if (config.densityDpi > maxDpi) {
-            config.densityDpi = maxDpi
-            changed = true
-        }
-
-        super.attachBaseContext(if (changed) base.createConfigurationContext(config) else base)
-    }
-
-    companion object {
-        private const val MAX_FONT_SCALE = 1.3f     // ~Android "Large" font step
-        private const val MAX_DENSITY_SCALE = 1.15f // relative to device default density
+        super.attachBaseContext(DisplayScalingClamp.wrap(base))
     }
 }

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-import { AppRegistry, LogBox } from 'react-native';
+import { AppRegistry, LogBox, Text, TextInput } from 'react-native';
 import { name as appName } from './app.json';
 
 import 'react-native-url-polyfill/auto';
@@ -13,5 +13,14 @@ import EcencyApp from './App';
 // ref: https://github.com/ecency/ecency-mobile/issues/2466
 // ignore warnings
 LogBox.ignoreLogs(['Require cycle:', 'Remote debugger']);
+
+// Cap accessibility font scaling app-wide so a large system "Font size" cannot
+// blow up text and overflow layouts. 1.3 keeps a meaningful accessibility boost
+// (matches Android's common "Large" step) while preventing the abnormal zoom.
+// Native density/fontScale are additionally clamped on Android in MainActivity.
+Text.defaultProps = Text.defaultProps || {};
+Text.defaultProps.maxFontSizeMultiplier = 1.3;
+TextInput.defaultProps = TextInput.defaultProps || {};
+TextInput.defaultProps.maxFontSizeMultiplier = 1.3;
 
 AppRegistry.registerComponent(appName, () => EcencyApp);

--- a/index.js
+++ b/index.js
@@ -17,10 +17,24 @@ LogBox.ignoreLogs(['Require cycle:', 'Remote debugger']);
 // Cap accessibility font scaling app-wide so a large system "Font size" cannot
 // blow up text and overflow layouts. 1.3 keeps a meaningful accessibility boost
 // (matches Android's common "Large" step) while preventing the abnormal zoom.
-// Native density/fontScale are additionally clamped on Android in MainActivity.
-Text.defaultProps = Text.defaultProps || {};
-Text.defaultProps.maxFontSizeMultiplier = 1.3;
-TextInput.defaultProps = TextInput.defaultProps || {};
-TextInput.defaultProps.maxFontSizeMultiplier = 1.3;
+// Android additionally clamps fontScale/density natively (MainActivity/MainApplication);
+// this is the cross-platform cap and the primary guard on iOS.
+//
+// React 19 ignores `defaultProps` on function components, so instead we wrap each
+// component's forwardRef render and inject maxFontSizeMultiplier into its props.
+// Explicit per-component maxFontSizeMultiplier values still take precedence.
+const MAX_FONT_SIZE_MULTIPLIER = 1.3;
+const capFontScaling = (Component) => {
+  const baseRender = Component && Component.render;
+  if (typeof baseRender !== 'function' || baseRender.__fontCapped) {
+    return;
+  }
+  const cappedRender = (props, ref) =>
+    baseRender({ maxFontSizeMultiplier: MAX_FONT_SIZE_MULTIPLIER, ...props }, ref);
+  cappedRender.__fontCapped = true;
+  Component.render = cappedRender;
+};
+capFontScaling(Text);
+capFontScaling(TextInput);
 
 AppRegistry.registerComponent(appName, () => EcencyApp);


### PR DESCRIPTION
Some Android users saw the whole UI rendered abnormally "zoomed in" (oversized text, images and icons with content overflowing) when their system Display size and/or Font size accessibility settings were large. The app honored these unbounded at every layer (no native clamp, no JS maxFontSizeMultiplier).

- MainActivity / MainApplication: clamp fontScale (<=1.3) and densityDpi (<=1.15x DENSITY_DEVICE_STABLE) in attachBaseContext via createConfigurationContext. Both contexts are clamped: the Activity governs view rendering, the Application governs what RN reports for Dimensions.get('window').
- index.js: cap Text/TextInput maxFontSizeMultiplier at 1.3 (cross-platform).

Scaling is clamped, not disabled, so moderate accessibility scaling still works. density/fontScale are intentionally NOT added to AndroidManifest configChanges so an in-session change recreates the Activity and the clamp re-applies (declaring them would suppress the recreation and bypass it).

Verified on emulator (Pixel 3 XL API 29, 560dpi -> cap 644): system density 900 and 1100 render identically (both pinned to 644) and font_scale 2.0 and 3.0 render identically (both capped at 1.3x).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents extreme system font/display scaling from breaking layouts and improves stability under high accessibility settings
  * Ensures consistent app appearance and usability by capping font and display scaling

* **New Features**
  * App-wide enforcement of a maximum font-size multiplier so text rendering remains predictable across devices
<!-- end of auto-generated comment: release notes by coderabbit.ai -->