### PR TITLE
Server-side Turnstile CAPTCHA on mobile free signup

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@babel/preset-typescript": "^7.26.0",
     "@babel/runtime": "^7.26.7",
     "@ecency/render-helper": "^2.5.10",
-    "@ecency/sdk": "^2.3.8",
+    "@ecency/sdk": "^2.3.9",
     "@esteemapp/react-native-autocomplete-input": "^4.2.1",
     "@esteemapp/react-native-multi-slider": "^1.1.0",
     "@native-html/iframe-plugin": "^2.6.1",

--- a/src/screens/register/children/registerAccountModal.tsx
+++ b/src/screens/register/children/registerAccountModal.tsx
@@ -13,6 +13,7 @@ import { InAppPurchaseContainer } from '../../../containers';
 import { Icon, MainButton, Modal, PostCardPlaceHolder, TextButton } from '../../../components';
 import LOGO_ESTM from '../../../assets/esteemcoin_boost.png';
 import ROUTES from '../../../constants/routeNames';
+import TurnstileWebView from './turnstileWebView';
 
 type Props = {
   username: string;
@@ -35,6 +36,14 @@ export const RegisterAccountModal = forwardRef(({ username, email, refUsername }
   const [disableFree, setDisableFree] = useState(false);
   const [isRegistering, setIsRegistering] = useState(false);
   const [isRegistered, setIsRegistered] = useState(false);
+  const [captchaToken, setCaptchaToken] = useState('');
+  // Bump to remount the Turnstile widget for a fresh (single-use) token after a failure.
+  const [captchaKey, setCaptchaKey] = useState(0);
+
+  const _resetCaptcha = () => {
+    setCaptchaToken('');
+    setCaptchaKey((k) => k + 1);
+  };
 
   useImperativeHandle(ref, () => ({
     showModal: ({ purchaseOnly }: { purchaseOnly: boolean } = { purchaseOnly: false }) => {
@@ -54,7 +63,7 @@ export const RegisterAccountModal = forwardRef(({ username, email, refUsername }
     setIsRegistering(true);
 
     try {
-      const result = await signUp(_username, email, refUsername);
+      const result = await signUp(_username, email, refUsername, captchaToken);
       if (result?.status >= 200 && result?.status < 300) {
         setIsRegistered(true);
       } else {
@@ -63,6 +72,7 @@ export const RegisterAccountModal = forwardRef(({ username, email, refUsername }
           intl.formatMessage({ id: 'alert.unknow_error' }),
         );
         setIsRegistered(false);
+        _resetCaptcha();
       }
     } catch (err) {
       const title = intl.formatMessage({ id: 'alert.fail' });
@@ -77,6 +87,7 @@ export const RegisterAccountModal = forwardRef(({ username, email, refUsername }
         body = intl.formatMessage({ id: 'register.error_message' }, { message });
       }
       Alert.alert(title, body);
+      _resetCaptcha();
     } finally {
       setIsRegistering(false);
     }
@@ -143,7 +154,7 @@ export const RegisterAccountModal = forwardRef(({ username, email, refUsername }
     </View>
   );
 
-  const _renderCard = ({ titleId, descriptionId, btnTitle, onPress }) => {
+  const _renderCard = ({ titleId, descriptionId, btnTitle, onPress, extra, disabled }) => {
     return (
       <View style={styles.cardContainer}>
         <Text style={styles.title}>
@@ -158,11 +169,12 @@ export const RegisterAccountModal = forwardRef(({ username, email, refUsername }
             })}
           </Text>
         </View>
+        {extra}
         <TextButton
           textStyle={styles.buttonText}
           onPress={onPress}
           style={styles.button}
-          disabled={isRegistering}
+          disabled={disabled !== undefined ? disabled : isRegistering}
           text={btnTitle}
         />
       </View>
@@ -178,9 +190,16 @@ export const RegisterAccountModal = forwardRef(({ username, email, refUsername }
           _renderCard({
             titleId: 'free_account.title',
             descriptionId: 'free_account.desc',
-
             btnTitle: intl.formatMessage({ id: 'free_account.btn_register' }),
             onPress: _handleOnPressRegister,
+            extra: (
+              <TurnstileWebView
+                key={captchaKey}
+                onVerify={setCaptchaToken}
+                onExpire={() => setCaptchaToken('')}
+              />
+            ),
+            disabled: isRegistering || !captchaToken,
           })}
 
         {productList.map((product) =>

--- a/src/screens/register/children/registerAccountModal.tsx
+++ b/src/screens/register/children/registerAccountModal.tsx
@@ -51,6 +51,8 @@ export const RegisterAccountModal = forwardRef(({ username, email, refUsername }
       setIsRegistered(false);
       setIsRegistering(false);
       setDisableFree(purchaseOnly);
+      // Start each modal session with a fresh challenge — never reuse a prior token.
+      _resetCaptcha();
     },
   }));
 
@@ -197,9 +199,10 @@ export const RegisterAccountModal = forwardRef(({ username, email, refUsername }
                 key={captchaKey}
                 onVerify={setCaptchaToken}
                 onExpire={() => setCaptchaToken('')}
+                onError={_resetCaptcha}
               />
             ),
-            disabled: isRegistering || !captchaToken,
+            disabled: !captchaToken,
           })}
 
         {productList.map((product) =>

--- a/src/screens/register/children/turnstileWebView.tsx
+++ b/src/screens/register/children/turnstileWebView.tsx
@@ -1,0 +1,92 @@
+import React, { useMemo } from 'react';
+import { View, StyleSheet } from 'react-native';
+import { WebView } from 'react-native-webview';
+
+// Public Cloudflare Turnstile sitekey (Managed mode). The token is verified
+// server-side in onboard; the secret never reaches the client. The widget runs in a
+// WebView whose origin is forced to ecency.com via baseUrl so the sitekey's hostname
+// check passes (it is enabled for ecency.com only). The token is bridged out via
+// window.ReactNativeWebView.postMessage.
+const TURNSTILE_SITEKEY = '0x4AAAAAADe6jH7FIi9dBzgR';
+const BASE_URL = 'https://ecency.com';
+
+const buildHtml = (sitekey: string) => `<!DOCTYPE html>
+<html>
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
+    <style>
+      html, body { margin: 0; padding: 0; background: transparent; }
+      .wrap { display: flex; justify-content: center; padding: 4px 0; }
+    </style>
+  </head>
+  <body>
+    <div class="wrap">
+      <div
+        class="cf-turnstile"
+        data-sitekey="${sitekey}"
+        data-callback="onVerify"
+        data-expired-callback="onExpire"
+        data-error-callback="onExpire"
+      ></div>
+    </div>
+    <script>
+      function post(type, token) {
+        if (window.ReactNativeWebView) {
+          window.ReactNativeWebView.postMessage(JSON.stringify({ type: type, token: token }));
+        }
+      }
+      window.onVerify = function (token) {
+        post('verify', token);
+      };
+      window.onExpire = function () {
+        post('expire');
+      };
+    </script>
+  </body>
+</html>`;
+
+interface Props {
+  onVerify: (token: string) => void;
+  onExpire: () => void;
+  height?: number;
+}
+
+const TurnstileWebView = ({ onVerify, onExpire, height = 76 }: Props) => {
+  const html = useMemo(() => buildHtml(TURNSTILE_SITEKEY), []);
+
+  const _onMessage = (event: { nativeEvent: { data: string } }) => {
+    try {
+      const data = JSON.parse(event.nativeEvent.data);
+      if (data.type === 'verify' && data.token) {
+        onVerify(data.token);
+      } else if (data.type === 'expire') {
+        onExpire();
+      }
+    } catch (_err) {
+      // ignore malformed bridge messages
+    }
+  };
+
+  return (
+    <View style={[styles.container, { height }]}>
+      <WebView
+        source={{ html, baseUrl: BASE_URL }}
+        originWhitelist={['*']}
+        javaScriptEnabled
+        domStorageEnabled
+        scrollEnabled={false}
+        androidLayerType="software"
+        style={styles.webview}
+        onMessage={_onMessage}
+      />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: { width: '100%' },
+  webview: { backgroundColor: 'transparent' },
+});
+
+export default TurnstileWebView;

--- a/src/screens/register/children/turnstileWebView.tsx
+++ b/src/screens/register/children/turnstileWebView.tsx
@@ -27,7 +27,7 @@ const buildHtml = (sitekey: string) => `<!DOCTYPE html>
         data-sitekey="${sitekey}"
         data-callback="onVerify"
         data-expired-callback="onExpire"
-        data-error-callback="onExpire"
+        data-error-callback="onError"
       ></div>
     </div>
     <script>
@@ -42,6 +42,9 @@ const buildHtml = (sitekey: string) => `<!DOCTYPE html>
       window.onExpire = function () {
         post('expire');
       };
+      window.onError = function () {
+        post('error');
+      };
     </script>
   </body>
 </html>`;
@@ -49,10 +52,11 @@ const buildHtml = (sitekey: string) => `<!DOCTYPE html>
 interface Props {
   onVerify: (token: string) => void;
   onExpire: () => void;
+  onError?: () => void;
   height?: number;
 }
 
-const TurnstileWebView = ({ onVerify, onExpire, height = 76 }: Props) => {
+const TurnstileWebView = ({ onVerify, onExpire, onError, height = 76 }: Props) => {
   const html = useMemo(() => buildHtml(TURNSTILE_SITEKEY), []);
 
   const _onMessage = (event: { nativeEvent: { data: string } }) => {
@@ -62,6 +66,8 @@ const TurnstileWebView = ({ onVerify, onExpire, height = 76 }: Props) => {
         onVerify(data.token);
       } else if (data.type === 'expire') {
         onExpire();
+      } else if (data.type === 'error') {
+        onError?.();
       }
     } catch (_err) {
       // ignore malformed bridge messages
@@ -72,7 +78,7 @@ const TurnstileWebView = ({ onVerify, onExpire, height = 76 }: Props) => {
     <View style={[styles.container, { height }]}>
       <WebView
         source={{ html, baseUrl: BASE_URL }}
-        originWhitelist={['*']}
+        originWhitelist={['https://*', 'about:blank']}
         javaScriptEnabled
         domStorageEnabled
         scrollEnabled={false}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1257,10 +1257,10 @@
     url "^0.11.0"
     xss "^1.0.9"
 
-"@ecency/sdk@^2.3.8":
-  version "2.3.8"
-  resolved "https://registry.yarnpkg.com/@ecency/sdk/-/sdk-2.3.8.tgz#ec790bb7e7f14705d547b6f84d6c7be07c85b7dd"
-  integrity sha512-5oKsqYSEuj8g6iJB7znRCojbA0kLBs3mc8Pk02/4UrkM7ELxoXOHRptYQEqLFoq51rpAKaCdRMqscizsuF00Mw==
+"@ecency/sdk@^2.3.9":
+  version "2.3.9"
+  resolved "https://registry.yarnpkg.com/@ecency/sdk/-/sdk-2.3.9.tgz#726da942f41f01994f33ae88ffef4ec9152666a3"
+  integrity sha512-8uVr5wqDRIS194vSytgF81LE8vn5Q96Pnc7JlBgcOOlDLxrg44GYFzbu+2s6ImtQskK0x6wVyo7616urjkCE8Q==
   dependencies:
     "@noble/ciphers" "^2.1.1"
     "@noble/curves" "^2.0.1"


### PR DESCRIPTION
## What
Brings the server-side CAPTCHA to the **mobile** free-signup flow, matching web. The app previously sent no CAPTCHA token; now it solves Cloudflare Turnstile (Managed mode) and forwards the token for server-side verification.

## How (no new native dependency)
- **`TurnstileWebView`** — renders the Turnstile widget inside the existing `react-native-webview`. The WebView origin is forced to **`ecency.com`** via `source={{ html, baseUrl }}` so the sitekey's hostname check passes (it's enabled for `ecency.com` only). The widget's callbacks `postMessage` the token/expiry back to RN.
- **`registerAccountModal`** — shows the widget in the free-account card, disables **Register** until a token is present, passes it to `signUp(username, email, referral, token)`, and remounts the widget for a fresh token on failure (Turnstile tokens are single-use).
- **`@ecency/sdk` `^2.3.8 → ^2.3.9`** (lockfile updated) for the `captchaToken` argument.

## Notes
- Backend verification is off by default and enabled separately (`CAPTCHA_MODE` on onboard); the secret stays server-side. Inert until enabled.
- The public sitekey is in the client by design.
- Follow-ups: a visible "challenge failed to load" message, and an hCaptcha RN-SDK fallback if the WebView path proves flaky in the app (backend already supports a provider split).

Validated: prettier 2.8.8 clean on the changed files; lockfile entry uses the real npm 2.3.9 tarball + integrity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Turnstile CAPTCHA to free account registration; registration is disabled until CAPTCHA is completed and shows intermediate registering/registered states.
* **Bug Fixes**
  * CAPTCHA state now resets on verification expiry or registration failure to allow retry.
* **Chores**
  * Updated a backend SDK dependency to a newer patch version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->