### PR TITLE
fix(editor): make reply/publish resilient to metadata failures

### DIFF
--- a/src/screens/editor/container/editorContainer.tsx
+++ b/src/screens/editor/container/editorContainer.tsx
@@ -307,7 +307,9 @@ class EditorContainer extends Component<EditorContainerProps, any> {
   }
 
   _handleAppStateChange = (nextAppState: AppStateStatus) => {
-    if (this._appState.match(/active|forground/) && nextAppState === 'inactive') {
+    // iOS emits 'inactive' when backgrounding; Android emits 'background'. Handle
+    // both so unsaved draft content is not lost when an Android user backgrounds.
+    if (this._appState.match(/active|forground/) && nextAppState.match(/inactive|background/)) {
       this._saveCurrentDraft(this._updatedDraftFields);
     }
     this._appState = nextAppState;
@@ -1046,27 +1048,45 @@ class EditorContainer extends Component<EditorContainerProps, any> {
         isPostSending: true,
       });
 
-      const { post } = this.state;
+      let permlink;
+      let parentAuthor;
+      let parentPermlink;
+      let draftId;
+      let jsonMetadata;
+      let author;
+      let rootAuthor;
+      let rootPermlink;
 
-      const _prefix = `re-${post.author.replace(/\./g, '')}`;
-      const permlink = generateUniquePermlink(_prefix);
+      try {
+        const { post } = this.state;
 
-      const parentAuthor = post.author;
-      const parentPermlink = post.permlink;
-      const parentTags = post.json_metadata.tags;
-      const draftId = `${currentAccount.name}/${parentAuthor}/${parentPermlink}`;
+        const _prefix = `re-${post.author.replace(/\./g, '')}`;
+        permlink = generateUniquePermlink(_prefix);
 
-      const meta = await extractMetadata({
-        body: fields.body,
-        fetchRatios: true,
-        postType: PostTypes.COMMENT,
-      });
-      const jsonMetadata = makeJsonMetadata(meta, parentTags || ['ecency']);
+        parentAuthor = post.author;
+        parentPermlink = post.permlink;
+        const parentTags = post.json_metadata.tags;
+        draftId = `${currentAccount.name}/${parentAuthor}/${parentPermlink}`;
 
-      const author = currentAccount.name;
+        const meta = await extractMetadata({
+          body: fields.body,
+          fetchRatios: true,
+          postType: PostTypes.COMMENT,
+        });
+        jsonMetadata = makeJsonMetadata(meta, parentTags || ['ecency']);
 
-      // Derive root author/permlink for proper cache invalidation and optimistic updates
-      const { rootAuthor, rootPermlink } = deriveDiscussionRoot(post, parentAuthor, parentPermlink);
+        author = currentAccount.name;
+
+        // Derive root author/permlink for proper cache invalidation and optimistic updates
+        ({ rootAuthor, rootPermlink } = deriveDiscussionRoot(post, parentAuthor, parentPermlink));
+      } catch (error) {
+        // Building the reply (metadata fetch, malformed parent post, …) failed —
+        // reset the sending flags so the reply editor isn't left permanently wedged.
+        this._isSubmitting = false;
+        this.setState({ isPostSending: false });
+        this._handleSubmitFailure(error);
+        return;
+      }
 
       try {
         // Add optimistic entry to discussions cache for immediate UI feedback

--- a/src/screens/editor/container/editorContainer.tsx
+++ b/src/screens/editor/container/editorContainer.tsx
@@ -307,9 +307,13 @@ class EditorContainer extends Component<EditorContainerProps, any> {
   }
 
   _handleAppStateChange = (nextAppState: AppStateStatus) => {
-    // iOS emits 'inactive' when backgrounding; Android emits 'background'. Handle
-    // both so unsaved draft content is not lost when an Android user backgrounds.
-    if (this._appState.match(/active|forground/) && nextAppState.match(/inactive|background/)) {
+    // iOS emits 'inactive' when backgrounding; Android emits 'background'. Use exact
+    // equality — a regex like /active/ also matches 'inactive', which would save
+    // twice on iOS (active->inactive, then inactive->background). Only save when
+    // there are pending edits, since _saveCurrentDraft dereferences the fields.
+    const wasForeground = this._appState === 'active';
+    const movingToBackground = nextAppState === 'inactive' || nextAppState === 'background';
+    if (wasForeground && movingToBackground && this._updatedDraftFields) {
       this._saveCurrentDraft(this._updatedDraftFields);
     }
     this._appState = nextAppState;

--- a/src/utils/editor.ts
+++ b/src/utils/editor.ts
@@ -302,27 +302,30 @@ export const extractMetadata = async ({
     }
   });
 
-  const postResponses = await Promise.all(postPromises);
+  // Use allSettled so a single failed linked-post fetch can't reject the whole
+  // metadata extraction — which previously threw out of extractMetadata and could
+  // wedge the publish/reply flow.
+  const postResults = await Promise.allSettled(postPromises);
 
   // Now combine responses with original URL data
-  postResponses.forEach((linkedPost, index) => {
-    try {
-      const url = promiseUrls[index];
+  postResults.forEach((result, index) => {
+    const url = promiseUrls[index];
+    const linkedPost = result.status === 'fulfilled' ? result.value : null;
 
-      out.links_meta = {
-        ...(out.links_meta || {}),
-        [url]: linkedPost
-          ? {
-              title: linkedPost.title,
-              summary: linkedPost.summary,
-              image: linkedPost.image,
-            }
-          : null,
-      };
-    } catch (e) {
-      // Skip url if post data not returned
-      console.log('error fetching post data for url, skipping url: ', urlData[index]?.url, e);
+    if (result.status === 'rejected') {
+      console.log('error fetching post data for url, skipping url: ', url, result.reason);
     }
+
+    out.links_meta = {
+      ...(out.links_meta || {}),
+      [url]: linkedPost
+        ? {
+            title: linkedPost.title,
+            summary: linkedPost.summary,
+            image: linkedPost.image,
+          }
+        : null,
+    };
   });
 
   // sort based on thumbUrl if provided


### PR DESCRIPTION
Hardens the editor reply/publish flow against failures while building post metadata.

## Changes
- **`extractMetadata` → `Promise.allSettled`** — a single failed linked-post fetch no longer rejects the whole metadata extraction (previously this could abort a publish/reply and surface a misleading error). Also removes an undefined `urlData` reference in the error path.
- **`_submitReply` guard** — the permlink/metadata computation now runs inside a try/catch that resets the sending flags on failure, so a metadata error or malformed parent post no longer leaves the reply editor permanently stuck.
- **Android background autosave** — draft autosave on backgrounding now also fires on Android (`background`), not just iOS (`inactive`), preventing loss of unsaved content.

## Validation
- `yarn lint` — clean
- `tsc --noEmit` — no errors in changed files
- `jest --ci` — 337 passed
- Reviewed with an adversarial pass over the reply/publish flow (no use-before-assign, happy-path metadata shape unchanged, no double-save).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved draft auto-save when the app moves from active to background/inactive on iOS and Android.
  * Enhanced reply submission error handling so failed metadata processing won't leave the editor stuck submitting.
  * Metadata extraction now tolerates individual linked-post fetch failures and continues processing remaining links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->