### PR TITLE
Skip proposal announcements on mobile so the native vote card handles voting

### DIFF
--- a/src/providers/queries/announcementsQueries.ts
+++ b/src/providers/queries/announcementsQueries.ts
@@ -8,7 +8,7 @@ import { SheetManager } from 'react-native-actions-sheet';
 import { useAppSelector, useLinkProcessor } from '../../hooks';
 import { updateAnnoucementsMeta } from '../../redux/actions/cacheActions';
 import { getPostUrl } from '../../utils/post';
-import { resolveAnnouncementAction } from '../../utils/announcementAction';
+import { isProposalAnnouncement, resolveAnnouncementAction } from '../../utils/announcementAction';
 import { delay } from '../../utils/editor';
 import { ButtonTypes } from '../../components/actionModal/container/actionModalContainer';
 import parseVersionNumber from '../../utils/parseVersionNumber';
@@ -47,8 +47,13 @@ export const useAnnouncementsQuery = () => {
       return;
     }
 
+    // Skip proposal-support announcements on mobile: the native in-feed
+    // ProposalVoteRequest card already casts the vote in-app (within navigation),
+    // so surfacing the banner here would only add a redundant in-app-browser
+    // detour. Pick the first non-proposal announcement instead.
+    const firstAnnounce = announcementsQuery.data?.find((a) => !isProposalAnnouncement(a));
+
     // bypass if logged in user is required for announcement, skip otherwise
-    const firstAnnounce = announcementsQuery.data && announcementsQuery.data[0];
     if (!firstAnnounce || (firstAnnounce?.auth && !currentAccount?.username)) {
       return;
     }

--- a/src/utils/announcementAction.test.ts
+++ b/src/utils/announcementAction.test.ts
@@ -1,4 +1,4 @@
-import { resolveAnnouncementAction } from './announcementAction';
+import { isProposalAnnouncement, resolveAnnouncementAction } from './announcementAction';
 
 const toUrl = (link: string) => `https://ecency.com${link}`;
 
@@ -34,5 +34,24 @@ describe('resolveAnnouncementAction', () => {
 
   it('returns none for an empty announcement', () => {
     expect(resolveAnnouncementAction({}, toUrl)).toEqual({ type: 'none' });
+  });
+});
+
+describe('isProposalAnnouncement', () => {
+  it('is true when proposal_ids has at least one id', () => {
+    expect(isProposalAnnouncement({ proposal_ids: [379] })).toBe(true);
+  });
+
+  it('is false for an empty proposal_ids array', () => {
+    expect(isProposalAnnouncement({ proposal_ids: [] })).toBe(false);
+  });
+
+  it('is false when proposal_ids is absent (plain link announcement)', () => {
+    expect(isProposalAnnouncement({ button_link: '/created/x' })).toBe(false);
+  });
+
+  it('is false for an empty announcement or undefined', () => {
+    expect(isProposalAnnouncement({})).toBe(false);
+    expect(isProposalAnnouncement(undefined)).toBe(false);
   });
 });

--- a/src/utils/announcementAction.ts
+++ b/src/utils/announcementAction.ts
@@ -1,9 +1,27 @@
 export interface AnnouncementActionData {
   button_link?: string;
   ops?: string;
+  proposal_ids?: number[];
 }
 
 export type AnnouncementAction = { type: 'open-link'; url: string } | { type: 'none' };
+
+/**
+ * Whether an announcement is a Hive proposal-support prompt.
+ *
+ * Proposal voting is handled natively on mobile by the in-feed
+ * `ProposalVoteRequest` card, which casts the vote in-app (within navigation,
+ * so PIN / HiveSigner / HiveAuth signing works). The announcement banner mounts
+ * ABOVE the navigation container and can't run that flow — it could only open
+ * the proposal web page in an in-app browser, a redundant and worse path. So we
+ * detect proposal announcements here and skip the banner for them, letting the
+ * native card own the experience. Mirrors the web discriminator
+ * (`proposal_ids?.length > 0`), which there votes inline instead.
+ */
+export const isProposalAnnouncement = (data?: AnnouncementActionData): boolean => {
+  const ids = data?.proposal_ids;
+  return Array.isArray(ids) && ids.length > 0;
+};
 
 /**
  * Decide what an announcement's primary button does.


### PR DESCRIPTION
Follow-up to #3212.

## Problem
For a Hive proposal announcement, tapping the banner only opened `button_link` — the proposal **web** page in an in-app browser. There was no actual in-app vote.

The banner can’t vote directly: the announcement renders **above the NavigationContainer** (it fires at app init), and the vote/sign flow needs navigation context (PIN entry, HiveSigner WebView, HiveAuth sheet). So an inline vote from this surface throws at startup.

## Approach
The app already has a native, direct-vote path: the in-feed `ProposalVoteRequest` card finds the active `@ecency` proposal itself and casts the vote **within** navigation (so signing works). Rather than a redundant in-app-browser detour, suppress proposal-type announcements on mobile and let that card own the flow.

- add `isProposalAnnouncement(data)` — true when `proposal_ids` is a non-empty array (mirrors the web discriminator, where the banner instead votes inline)
- `announcementsQueries` now selects the first **non-proposal** announcement (`data?.find(a => !isProposalAnnouncement(a))`) instead of `data[0]`; a proposal-only list shows no banner
- 4 unit tests for the helper

## Result
- Proposal announcements: **no banner / no in-app browser** on mobile — the user gets the native “Support / remind later” vote card in their feed (real in-app vote + signing).
- Non-proposal announcements: unchanged (still shown, still open their link).

Web parity: the web banner already casts the vote inline, so this keeps both clients on a real voting experience rather than a link-out.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile announcement display by preventing proposal-related announcements from appearing on mobile devices, ensuring users see relevant announcements instead.

* **Tests**
  * Added test coverage for proposal announcement detection logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->