### PR TITLE
fix(auth): make PIN migration and redux migrations fail-safe

### DIFF
--- a/src/providers/hive/auth.ts
+++ b/src/providers/hive/auth.ts
@@ -493,8 +493,9 @@ export const updatePinCode = (data) =>
                 currentUser = updatedUserData;
               }
             });
-            resolve(currentUser);
           }
+          // Resolve even when there are no users so an awaiting caller cannot hang.
+          resolve(currentUser);
         })
         .catch((err) => {
           reject(err);

--- a/src/screens/pinCode/container/pinCodeContainer.tsx
+++ b/src/screens/pinCode/container/pinCodeContainer.tsx
@@ -266,12 +266,18 @@ class PinCodeContainer extends Component {
 
     // migrate data to default pin if encUnlockPin is not set.
     if (!encUnlockPin) {
-      await MigrationHelpers.migrateUserEncryption(
+      const migrated = await MigrationHelpers.migrateUserEncryption(
         dispatch,
         currentAccount,
         applicationPinCode,
         this._onRefreshTokenFailed,
       );
+      // Migration failed — keys are still on the old PIN, so any signing the
+      // caller would trigger next will fail. _onRefreshTokenFailed has already
+      // surfaced the error/re-login; do not advance into the requested operation.
+      if (!migrated) {
+        return false;
+      }
     }
 
     // on successful code verification run requested operation passed as props

--- a/src/utils/migrationHelpers.test.ts
+++ b/src/utils/migrationHelpers.test.ts
@@ -311,7 +311,7 @@ describe('reduxMigrations', () => {
   });
 
   describe('failure isolation', () => {
-    it('skips a throwing migration and preserves state instead of wiping it', () => {
+    it('rolls back a throwing migration and preserves the rest of the state', () => {
       // v1 writes state.application.notificationDetails.favoriteNotification; with
       // notificationDetails absent the migration throws. The wrapper must swallow
       // that so redux-persist does not drop ALL persisted state on rehydration.
@@ -320,8 +320,25 @@ describe('reduxMigrations', () => {
       expect(() => {
         result = reduxMigrations[1](state);
       }).not.toThrow();
-      expect(result).toBe(state);
+      // unrelated persisted state survives
       expect(result.account.keep).toBe('me');
+      // the failed migration's partial change is not applied
+      expect(result.application.notificationDetails).toBeUndefined();
+    });
+
+    it('returns a clean snapshot (not a partially-mutated object) on a mid-migration throw', () => {
+      // v13 mutates state.wallet before it touches state.cache; with cache absent
+      // it throws after the wallet mutation. The rollback must discard that partial
+      // wallet mutation, not bake it in.
+      const state = {
+        wallet: { selectedCoins: [{ symbol: 'BTC' }] },
+        account: { keep: 'me' },
+      } as any;
+      const result = reduxMigrations[13](state);
+      expect(result.account.keep).toBe('me');
+      // selectedCoins was NOT deleted (rolled back), selectedAssets was NOT added
+      expect(result.wallet.selectedCoins).toBeDefined();
+      expect(result.wallet.selectedAssets).toBeUndefined();
     });
   });
 });

--- a/src/utils/migrationHelpers.test.ts
+++ b/src/utils/migrationHelpers.test.ts
@@ -309,4 +309,19 @@ describe('reduxMigrations', () => {
       expect(result.cache.replyCache).toEqual({});
     });
   });
+
+  describe('failure isolation', () => {
+    it('skips a throwing migration and preserves state instead of wiping it', () => {
+      // v1 writes state.application.notificationDetails.favoriteNotification; with
+      // notificationDetails absent the migration throws. The wrapper must swallow
+      // that so redux-persist does not drop ALL persisted state on rehydration.
+      const state = { application: {}, account: { keep: 'me' } } as any;
+      let result;
+      expect(() => {
+        result = reduxMigrations[1](state);
+      }).not.toThrow();
+      expect(result).toBe(state);
+      expect(result.account.keep).toBe('me');
+    });
+  });
 });

--- a/src/utils/migrationHelpers.ts
+++ b/src/utils/migrationHelpers.ts
@@ -117,6 +117,15 @@ export const migrateUserEncryption = async (dispatch, currentAccount, encUserPin
 
     migratedLocal = await updatePinCode(pinData);
 
+    // updatePinCode resolves with no record when storage has no matching user.
+    // Bail BEFORE mutating PIN/account state so a retry starts from a clean state —
+    // otherwise local is nulled and the app PIN is already switched to DEFAULT_PIN,
+    // and the user can no longer pass PIN verification on the next unlock.
+    if (!migratedLocal) {
+      onFailure(new Error('PIN migration produced no account data'));
+      return false;
+    }
+
     const _currentAccount = currentAccount;
     _currentAccount.local = migratedLocal;
 
@@ -136,13 +145,6 @@ export const migrateUserEncryption = async (dispatch, currentAccount, encUserPin
     // the next unlock.
     console.warn('pin update failure: ', err);
     onFailure(err);
-    return false;
-  }
-
-  // updatePinCode resolves with no record when storage has no matching user;
-  // abort rather than mark the migration complete with missing/old-PIN keys.
-  if (!migratedLocal) {
-    onFailure(new Error('PIN migration produced no account data'));
     return false;
   }
 
@@ -504,11 +506,21 @@ const reduxMigrations = {
 const safeReduxMigrations = Object.keys(reduxMigrations).reduce((acc, version) => {
   const migrate = (reduxMigrations as any)[version];
   acc[version] = (state: any) => {
+    // Migrations mutate `state` in place, so snapshot the (JSON-serializable,
+    // persisted) state first and roll back to it on a throw — this is a true
+    // "skip", not a partially-applied mutation. The persisted state to migrate is
+    // small relative to rehydration cost, and only the versions actually behind run.
+    let snapshot;
+    try {
+      snapshot = state ? JSON.parse(JSON.stringify(state)) : state;
+    } catch (_cloneErr) {
+      snapshot = state;
+    }
     try {
       return migrate(state);
     } catch (err) {
-      console.warn(`redux-persist migration ${version} failed, skipping:`, err);
-      return state;
+      console.warn(`redux-persist migration ${version} failed, rolling back:`, err);
+      return snapshot;
     }
   };
   return acc;

--- a/src/utils/migrationHelpers.ts
+++ b/src/utils/migrationHelpers.ts
@@ -19,7 +19,7 @@ import { getQueryClient } from '../providers/queries';
 import AUTH_TYPE from '../constants/authType';
 
 // Services
-import { getSCAccount, getSettings, getUserDataWithUsername, removeUserData } from '../realm/realm';
+import { getSCAccount, getSettings, removeUserData } from '../realm/realm';
 import { updateCurrentAccount, updateOtherAccount } from '../redux/actions/accountAction';
 
 import {
@@ -104,9 +104,10 @@ export const migrateUserEncryption = async (dispatch, currentAccount, encUserPin
   const oldPinCode = decryptKey(encUserPin, Config.PIN_KEY);
 
   if (oldPinCode === undefined || oldPinCode === Config.DEFAULT_PIN) {
-    return;
+    return true;
   }
 
+  let migratedLocal;
   try {
     const pinData = {
       pinCode: Config.DEFAULT_PIN,
@@ -114,10 +115,10 @@ export const migrateUserEncryption = async (dispatch, currentAccount, encUserPin
       oldPinCode,
     };
 
-    const response = updatePinCode(pinData);
+    migratedLocal = await updatePinCode(pinData);
 
     const _currentAccount = currentAccount;
-    _currentAccount.local = response;
+    _currentAccount.local = migratedLocal;
 
     dispatch(
       updateCurrentAccount({
@@ -128,24 +129,39 @@ export const migrateUserEncryption = async (dispatch, currentAccount, encUserPin
     const encryptedPin = encryptKey(Config.DEFAULT_PIN, Config.PIN_KEY);
     dispatch(setPinCode(encryptedPin));
   } catch (err) {
+    // Re-encryption to DEFAULT_PIN failed. Do NOT mark the migration complete
+    // (setEncryptedUnlockPin) below — otherwise the keys stay encrypted with the
+    // old PIN while the app expects DEFAULT_PIN, silently locking the user out of
+    // signing. Surface the failure (offers re-login) and abort so it can retry on
+    // the next unlock.
     console.warn('pin update failure: ', err);
+    onFailure(err);
+    return false;
+  }
+
+  // updatePinCode resolves with no record when storage has no matching user;
+  // abort rather than mark the migration complete with missing/old-PIN keys.
+  if (!migratedLocal) {
+    onFailure(new Error('PIN migration produced no account data'));
+    return false;
   }
 
   dispatch(setEncryptedUnlockPin(encUserPin));
 
-  const realmData = await getUserDataWithUsername(currentAccount.name);
-
+  // Reuse the freshly re-encrypted record returned by updatePinCode instead of
+  // re-reading realm: the AsyncStorage write inside updatePinCode is not awaited,
+  // so a disk re-read here can race it and return stale, old-PIN-encrypted keys.
   let _currentAccount = currentAccount;
   _currentAccount.username = _currentAccount.name;
-  [_currentAccount.local] = realmData;
+  _currentAccount.local = migratedLocal;
 
   try {
     const pinHash = encryptKey(Config.DEFAULT_PIN, Config.PIN_KEY);
     // migration script for previously mast key based logged in user not having access token
-    if (realmData[0].authType !== AUTH_TYPE.STEEM_CONNECT && realmData[0].accessToken === '') {
+    if (migratedLocal.authType !== AUTH_TYPE.STEEM_CONNECT && migratedLocal.accessToken === '') {
       _currentAccount = await migrateToMasterKeyWithAccessToken(
         _currentAccount,
-        realmData[0],
+        migratedLocal,
         pinHash,
       );
     }
@@ -179,6 +195,7 @@ export const migrateUserEncryption = async (dispatch, currentAccount, encUserPin
 
   dispatch(updateCurrentAccount({ ..._currentAccount }));
   dispatch(fetchSubscribedCommunities(_currentAccount.name));
+  return true;
 };
 
 export const repairUserAccountData = async (username, dispatch, intl, accounts, pinHash) => {
@@ -481,9 +498,25 @@ const reduxMigrations = {
   },
 };
 
+// Wrap every migration so a throw degrades to "skip this migration" and keep the
+// rest of the persisted state, instead of rejecting rehydration — which makes
+// redux-persist drop ALL persisted state (silent logout + loss of local drafts).
+const safeReduxMigrations = Object.keys(reduxMigrations).reduce((acc, version) => {
+  const migrate = (reduxMigrations as any)[version];
+  acc[version] = (state: any) => {
+    try {
+      return migrate(state);
+    } catch (err) {
+      console.warn(`redux-persist migration ${version} failed, skipping:`, err);
+      return state;
+    }
+  };
+  return acc;
+}, {} as Record<string, (state: any) => any>);
+
 export default {
   migrateSettings,
   migrateUserEncryption,
   migrateSelectedTokens,
-  reduxMigrations,
+  reduxMigrations: safeReduxMigrations,
 };


### PR DESCRIPTION
Hardens two one-time migration paths so a failure degrades gracefully instead of leaving the app in a bad state.

## PIN re-encryption migration (`migrateUserEncryption`)
- **Await** the re-encryption and **abort on failure** instead of marking the migration complete — so it retries on the next unlock rather than leaving the account stuck with keys on the old PIN.
- **Reuse** the re-encrypted record returned in-memory instead of re-reading storage, avoiding a race with the (un-awaited) write.
- Resolve the underlying pin update even when there is no matching user, so an awaiting caller can't hang.
- The unlock flow no longer advances into the requested operation when the migration didn't succeed.

## Redux-persist migrations
- Wrap each migration so a single failing migration is **skipped** instead of rejecting rehydration and dropping **all** persisted state (which would log the user out and lose local drafts).

## Validation
- `yarn lint` — clean
- `tsc --noEmit` — no errors in changed files
- `jest --ci` — 336 passed (added a failure-isolation test for the migration wrapper)

Reviewed with an adversarial pass over the auth-unlock and rehydration paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed PIN verification process that could hang in certain conditions
  * Improved encryption key update reliability with better error handling
  * Enhanced app stability by gracefully handling update failures and preventing data loss

* **Tests**
  * Added test coverage for update failure scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->