### PR TITLE
fix(speak): use the refreshed token for video upload, not the stale one

### DIFF
--- a/src/providers/queries/editorQueries/speakQueries.ts
+++ b/src/providers/queries/editorQueries/speakQueries.ts
@@ -49,7 +49,6 @@ export const useThreeSpeakEmbedUpload = () => {
   const dispatch = useAppDispatch();
   const currentAccount = useAppSelector(selectCurrentAccount);
   const pinHash = useAppSelector(selectPin);
-  const getToken = useAccessToken();
   const [completed, setCompleted] = useState(0);
 
   const mutation = useMutation({
@@ -65,19 +64,26 @@ export const useThreeSpeakEmbedUpload = () => {
         throw new Error('No active account');
       }
 
-      // Refresh the HiveSigner token before uploading to avoid
-      // expired-token failures on long-running sessions
+      // Refresh the HiveSigner token before uploading to avoid expired-token
+      // failures on long-running sessions. refreshSCToken returns the (possibly
+      // refreshed) ENCRYPTED token re-encrypted with this pin — use its return,
+      // not the render-captured Redux account, which would be the stale,
+      // pre-refresh token.
       const pinCode = getDigitPinCode(pinHash);
+      let encryptedToken = currentAccount.local?.accessToken;
       try {
-        await refreshSCToken(currentAccount.local, pinCode);
+        encryptedToken = await refreshSCToken(currentAccount.local, pinCode);
       } catch {
-        // refresh failed — proceed with existing token, server
-        // will reject if it's truly expired
+        // refresh failed and the token is expired — fall back to the stored
+        // token; the server will reject if it is truly expired.
       }
 
-      const accessToken = getToken();
-      if (!accessToken) {
+      if (!encryptedToken) {
         throw new Error('No access token available');
+      }
+      const accessToken = decryptKey(encryptedToken, pinCode as string);
+      if (!accessToken) {
+        throw new Error('Failed to decrypt access token');
       }
 
       try {


### PR DESCRIPTION
The 3Speak video upload refreshes the HiveSigner token before uploading, but then uploaded with the **pre-refresh** token, so the refresh was effectively a no-op and long-running sessions could upload with an expired token.

## Cause
`refreshSCToken` returns the refreshed, re-encrypted access token, but the upload `await`ed it without using the return, then read the token via `getToken()` — which decrypts `currentAccount.local.accessToken` from the render-captured Redux value (the pre-refresh token).

## Fix
Use `refreshSCToken`'s return value: decrypt the (possibly refreshed) token it returns, falling back to the stored token if the refresh fails.

## Validation
- `yarn lint` / `tsc --noEmit` — clean
- `jest --ci` — 337 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved video upload authentication handling with better token refresh logic and fallback mechanisms, ensuring more reliable uploads even when token refresh encounters issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->