### PR TITLE
fix(wallet): normalize transfer amounts to asset precision across all signing paths

### DIFF
--- a/src/containers/transferContainer.ts
+++ b/src/containers/transferContainer.ts
@@ -20,7 +20,7 @@ import { getUserDataWithUsername } from '../realm/realm';
 import { getPointsSummary } from '../providers/ecency/ePoint';
 
 // Utils
-import { countDecimals } from '../utils/number';
+import { getAssetPrecision, toFixedNoExp, formatTokenQuantity } from '../utils/number';
 import { fetchTokenBalances } from '../providers/hive-engine/hiveEngine';
 import TransferTypes from '../constants/transferTypes';
 import { fetchSpkMarkets } from '../providers/hive-spk/hiveSpk';
@@ -263,11 +263,15 @@ class TransferContainer extends Component {
       data.executions = +executions;
     }
 
-    if (countDecimals(Number(data.amount)) < 3) {
-      data.amount = Number(data.amount).toFixed(3);
-    }
+    // Normalize to the asset's on-chain precision before building the op: HIVE/HBD/
+    // POINTS need exactly 3 decimals, VESTS 6; Hive-Engine tokens use their own
+    // precision (no scientific notation). Over-precise amounts are otherwise rejected.
+    const amountValue =
+      tokenLayer === TokenLayers.ENGINE
+        ? formatTokenQuantity(data.amount)
+        : toFixedNoExp(data.amount, getAssetPrecision(fundType));
 
-    data.amount = `${data.amount} ${fundType}`;
+    data.amount = `${amountValue} ${fundType}`;
 
     const _onSuccess = () => {
       dispatch(toastNotification(intl.formatMessage({ id: 'alert.successful' })));

--- a/src/containers/transferContainer.ts
+++ b/src/containers/transferContainer.ts
@@ -45,6 +45,7 @@ class TransferContainer extends Component {
       initialAmount: props.route.params?.initialAmount,
       initialMemo: props.route.params?.initialMemo,
       recurrentTransfers: [],
+      tokenPrecision: undefined,
     };
   }
 
