### PR TITLE
fix(persistence): correct query-persist allowlist for unified SDK keys

### DIFF
--- a/src/providers/queries/bookmarkQueries.ts
+++ b/src/providers/queries/bookmarkQueries.ts
@@ -84,7 +84,9 @@ export const useAddBookmarkMutation = () => {
     username,
     code,
     () => {
-      queryClient.invalidateQueries({ queryKey: ['bookmarks'] });
+      // SDK keys bookmarks under the 'accounts' namespace; a ['bookmarks'] prefix
+      // does not match ['accounts','bookmarks',…] so the list would stay stale.
+      queryClient.invalidateQueries({ queryKey: ['accounts', 'bookmarks'] });
       dispatch(toastNotification(intl.formatMessage({ id: 'alert.success' })));
     },
     () => {
@@ -107,7 +109,9 @@ export const useDeleteBookmarkMutation = () => {
     username,
     code,
     () => {
-      queryClient.invalidateQueries({ queryKey: ['bookmarks'] });
+      // SDK keys bookmarks under the 'accounts' namespace; a ['bookmarks'] prefix
+      // does not match ['accounts','bookmarks',…] so the list would stay stale.
+      queryClient.invalidateQueries({ queryKey: ['accounts', 'bookmarks'] });
       dispatch(toastNotification(intl.formatMessage({ id: 'alert.success' })));
     },
     () => {
@@ -130,7 +134,9 @@ export const useAddFavouriteMutation = () => {
     username,
     code,
     () => {
-      queryClient.invalidateQueries({ queryKey: ['favorites'] });
+      // SDK keys favorites under the 'accounts' namespace; a ['favorites'] prefix
+      // does not match ['accounts','favorites',…] so the list would stay stale.
+      queryClient.invalidateQueries({ queryKey: ['accounts', 'favorites'] });
       dispatch(toastNotification(intl.formatMessage({ id: 'alert.success' })));
     },
     () => {
@@ -153,7 +159,9 @@ export const useDeleteFavouriteMutation = () => {
     username,
     code,
     () => {
-      queryClient.invalidateQueries({ queryKey: ['favorites'] });
+      // SDK keys favorites under the 'accounts' namespace; a ['favorites'] prefix
+      // does not match ['accounts','favorites',…] so the list would stay stale.
+      queryClient.invalidateQueries({ queryKey: ['accounts', 'favorites'] });
       dispatch(toastNotification(intl.formatMessage({ id: 'alert.success' })));
     },
     () => {

--- a/src/providers/queries/index.ts
+++ b/src/providers/queries/index.ts
@@ -3,7 +3,7 @@ import { createAsyncStoragePersister } from '@tanstack/query-async-storage-persi
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { PersistQueryClientProviderProps } from '@tanstack/react-query-persist-client';
 import { getQueryClient as getQueryClientFromSDK } from '@ecency/sdk';
-import QUERIES from './queryKeys';
+import VersionNumber from 'react-native-version-number';
 import { initSdkConfig } from './sdk-config';
 
 export const initQueryClient = () => {
@@ -27,83 +27,86 @@ export const initQueryClient = () => {
     console.error('Failed to initialize SDK config:', error);
   });
 
+  // Selective persistence allowlist. Query keys are unified in @ecency/sdk
+  // (QueryKeys.*), so we match on the SDK namespace (queryKey[0]) and subtype
+  // (queryKey[1]). Infinite lists carry full post bodies and grow with each page
+  // scrolled, so they are persisted only while a single page is loaded to keep
+  // the on-disk cache bounded.
   const _shouldDehydrateQuery = (query: Query) => {
-    const _isSuccess = query.state.status === 'success';
+    if (query.state.status !== 'success') {
+      // Only log errors (not pending states) for debugging
+      if (query.state.status === 'error') {
+        console.log('query error for dehydration', query.queryKey, query.state.error);
+      }
+      return false;
+    }
 
     // Don't persist queries with undefined in their query keys
     if (query.queryKey.some((key) => key === undefined)) {
       return false;
     }
 
-    if (_isSuccess) {
-      // Cherry pick which queries to dehydrate for persistence
-      const queryKeyType = query.queryKey[0];
+    const namespace = query.queryKey[0];
+    const subType = query.queryKey[1];
 
-      // Handle SDK queries
-      if (
-        queryKeyType === 'core' ||
-        queryKeyType === 'posts' ||
-        queryKeyType === 'get-account-full' ||
-        queryKeyType === 'notifications'
-      ) {
-        // SDK posts queries - selective persistence
-        if (queryKeyType === 'posts') {
-          const subType = query.queryKey[1];
+    const data = query.state.data as any;
+    const isSinglePage = !(data?.pages && data.pages.length > 1);
 
-          // Don't persist individual post entries
-          if (subType === 'entry') {
-            return false;
-          }
+    switch (namespace) {
+      // SDK global config + the user's own account-full data (small, offline-useful)
+      case 'core':
+      case 'get-account-full':
+        return true;
 
-          // For feed queries (account-posts, posts-ranked, waves), only persist first page
-          if (subType === 'account-posts' || subType === 'posts-ranked' || subType === 'waves') {
-            // These are infinite queries - only persist if it's the first page
-            // Check if query has been fetched (has pages data)
-            const queryData = query.state.data as any;
-            if (queryData?.pages && queryData.pages.length > 1) {
-              return false; // Don't persist if more than first page loaded
-            }
-            return true; // Persist first page only
-          }
-
-          return true; // Persist other post queries
+      // QueryKeys.posts.*
+      case 'posts':
+        if (subType === 'entry') {
+          return false; // individual posts refetch on view
         }
-
-        if (queryKeyType === 'notifications' && query.queryKey[1] === 'announcements') {
-          return false; // Don't persist announcements
+        // Feeds + drafts/schedules are infinite lists — persist first page only so
+        // persisted storage can't grow unbounded with full post bodies on scroll.
+        if (
+          subType === 'account-posts' ||
+          subType === 'posts-ranked' ||
+          subType === 'waves' ||
+          subType === 'drafts' ||
+          subType === 'schedules'
+        ) {
+          return isSinglePage;
         }
+        return true; // other post queries (discussions, comment history, …)
 
-        return true; // Persist other SDK queries
-      }
+      // QueryKeys.accounts.* — bookmarks/favorites moved under this namespace on the
+      // SDK key unification, so the old 'bookmarks'/'favourites' cases were dead and
+      // they were silently never persisted. Persist first page only.
+      case 'accounts':
+        if (subType === 'bookmarks' || subType === 'favorites') {
+          return isSinglePage;
+        }
+        return false; // other account lists (followers, following, …) not persisted
 
-      // Handle mobile-specific legacy queries (explicit allowlist)
-      switch (queryKeyType) {
-        case QUERIES.NOTIFICATIONS.GET:
-          return query.queryKey[2] === ''; // only dehydrate first page of notifications
-        case 'drafts':
-        case 'schedules':
-          return query.queryKey[2] === 0; // First page only
-        case 'bookmarks':
-        case 'favourites':
-        case 'points':
-          return true;
-        default:
+      // QueryKeys.notifications.*
+      case 'notifications':
+        if (subType === 'announcements') {
           return false;
-      }
-    }
+        }
+        return isSinglePage; // first page only (was: all pages)
 
-    // Only log errors (not pending states) for debugging
-    if (query.state.status === 'error') {
-      console.log('query error for dehydration', query.queryKey, query.state.error);
-    }
+      case 'points':
+        return true;
 
-    return false;
+      default:
+        return false;
+    }
   };
 
   return {
     client,
     persistOptions: {
       persister: asyncStoragePersister,
+      // Bust the persisted cache across app updates so query data whose shape
+      // changed with an SDK/schema update can't be restored stale.
+      buster: VersionNumber.appVersion,
       dehydrateOptions: {
         shouldDehydrateQuery: _shouldDehydrateQuery,
       },


### PR DESCRIPTION
The react-query selective-persistence allowlist had drifted from the unified `@ecency/sdk` query keys, causing both over- and under-persistence.

## What was wrong (verified against runtime SDK keys)
| Query | Runtime key | Was | Now |
|---|---|---|---|
| drafts / schedules | `["posts","drafts"/"schedules","infinite",…]` | persisted **all pages** (full bodies) | first page only |
| notifications list | `["notifications",username,…]` | persisted **all pages** | first page only |
| bookmarks / favorites | `["accounts","bookmarks"/"favorites","infinite",…]` | **never persisted** (matched no branch) | first page only |
| account-full / points / feeds | (unchanged) | correct | unchanged |

The old mobile-specific `switch` cases (`'drafts'`, `'schedules'`, `'notifications'`, `'bookmarks'`, `'favourites'`) were **dead code** after the SDK key unification.

## Changes
- Rewrote `shouldDehydrateQuery` to match the SDK **namespace + subtype**, bounding infinite lists (drafts/schedules/notifications) to the first page like feeds, and persisting bookmarks/favorites again.
- Removed the dead legacy `switch` cases.
- Added a `buster: VersionNumber.appVersion` so persisted data whose shape changed across an app/SDK update isn't restored stale.

## Validation
- `yarn lint` / `tsc --noEmit` — clean
- `jest --ci` — 337 passed
- Verified the policy against every runtime key.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed bookmark and favourite synchronization issues where updates wouldn't consistently appear in all parts of the application
  * Improved data cache handling to automatically refresh stored information when the app is updated to a new version

<!-- end of auto-generated comment: release notes by coderabbit.ai -->