### PR TITLE
perf(feed): engage PostCard memo + stabilize interaction handler

### DIFF
--- a/src/components/leaderboard/view/leaderboardView.tsx
+++ b/src/components/leaderboard/view/leaderboardView.tsx
@@ -87,7 +87,7 @@ class LeaderboardView extends PureComponent {
           <FlatList
             data={users}
             refreshing={refreshing}
-            keyExtractor={(item) => get(item, '_id', Math.random()).toString()}
+            keyExtractor={(item, index) => (get(item, '_id') ?? index).toString()}
             removeClippedSubviews={false}
             ListEmptyComponent={this._renderEmptyView}
             onRefresh={() => fetchLeaderBoard()}

--- a/src/components/leaderboard/view/leaderboardView.tsx
+++ b/src/components/leaderboard/view/leaderboardView.tsx
@@ -87,7 +87,7 @@ class LeaderboardView extends PureComponent {
           <FlatList
             data={users}
             refreshing={refreshing}
-            keyExtractor={(item, index) => (get(item, '_id') ?? index).toString()}
+            keyExtractor={(item, index) => get(item, '_id')?.toString() ?? `index-${index}`}
             removeClippedSubviews={false}
             ListEmptyComponent={this._renderEmptyView}
             onRefresh={() => fetchLeaderBoard()}

--- a/src/components/postCard/container/postCard.tsx
+++ b/src/components/postCard/container/postCard.tsx
@@ -24,6 +24,17 @@ export enum PostCardActionIds {
 }
 
 const PostCard = ({ intl, content, isHideImage, nsfw, pageType, handleCardInteraction }) => {
+  // Inject this card's `content` into the (stable) parent handler so children
+  // receive a referentially-stable callback. The list passes a stable
+  // handleCardInteraction; wrapping it here (instead of a fresh inline arrow in
+  // the list's renderItem) keeps the memo comparator below from re-rendering
+  // every card on each list re-render.
+  const handleInteraction = React.useCallback(
+    (id: PostCardActionIds, payload: any, onCallback?: any) =>
+      handleCardInteraction(id, payload, content, onCallback),
+    [handleCardInteraction, content],
+  );
+
   return (
     <View style={styles.post}>
       <PostCardHeader
@@ -31,15 +42,15 @@ const PostCard = ({ intl, content, isHideImage, nsfw, pageType, handleCardIntera
         content={content}
         pageType={pageType}
         isHideImage={isHideImage}
-        handleCardInteraction={handleCardInteraction}
+        handleCardInteraction={handleInteraction}
       />
       <PostCardContent
         content={content}
         isHideImage={isHideImage}
         nsfw={nsfw}
-        handleCardInteraction={handleCardInteraction}
+        handleCardInteraction={handleInteraction}
       />
-      <PostCardActionsPanel content={content} handleCardInteraction={handleCardInteraction} />
+      <PostCardActionsPanel content={content} handleCardInteraction={handleInteraction} />
     </View>
   );
 };

--- a/src/components/postsList/container/postsListContainer.tsx
+++ b/src/components/postsList/container/postsListContainer.tsx
@@ -142,8 +142,6 @@ const postsListContainer = (
   const hasInitiallyScrolled = useRef(false);
 
   useEffect(() => {
-    console.log('Scroll Position: ', scrollPosition);
-
     // Only restore scroll position once on initial mount, not during pagination
     // Only set the flag after we actually restore a position with data present
     if (!hasInitiallyScrolled.current && scrollPosition !== undefined && scrollPosition > 0) {
@@ -265,9 +263,7 @@ const postsListContainer = (
           pageType={pageType}
           isHideImage={isHideImages}
           nsfw={nsfw}
-          handleCardInteraction={(id: PostCardActionIds, payload: any, onCallback) =>
-            _handleCardInteraction(id, payload, item, onCallback)
-          }
+          handleCardInteraction={_handleCardInteraction}
         />
       );
     },

--- a/src/components/tabbedPosts/view/postsTabContent.tsx
+++ b/src/components/tabbedPosts/view/postsTabContent.tsx
@@ -185,20 +185,25 @@ const PostsTabContent = ({
     }
   };
 
-  // show quick reply modal
-  const _showQuickReplyModal = (post: any) => {
-    if (isLoggedIn) {
-      SheetManager.show(SheetNames.QUICK_POST, {
-        payload: {
-          mode: 'comment',
-          parentPost: post,
-        },
-      });
-    } else {
-      // TODO: show proper alert message
-      console.log('Not LoggedIn');
-    }
-  };
+  // show quick reply modal. Memoized so it (and the _handleCardInteraction /
+  // PostCard memo chain that depends on it) stays referentially stable across
+  // renders, only changing when login state changes.
+  const _showQuickReplyModal = useCallback(
+    (post: any) => {
+      if (isLoggedIn) {
+        SheetManager.show(SheetNames.QUICK_POST, {
+          payload: {
+            mode: 'comment',
+            parentPost: post,
+          },
+        });
+      } else {
+        // TODO: show proper alert message
+        console.log('Not LoggedIn');
+      }
+    },
+    [isLoggedIn],
+  );
 
   return (
     <>

--- a/src/components/uploadsGalleryModal/children/uploadsGalleryContent.tsx
+++ b/src/components/uploadsGalleryModal/children/uploadsGalleryContent.tsx
@@ -324,7 +324,6 @@ const UploadsGalleryContent = ({
         visibleMap[viewable.index] = viewable.isViewable;
       }
     });
-    console.log('Visible items', JSON.stringify(visibleMap));
     setViewableItemsMap(visibleMap);
   };
 


### PR DESCRIPTION
Feed/list render-performance cleanups. Behavior-preserving.

## Changes
- **PostCard memo actually engages.** The list passed a fresh inline `handleCardInteraction` arrow per render, and `PostCard`'s memo comparator compares that prop — so every card re-rendered on each list re-render. Now the list passes the stable `_handleCardInteraction` directly, and `PostCard` injects its own `content` via a `useCallback` wrapper. To make the chain truly stable, `_showQuickReplyModal` (a dependency of `_handleCardInteraction`) is now `useCallback`'d, so the handler only changes on login-state change.
- **Leaderboard keyExtractor.** Replaced the random-id fallback (which produced a new key — and a full row remount — every render) with a stable index fallback.
- **Removed two debug logs on hot paths** — one on every scroll-position change, one `JSON.stringify` on every viewable-items change.

## Notes
- Verified end-to-end (adversarial pass) that every feed action (USER/OPTIONS/NAVIGATE/REPLY/UPVOTE/PAYOUT_DETAILS/TIP) receives identical arguments — the wrapper's injected `content` equals the previous `item`, and the UPVOTE `onVotingStart` callback chain is intact.
- The round-2 "comments renderItem defeats memo" item was a false positive (`CommentView`'s comparator only compares data props), so it is intentionally not touched.

## Validation
- `yarn lint` / `tsc --noEmit` — clean
- `jest --ci` — 337 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized list rendering with stable item key generation and callback handling, reducing unnecessary re-renders when scrolling through posts.
  * Removed debug logging for cleaner performance.

* **Bug Fixes**
  * Fixed list key generation fallback for better list stability during updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->