@@ -87,6 +88,7 @@ class TransferContainer extends Component {
     queryClient.fetchQuery(getAccountsQueryOptions([username])).then(async (accounts) => {
       const account = accounts[0];
       let balance;
+      let enginePrecision;
 
       const assetLayer = this.props.route.params?.assetLayer ?? this.props.route.params?.tokenLayer;
       if (assetLayer === TokenLayers.ENGINE) {
@@ -94,6 +96,7 @@ class TransferContainer extends Component {
 
         tokenBalances.forEach((tokenBalance) => {
           if (tokenBalance.symbol === fundType) {
+            enginePrecision = tokenBalance.precision;
             switch (transferType) {
               case TransferTypes.UNDELEGATE:
                 balance = tokenBalance.delegationsOut;
@@ -112,6 +115,7 @@ class TransferContainer extends Component {
             balance = '0';
           }
         });
+        this.setState({ tokenPrecision: enginePrecision });
       } else {
         if (
           (transferType === 'purchase_estm' || transferType === 'transfer_token') &&
@@ -268,7 +272,7 @@ class TransferContainer extends Component {
     // precision (no scientific notation). Over-precise amounts are otherwise rejected.
     const amountValue =
       tokenLayer === TokenLayers.ENGINE
-        ? formatTokenQuantity(data.amount)
+        ? formatTokenQuantity(data.amount, this.state.tokenPrecision)
         : toFixedNoExp(data.amount, getAssetPrecision(fundType));
 
     data.amount = `${amountValue} ${fundType}`;
@@ -657,6 +661,7 @@ class TransferContainer extends Component {
         fetchRecurrentTransfers: this._fetchRecurrentTransfers,
         recurrentTransfers,
         tokenLayer,
+        tokenPrecision: this.state.tokenPrecision,
         setFundType: this._setFundType,
       })
     );

--- a/src/hooks/useTransferMutations.ts
+++ b/src/hooks/useTransferMutations.ts
@@ -28,6 +28,7 @@ import { selectCurrentAccount } from '../redux/selectors';
 import type { RootState } from '../redux/store/store';
 import { getEngineActionOpArray } from '../providers/hive-engine/hiveEngineActions';
 import { EngineActions } from '../providers/hive-engine/hiveEngine.types';
+import { toMilliUnits } from '../utils/number';
 
 /**
  * Bundles all transfer-related SDK mutation hooks into a single object.
@@ -209,7 +210,7 @@ export function useTransferMutations() {
     ({ destination, amount }: { destination: string; amount: number }) => {
       const json = {
         to: destination,
-        amount: amount * 1000,
+        amount: toMilliUnits(amount),
       };
       return [
         [

--- a/src/providers/hive-engine/hiveEngineActions.ts
+++ b/src/providers/hive-engine/hiveEngineActions.ts
@@ -1,5 +1,6 @@
 import type { Operation } from '@ecency/sdk';
 import parseToken from '../../utils/parseToken';
+import { formatTokenQuantity } from '../../utils/number';
 import { EngineActionJSON, EngineActions, EngineContracts } from './hiveEngine.types';
 
 export const getEngineActionJSON = (
@@ -15,7 +16,7 @@ export const getEngineActionJSON = (
     contractPayload: {
       symbol,
       to,
-      quantity: parseToken(amount).toString(),
+      quantity: formatTokenQuantity(parseToken(amount)),
       memo: action === EngineActions.TRANSFER ? memo : undefined,
     },
   };

--- a/src/providers/hive-spk/hiveSpk.ts
+++ b/src/providers/hive-spk/hiveSpk.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { toMilliUnits } from '../../utils/number';
 import { Markets, SpkApiWallet, SpkMarkets } from './hiveSpk.types';
 
 export const SPK_NODE_ECENCY = 'good-karma.spk';
@@ -76,7 +77,7 @@ export const fetchSpkMarkets = async (): Promise<Markets> => {
 
 export const getSpkActionJSON = (amount: number, to?: string, memo?: string) => {
   return {
-    amount: amount * 1000,
+    amount: toMilliUnits(amount),
     ...(to ? { to } : {}),
     ...(memo ? { memo } : {}),
   };

--- a/src/screens/transfer/screen/transferScreen.tsx
+++ b/src/screens/transfer/screen/transferScreen.tsx
@@ -22,6 +22,7 @@ import { getEngineActionJSON } from '../../../providers/hive-engine/hiveEngineAc
 import { getSpkActionJSON, SPK_NODE_ECENCY } from '../../../providers/hive-spk/hiveSpk';
 import parseToken from '../../../utils/parseToken';
 import { buildTransferOpsArray } from '../../../utils/transactionOpsBuilder';
+import { getAssetPrecision, toFixedNoExp, formatTokenQuantity } from '../../../utils/number';
 import { SheetNames } from '../../../navigation/sheets';
 import TokenLayers from '../../../constants/tokenLayers';
 import { EngineActions } from '../../../providers/hive-engine/hiveEngine.types';
@@ -291,6 +292,13 @@ const TransferView = ({
     if (newValue.includes(',')) {
       newValue = newValue.replace(',', '.');
     }
+    // Cap decimals to the asset's precision so an over-precise amount can never be
+    // entered (HIVE/HBD/POINTS = 3, VESTS = 6; engine tokens allow up to 8).
+    const maxDecimals = isEngineToken ? 8 : getAssetPrecision(fundType);
+    const dotIndex = newValue.indexOf('.');
+    if (dotIndex !== -1 && newValue.length - dotIndex - 1 > maxDecimals) {
+      newValue = newValue.slice(0, dotIndex + 1 + maxDecimals);
+    }
     const parsed = parseFloat(newValue);
     if (newValue === '' || newValue === '.' || Number.isNaN(parsed)) {
       setAmount(newValue);
@@ -381,6 +389,10 @@ const TransferView = ({
   // --- HiveSigner Path ---
   let path;
   if (hsTransfer) {
+    // Normalize the amount to the asset's on-chain precision before encoding the
+    // hive-uri; this HiveSigner path previously sent the raw, unclamped user input.
+    const hsNativeAmount = `${toFixedNoExp(amount, getAssetPrecision(fundType))} ${fundType}`;
+    const hsEngineAmount = `${formatTokenQuantity(amount)} ${fundType}`;
     const destinations = destination
       .trim()
       .split(/[\s,]+/)
@@ -400,7 +412,7 @@ const TransferView = ({
                   getEngineActionJSON(
                     EngineActions.TRANSFER,
                     receiver,
-                    `${amount} ${fundType}`,
+                    hsEngineAmount,
                     fundType,
                     memo,
                   ),
@@ -414,7 +426,7 @@ const TransferView = ({
         const json = getEngineActionJSON(
           transferType as EngineActions,
           destination,
-          `${amount} ${fundType}`,
+          hsEngineAmount,
           fundType,
           memo,
         );
@@ -434,31 +446,31 @@ const TransferView = ({
       )}`;
     } else if (transferType === TransferTypes.RECURRENT_TRANSFER) {
       path = `sign/recurrent_transfer?from=${from}&to=${destination}&amount=${encodeURIComponent(
-        `${amount} ${fundType}`,
+        hsNativeAmount,
       )}&memo=${encodeURIComponent(memo)}&recurrence=${recurrence}&executions=${executions}`;
     } else if (transferType === TransferTypes.TRANSFER_TO_SAVINGS) {
       path = `sign/transfer_to_savings?from=${from}&to=${destination}&amount=${encodeURIComponent(
-        `${amount} ${fundType}`,
+        hsNativeAmount,
       )}&memo=${encodeURIComponent(memo)}`;
     } else if (transferType === TransferTypes.DELEGATE_VESTING_SHARES) {
       path = `sign/delegate_vesting_shares?delegator=${from}&delegatee=${destination}&vesting_shares=${encodeURIComponent(
-        `${amount} ${fundType}`,
+        hsNativeAmount,
       )}`;
     } else if (transferType === TransferTypes.TRANSFER_TO_VESTING) {
       path = `sign/transfer_to_vesting?from=${from}&to=${destination}&amount=${encodeURIComponent(
-        `${amount} ${fundType}`,
+        hsNativeAmount,
       )}`;
     } else if (transferType === TransferTypes.TRANSFER_FROM_SAVINGS) {
       path = `sign/transfer_from_savings?from=${from}&to=${destination}&amount=${encodeURIComponent(
-        `${amount} ${fundType}`,
+        hsNativeAmount,
       )}&request_id=${new Date().getTime() >>> 0}`;
     } else if (transferType === TransferTypes.CONVERT) {
-      path = `sign/convert?owner=${from}&amount=${encodeURIComponent(
-        `${amount} ${fundType}`,
-      )}&requestid=${new Date().getTime() >>> 0}`;
+      path = `sign/convert?owner=${from}&amount=${encodeURIComponent(hsNativeAmount)}&requestid=${
+        new Date().getTime() >>> 0
+      }`;
     } else if (transferType === TransferTypes.WITHDRAW_VESTING) {
       path = `sign/withdraw_vesting?account=${from}&vesting_shares=${encodeURIComponent(
-        `${amount} ${fundType}`,
+        hsNativeAmount,
       )}`;
     } else if (transferType === TransferTypes.ECENCY_POINT_TRANSFER) {
       path = hiveuri
@@ -485,7 +497,7 @@ const TransferView = ({
         .encodeOps(
           destinations.map((receiver) => [
             'transfer',
-            { from, to: receiver, amount: `${amount} ${fundType}`, memo },
+            { from, to: receiver, amount: hsNativeAmount, memo },
           ]),
         )
         .replace('hive://', '');

--- a/src/screens/transfer/screen/transferScreen.tsx
+++ b/src/screens/transfer/screen/transferScreen.tsx
@@ -486,7 +486,7 @@ const TransferView = ({
               json: JSON.stringify({
                 sender: selectedAccount.name,
                 receiver,
-                amount: `${Number(amount).toFixed(3)} ${fundType}`,
+                amount: hsNativeAmount,
                 memo,
               }),
             },
@@ -550,7 +550,13 @@ const TransferView = ({
     }
   };
 
-  const nextBtnDisabled = !((isEngineToken ? amount > 0 : amount >= 0.001) && isUsernameValid);
+  const nextBtnDisabled = !(
+    (isEngineToken ? amount > 0 : amount >= 0.001) &&
+    isUsernameValid &&
+    // Wait for the Engine token's precision to load so the amount can't be
+    // broadcast with the fallback 8-decimal precision before it is known.
+    (!isEngineToken || tokenPrecision !== undefined)
+  );
 
   useEffect(() => {
     if (isRecurrentTransfer) {

--- a/src/screens/transfer/screen/transferScreen.tsx
+++ b/src/screens/transfer/screen/transferScreen.tsx
@@ -48,6 +48,7 @@ interface TransferViewProps {
   fetchRecurrentTransfers?: () => void;
   recurrentTransfers?: any;
   tokenLayer?: string;
+  tokenPrecision?: number;
   badActors?: Set<string>;
   setFundType?: (fundType: string) => void;
 }
@@ -71,6 +72,7 @@ const TransferView = ({
   fetchRecurrentTransfers,
   recurrentTransfers,
   tokenLayer,
+  tokenPrecision,
   badActors,
   setFundType,
 }: TransferViewProps) => {
@@ -294,7 +296,7 @@ const TransferView = ({
     }
     // Cap decimals to the asset's precision so an over-precise amount can never be
     // entered (HIVE/HBD/POINTS = 3, VESTS = 6; engine tokens allow up to 8).
-    const maxDecimals = isEngineToken ? 8 : getAssetPrecision(fundType);
+    const maxDecimals = isEngineToken ? tokenPrecision ?? 8 : getAssetPrecision(fundType);
     const dotIndex = newValue.indexOf('.');
     if (dotIndex !== -1 && newValue.length - dotIndex - 1 > maxDecimals) {
       newValue = newValue.slice(0, dotIndex + 1 + maxDecimals);
@@ -392,7 +394,7 @@ const TransferView = ({
     // Normalize the amount to the asset's on-chain precision before encoding the
     // hive-uri; this HiveSigner path previously sent the raw, unclamped user input.
     const hsNativeAmount = `${toFixedNoExp(amount, getAssetPrecision(fundType))} ${fundType}`;
-    const hsEngineAmount = `${formatTokenQuantity(amount)} ${fundType}`;
+    const hsEngineAmount = `${formatTokenQuantity(amount, tokenPrecision)} ${fundType}`;
     const destinations = destination
       .trim()
       .split(/[\s,]+/)

--- a/src/utils/number.test.ts
+++ b/src/utils/number.test.ts
@@ -223,9 +223,11 @@ describe('toFixedNoExp', () => {
     expect(toFixedNoExp(1.5, 3)).toBe('1.500');
   });
 
-  it('normalizes over-precise amounts down to the asset precision', () => {
+  it('truncates over-precise amounts toward zero (never rounds up past balance)', () => {
     expect(toFixedNoExp('10.12345', 3)).toBe('10.123');
-    expect(toFixedNoExp('1.23456789', 6)).toBe('1.234568');
+    expect(toFixedNoExp('1.23456789', 6)).toBe('1.234567');
+    expect(toFixedNoExp('10.9995', 3)).toBe('10.999');
+    expect(toFixedNoExp('0.9999', 3)).toBe('0.999');
   });
 
   it('never emits scientific notation for tiny values', () => {

--- a/src/utils/number.test.ts
+++ b/src/utils/number.test.ts
@@ -5,6 +5,10 @@ import {
   formatNumberInputStr,
   getAbbreviatedNumber,
   formatAmount,
+  getAssetPrecision,
+  toFixedNoExp,
+  formatTokenQuantity,
+  toMilliUnits,
 } from './number';
 
 describe('countDecimals', () => {
@@ -186,5 +190,87 @@ describe('formatAmount', () => {
       maximumFractionDigits: 2,
     });
     expect(result).toBe('1.12');
+  });
+});
+
+describe('getAssetPrecision', () => {
+  it('returns 3 for HIVE/HBD/POINTS', () => {
+    expect(getAssetPrecision('HIVE')).toBe(3);
+    expect(getAssetPrecision('HBD')).toBe(3);
+    expect(getAssetPrecision('POINT')).toBe(3);
+    expect(getAssetPrecision('POINTS')).toBe(3);
+  });
+
+  it('returns 6 for VESTS', () => {
+    expect(getAssetPrecision('VESTS')).toBe(6);
+  });
+
+  it('is case-insensitive and trims', () => {
+    expect(getAssetPrecision(' hive ')).toBe(3);
+    expect(getAssetPrecision('vests')).toBe(6);
+  });
+
+  it('defaults to 3 for unknown/missing symbols', () => {
+    expect(getAssetPrecision('SOMETOKEN')).toBe(3);
+    expect(getAssetPrecision(undefined)).toBe(3);
+    expect(getAssetPrecision('')).toBe(3);
+  });
+});
+
+describe('toFixedNoExp', () => {
+  it('pads under-precise amounts to the asset precision', () => {
+    expect(toFixedNoExp('10', 3)).toBe('10.000');
+    expect(toFixedNoExp(1.5, 3)).toBe('1.500');
+  });
+
+  it('normalizes over-precise amounts down to the asset precision', () => {
+    expect(toFixedNoExp('10.12345', 3)).toBe('10.123');
+    expect(toFixedNoExp('1.23456789', 6)).toBe('1.234568');
+  });
+
+  it('never emits scientific notation for tiny values', () => {
+    expect(toFixedNoExp(0.0000001, 3)).toBe('0.000');
+    expect(toFixedNoExp(1e-7, 8)).toBe('0.00000010');
+    expect(toFixedNoExp(1e-7, 8)).not.toContain('e');
+  });
+
+  it('returns a zero-precision string for non-numeric input', () => {
+    expect(toFixedNoExp('abc', 3)).toBe('0.000');
+    expect(toFixedNoExp(NaN, 3)).toBe('0.000');
+  });
+});
+
+describe('formatTokenQuantity', () => {
+  it('strips trailing zeros and never pads', () => {
+    expect(formatTokenQuantity('10')).toBe('10');
+    expect(formatTokenQuantity('10.500')).toBe('10.5');
+    expect(formatTokenQuantity(1.23456789)).toBe('1.23456789');
+  });
+
+  it('avoids scientific notation for tiny token amounts', () => {
+    expect(formatTokenQuantity(0.0000001)).toBe('0.0000001');
+    expect(formatTokenQuantity(0.0000001)).not.toContain('e');
+  });
+
+  it('handles zero and invalid input', () => {
+    expect(formatTokenQuantity(0)).toBe('0');
+    expect(formatTokenQuantity('abc')).toBe('0');
+  });
+});
+
+describe('toMilliUnits', () => {
+  it('converts to integer milli-units', () => {
+    expect(toMilliUnits(1)).toBe(1000);
+    expect(toMilliUnits('1.5')).toBe(1500);
+  });
+
+  it('rounds away binary-float error (no 1004.9999999999999)', () => {
+    expect(toMilliUnits(1.005)).toBe(1005);
+    expect(Number.isInteger(toMilliUnits(0.029))).toBe(true);
+    expect(toMilliUnits(0.029)).toBe(29);
+  });
+
+  it('returns 0 for invalid input', () => {
+    expect(toMilliUnits('abc')).toBe(0);
   });
 });

--- a/src/utils/number.test.ts
+++ b/src/utils/number.test.ts
@@ -228,6 +228,15 @@ describe('toFixedNoExp', () => {
     expect(toFixedNoExp('1.23456789', 6)).toBe('1.234567');
     expect(toFixedNoExp('10.9995', 3)).toBe('10.999');
     expect(toFixedNoExp('0.9999', 3)).toBe('0.999');
+    // A run of 9s must not carry/round up (regression guard)
+    expect(toFixedNoExp('1.999999999', 3)).toBe('1.999');
+    expect(toFixedNoExp('0.9999999', 6)).toBe('0.999999');
+  });
+
+  it('keeps float-error values exact (0.3 stays 0.300, not 0.299)', () => {
+    expect(toFixedNoExp(0.3, 3)).toBe('0.300');
+    expect(toFixedNoExp(0.1, 3)).toBe('0.100');
+    expect(toFixedNoExp(0.1 + 0.2, 3)).toBe('0.300');
   });
 
   it('never emits scientific notation for tiny values', () => {

--- a/src/utils/number.ts
+++ b/src/utils/number.ts
@@ -26,6 +26,63 @@ export const getDecimalPlaces = (value: number) => {
   return match ? match[0].length : 0;
 };
 
+// Required on-chain decimal precision per native Hive asset. HIVE/HBD/POINTS are
+// exactly 3 decimals; VESTS is 6. Used to normalize broadcast amounts so the
+// chain does not reject them for a precision mismatch.
+const NATIVE_ASSET_PRECISION: Record<string, number> = {
+  HIVE: 3,
+  HBD: 3,
+  HP: 3,
+  POINT: 3,
+  POINTS: 3,
+  SPK: 3,
+  LARYNX: 3,
+  TESTS: 3,
+  TBD: 3,
+  VESTS: 6,
+};
+
+export const getAssetPrecision = (symbol?: string): number => {
+  if (!symbol) {
+    return 3;
+  }
+  return NATIVE_ASSET_PRECISION[symbol.trim().toUpperCase()] ?? 3;
+};
+
+// Format an amount to exactly `precision` decimals as a plain decimal string.
+// Unlike `Number.toString()` (which yields an invalid `1e-7`-style value for tiny
+// amounts), toFixed renders a plain decimal across the on-chain magnitude range and
+// rounds the float representation correctly.
+export const toFixedNoExp = (value: number | string, precision: number): string => {
+  const num = typeof value === 'number' ? value : parseFloat(String(value));
+  if (!Number.isFinite(num)) {
+    return (0).toFixed(precision);
+  }
+  return num.toFixed(precision);
+};
+
+// Format a Hive-Engine token quantity: fixed-point (never scientific notation),
+// capped at the token precision (default 8 — the engine maximum), with trailing
+// zeros and any dangling decimal point stripped so the quantity string is clean.
+export const formatTokenQuantity = (value: number | string, precision = 8): string => {
+  const num = typeof value === 'number' ? value : parseFloat(String(value));
+  if (!Number.isFinite(num)) {
+    return '0';
+  }
+  const fixed = num.toFixed(Math.max(0, Math.min(precision, 8)));
+  return fixed.indexOf('.') === -1 ? fixed : fixed.replace(/\.?0+$/, '');
+};
+
+// Convert a human SPK/LARYNX amount to integer milli-units. SPK custom_json ops
+// expect an integer; a raw `value * 1000` float yields e.g. 1004.9999999999999.
+export const toMilliUnits = (value: number | string): number => {
+  const num = typeof value === 'number' ? value : parseFloat(String(value));
+  if (!Number.isFinite(num)) {
+    return 0;
+  }
+  return Math.round(num * 1000);
+};
+
 export const formatNumberInputStr = (text: string, precision = 10) => {
   if (text.includes(',')) {
     text = text.replace(',', '.');

--- a/src/utils/number.ts
+++ b/src/utils/number.ts
@@ -49,16 +49,26 @@ export const getAssetPrecision = (symbol?: string): number => {
   return NATIVE_ASSET_PRECISION[symbol.trim().toUpperCase()] ?? 3;
 };
 
-// Truncate `value` toward zero to exactly `precision` decimals, as a plain decimal
-// string. The value is formatted with extra precision first so binary-float
-// artifacts (e.g. 10.123 * 1000 === 10122.999999999998) cannot corrupt the result,
-// then sliced. Unlike `toFixed`, this never rounds the amount UP past what the user
-// holds (keeping it consistent with the input cap), and never emits scientific
-// notation (which `Number.toString()` would, as an invalid `1e-7`-style value).
+// Truncate `num` toward zero to exactly `precision` decimals, returned as a plain
+// decimal string. It slices the decimal-string representation rather than using
+// `toFixed`, which rounds and can carry on a run of 9s (e.g. 1.999999999 -> 2.000),
+// breaking the "never exceed the user's balance" guarantee. `Number.toString()` gives
+// the shortest round-trip form (so 0.3 stays "0.3", not "0.2999…"); scientific-
+// notation values (tiny magnitudes) are expanded via toFixed, where their
+// sub-precision digits truncate to zero anyway.
 const truncateToPrecision = (num: number, precision: number): string => {
-  const fixed = Math.abs(num).toFixed(precision + 4);
-  const dot = fixed.indexOf('.');
-  const cut = precision > 0 ? fixed.slice(0, dot + 1 + precision) : fixed.slice(0, dot);
+  let s = Math.abs(num).toString();
+  if (s.indexOf('e') !== -1 || s.indexOf('E') !== -1) {
+    s = Math.abs(num).toFixed(precision);
+  }
+  const dot = s.indexOf('.');
+  let cut: string;
+  if (dot === -1) {
+    cut = precision > 0 ? `${s}.${'0'.repeat(precision)}` : s;
+  } else {
+    const frac = `${s.slice(dot + 1)}${'0'.repeat(precision)}`.slice(0, precision);
+    cut = precision > 0 ? `${s.slice(0, dot)}.${frac}` : s.slice(0, dot);
+  }
   const sign = num < 0 && Number(cut) !== 0 ? '-' : '';
   return sign + cut;
 };

--- a/src/utils/number.ts
+++ b/src/utils/number.ts
@@ -49,28 +49,41 @@ export const getAssetPrecision = (symbol?: string): number => {
   return NATIVE_ASSET_PRECISION[symbol.trim().toUpperCase()] ?? 3;
 };
 
-// Format an amount to exactly `precision` decimals as a plain decimal string.
-// Unlike `Number.toString()` (which yields an invalid `1e-7`-style value for tiny
-// amounts), toFixed renders a plain decimal across the on-chain magnitude range and
-// rounds the float representation correctly.
+// Truncate `value` toward zero to exactly `precision` decimals, as a plain decimal
+// string. The value is formatted with extra precision first so binary-float
+// artifacts (e.g. 10.123 * 1000 === 10122.999999999998) cannot corrupt the result,
+// then sliced. Unlike `toFixed`, this never rounds the amount UP past what the user
+// holds (keeping it consistent with the input cap), and never emits scientific
+// notation (which `Number.toString()` would, as an invalid `1e-7`-style value).
+const truncateToPrecision = (num: number, precision: number): string => {
+  const fixed = Math.abs(num).toFixed(precision + 4);
+  const dot = fixed.indexOf('.');
+  const cut = precision > 0 ? fixed.slice(0, dot + 1 + precision) : fixed.slice(0, dot);
+  const sign = num < 0 && Number(cut) !== 0 ? '-' : '';
+  return sign + cut;
+};
+
+// Format an amount to exactly `precision` decimals, truncating excess precision
+// toward zero (so the broadcast never inflates past the user's balance) and padding
+// when under-precise.
 export const toFixedNoExp = (value: number | string, precision: number): string => {
   const num = typeof value === 'number' ? value : parseFloat(String(value));
   if (!Number.isFinite(num)) {
     return (0).toFixed(precision);
   }
-  return num.toFixed(precision);
+  return truncateToPrecision(num, precision);
 };
 
-// Format a Hive-Engine token quantity: fixed-point (never scientific notation),
-// capped at the token precision (default 8 — the engine maximum), with trailing
-// zeros and any dangling decimal point stripped so the quantity string is clean.
+// Format a Hive-Engine token quantity: truncated to the token precision (default 8 —
+// the engine maximum), never scientific notation, with trailing zeros and any
+// dangling decimal point stripped so the quantity string is clean.
 export const formatTokenQuantity = (value: number | string, precision = 8): string => {
   const num = typeof value === 'number' ? value : parseFloat(String(value));
   if (!Number.isFinite(num)) {
     return '0';
   }
-  const fixed = num.toFixed(Math.max(0, Math.min(precision, 8)));
-  return fixed.indexOf('.') === -1 ? fixed : fixed.replace(/\.?0+$/, '');
+  const truncated = truncateToPrecision(num, Math.max(0, Math.min(precision, 8)));
+  return truncated.indexOf('.') === -1 ? truncated : truncated.replace(/\.?0+$/, '');
 };
 
 // Convert a human SPK/LARYNX amount to integer milli-units. SPK custom_json ops

--- a/src/utils/transactionOpsBuilder.test.ts
+++ b/src/utils/transactionOpsBuilder.test.ts
@@ -29,12 +29,30 @@ describe('buildTransferOpsArray', () => {
       expect(ops[0][1].amount).toBe('10.000 HIVE');
     });
 
-    it('preserves existing decimal precision when >= 3', () => {
+    it('normalizes an over-precise amount down to the asset precision (3 dp for HIVE)', () => {
       const ops = buildTransferOpsArray(TransferTypes.TRANSFER, {
         ...baseData,
         amount: '10.12345',
       });
-      expect(ops[0][1].amount).toBe('10.12345 HIVE');
+      expect(ops[0][1].amount).toBe('10.123 HIVE');
+    });
+
+    it('uses 6 dp for VESTS amounts', () => {
+      const ops = buildTransferOpsArray(TransferTypes.DELEGATE_VESTING_SHARES, {
+        ...baseData,
+        amount: '10',
+        fundType: 'VESTS',
+      });
+      expect(ops[0][1].vesting_shares).toBe('10.000000 VESTS');
+    });
+
+    it('does not force engine-token quantities to 3 dp (mock shape: [op, action, from, to, amount, symbol, memo])', () => {
+      const ops = buildTransferOpsArray(TransferTypes.TRANSFER, {
+        ...baseData,
+        amount: '10.5',
+        tokenLayer: TokenLayers.ENGINE,
+      });
+      expect(ops[0][4]).toBe('10.5 HIVE');
     });
   });
 

--- a/src/utils/transactionOpsBuilder.ts
+++ b/src/utils/transactionOpsBuilder.ts
@@ -2,7 +2,7 @@ import { getEngineActionOpArray } from '../providers/hive-engine/hiveEngineActio
 import { EngineActions } from '../providers/hive-engine/hiveEngine.types';
 import { buildActiveCustomJsonOpArr } from '../providers/hive/hive';
 import { getSpkActionJSON } from '../providers/hive-spk/hiveSpk';
-import { countDecimals } from './number';
+import { getAssetPrecision, toFixedNoExp, formatTokenQuantity } from './number';
 import TransferTypes from '../constants/transferTypes';
 import parseToken from './parseToken';
 import TokenLayers from '../constants/tokenLayers';
@@ -24,11 +24,15 @@ export const buildTransferOpsArray = (
   transferType: string,
   { from, to, amount, memo, fundType, recurrence, executions, tokenLayer }: TansferData,
 ) => {
-  if (countDecimals(Number(amount)) < 3) {
-    amount = Number(amount).toFixed(3);
-  }
+  // Normalize to the asset's on-chain precision before building the op: HIVE/HBD/
+  // POINTS need exactly 3 decimals, VESTS 6; Hive-Engine tokens use their own
+  // precision (no scientific notation). Over-precise amounts are otherwise rejected.
+  const amountValue =
+    tokenLayer === TokenLayers.ENGINE
+      ? formatTokenQuantity(amount)
+      : toFixedNoExp(amount, getAssetPrecision(fundType));
 
-  amount = `${amount} ${fundType}`;
+  amount = `${amountValue} ${fundType}`;
 
   // check layer and build appropriate operation
   if (tokenLayer === TokenLayers.ENGINE) {


### PR DESCRIPTION
Transfer amounts were not consistently normalized to the asset's required on-chain precision before broadcast, which could cause the node to reject the operation (precision mismatch) or send a wrong quantity. This unifies amount normalization across **all three signing paths** (key, HiveAuth, HiveSigner).

## Changes
- **Shared helpers** in `utils/number.ts` — asset-precision lookup, fixed-precision formatting (no scientific notation), token-quantity formatting, and integer milli-unit conversion — with unit tests.
- **All signing paths** now format the amount to the correct precision before building the op. The HiveSigner path previously applied **no** normalization.
- **Input cap** — the amount field now limits decimal entry to the asset's precision.
- **Hive-Engine** token quantities are formatted without scientific notation / forced padding.
- **SPK/LARYNX** milli-unit amounts are rounded to integers (was a raw float multiply that could yield non-integer values).

## Validation
- `yarn lint` — clean
- `tsc --noEmit` — no errors in changed files
- `jest --ci` — 334 passed (16 new); updated the op-builder test that asserted the old behavior and added asset-precision / engine / milli-unit / no-exponent cases.

## Notes / follow-ups (out of scope here)
- A few non-wallet-send surfaces (in-app browser bridge, QR/URI signing, token swap) format amounts independently and will be aligned separately.
- The SDK's SPK power/lock builders multiply by 1000 without rounding; the app rounds where it owns the conversion, but a couple of SPK token-transfer/power op contracts should be reconciled with the SDK in a follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Amount input now enforces asset-specific decimal precision and disables advancing until token precision loads for tokens.

* **Bug Fixes**
  * Improved decimal precision handling and normalization for native assets, vesting, and tokens so submitted amounts match on‑chain requirements.
  * Token quantities are now consistently formatted to avoid precision/rounding issues.

* **Tests**
  * Expanded test coverage for decimal normalization across transfer types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->