### PR TITLE
chore(telemetry): disable default PII and scrub secrets from Sentry

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -9,18 +9,49 @@ if (enableSessionReplay) {
   integrations.unshift(Sentry.mobileReplayIntegration());
 }
 
+// Defense-in-depth: redact Hive private keys (WIF) and obvious bearer/access
+// tokens from anything that reaches Sentry, so an accidental log of a secret can
+// never leave the device in a breadcrumb or event payload.
+const HIVE_WIF_KEY = /\b5[HJK][1-9A-HJ-NP-Za-km-z]{48,51}\b/g;
+const BEARER_TOKEN = /\b(Bearer|Basic)\s+[A-Za-z0-9._~+/=-]{12,}/gi;
+const redactSecrets = (value: unknown): any => {
+  if (typeof value !== 'string') {
+    return value;
+  }
+  return value.replace(HIVE_WIF_KEY, '<redacted-key>').replace(BEARER_TOKEN, '$1 <redacted>');
+};
+
 Sentry.init({
   dsn: 'https://a7b0c5a49bdeae965767e2967411b7b0@o4507985141956608.ingest.de.sentry.io/4509786252116048',
 
-  // Adds more context data to events (IP address, cookies, user, etc.)
-  // For more information, visit: https://docs.sentry.io/platforms/react-native/data-management/data-collected/
-  sendDefaultPii: true,
+  // Do not attach default PII (IP address, cookies, user, etc.) to events.
+  // https://docs.sentry.io/platforms/react-native/data-management/data-collected/
+  sendDefaultPii: false,
 
   // Disable in production to avoid unnecessary background
   // processing and battery impact while still sampling replays in development.
   replaysSessionSampleRate: enableSessionReplay ? 0.1 : 0,
   replaysOnErrorSampleRate: enableSessionReplay ? 1 : 0,
   integrations,
+
+  beforeBreadcrumb(breadcrumb) {
+    if (typeof breadcrumb.message === 'string') {
+      breadcrumb.message = redactSecrets(breadcrumb.message);
+    }
+    return breadcrumb;
+  },
+
+  beforeSend(event) {
+    if (typeof event.message === 'string') {
+      event.message = redactSecrets(event.message);
+    }
+    event.exception?.values?.forEach((value) => {
+      if (typeof value.value === 'string') {
+        value.value = redactSecrets(value.value);
+      }
+    });
+    return event;
+  },
 
   // uncomment the line below to enable Spotlight (https://spotlightjs.com)
   // spotlight: __DEV__,

--- a/App.tsx
+++ b/App.tsx
@@ -21,6 +21,41 @@ const redactSecrets = (value: unknown): any => {
   return value.replace(HIVE_WIF_KEY, '<redacted-key>').replace(BEARER_TOKEN, '$1 <redacted>');
 };
 
+// Deep-redact every string inside a value. Sentry stores raw console arguments
+// under breadcrumb.data (e.g. data.arguments[1]), so scrubbing the message alone
+// is not enough. Mutates objects/arrays in place; depth-guarded.
+const redactDeep = (value: any, depth = 0): any => {
+  if (value == null || depth > 6) {
+    return value;
+  }
+  if (typeof value === 'string') {
+    return redactSecrets(value);
+  }
+  if (Array.isArray(value)) {
+    for (let i = 0; i < value.length; i += 1) {
+      value[i] = redactDeep(value[i], depth + 1);
+    }
+    return value;
+  }
+  if (typeof value === 'object') {
+    Object.keys(value).forEach((key) => {
+      value[key] = redactDeep(value[key], depth + 1);
+    });
+  }
+  return value;
+};
+
+const redactBreadcrumb = (breadcrumb: any) => {
+  if (!breadcrumb) {
+    return breadcrumb;
+  }
+  if (typeof breadcrumb.message === 'string') {
+    breadcrumb.message = redactSecrets(breadcrumb.message);
+  }
+  breadcrumb.data = redactDeep(breadcrumb.data);
+  return breadcrumb;
+};
+
 Sentry.init({
   dsn: 'https://a7b0c5a49bdeae965767e2967411b7b0@o4507985141956608.ingest.de.sentry.io/4509786252116048',
 
@@ -35,10 +70,7 @@ Sentry.init({
   integrations,
 
   beforeBreadcrumb(breadcrumb) {
-    if (typeof breadcrumb.message === 'string') {
-      breadcrumb.message = redactSecrets(breadcrumb.message);
-    }
-    return breadcrumb;
+    return redactBreadcrumb(breadcrumb);
   },
 
   beforeSend(event) {
@@ -50,6 +82,12 @@ Sentry.init({
         value.value = redactSecrets(value.value);
       }
     });
+    // Breadcrumbs already on the event (data included, in case any predate the
+    // beforeBreadcrumb scrub). event.breadcrumbs may be an array or {values:[]}.
+    const breadcrumbs: any = (event.breadcrumbs as any)?.values ?? event.breadcrumbs;
+    if (Array.isArray(breadcrumbs)) {
+      breadcrumbs.forEach((breadcrumb) => redactBreadcrumb(breadcrumb));
+    }
     return event;
   },
 

--- a/src/screens/application/container/applicationContainer.tsx
+++ b/src/screens/application/container/applicationContainer.tsx
@@ -1079,7 +1079,7 @@ class ApplicationContainer extends Component {
       }
 
       const token = await getMessaging().getToken();
-      console.log('FCM Token:', token);
+      console.log('FCM Token obtained:', !!token);
       saveNotificationSetting(
         accessToken,
         username,


### PR DESCRIPTION
Privacy/telemetry hardening for Sentry.

## Changes
- **`sendDefaultPii: false`** — stop attaching default PII (IP address, cookies, user) to events.
- **Scrubbers** — `beforeBreadcrumb`/`beforeSend` redact Hive private keys (WIF format) and bearer tokens from breadcrumb messages and event payloads, as defense-in-depth so an accidental log of a secret can't leave the device.
- **FCM token** — log presence (`!!token`) instead of the raw token value.

## Validation
- `yarn lint` — clean
- `tsc --noEmit` — no errors in changed files
- `jest --ci` — 337 passed
- Sanity-checked the redaction: a WIF key and a `Bearer <token>` are redacted; ordinary log lines (authors, permlinks) are left untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Enhanced event logging security by disabling default personally identifiable information collection.
* Added redaction filters to prevent sensitive credentials from appearing in error events before transmission.
* Improved notification token handling to prevent sensitive data exposure in console output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->