### PR TITLE
fix(editor): remove server draft after publishing from it

### DIFF
--- a/src/providers/queries/draftQueries.ts
+++ b/src/providers/queries/draftQueries.ts
@@ -138,7 +138,9 @@ export const useUpdateDraftMutation = () => {
  * which stores data under ["posts", "drafts", "infinite", username, limit].
  * We invalidate the infinite query on success so the list updates.
  */
-export const useDraftDeleteMutation = () => {
+export const useDraftDeleteMutation = ({
+  showErrorToast = true,
+}: { showErrorToast?: boolean } = {}) => {
   const intl = useIntl();
   const dispatch = useAppDispatch();
   const { username, code } = useAuth();
@@ -152,7 +154,12 @@ export const useDraftDeleteMutation = () => {
       queryClient.invalidateQueries({ queryKey: draftsInfiniteQueryKey(username) });
     },
     () => {
-      dispatch(toastNotification(intl.formatMessage({ id: 'alert.fail' })));
+      // Callers that delete as a background cleanup (e.g. removing the draft a
+      // just-published post was composed from) suppress the toast so a cleanup
+      // failure doesn't surface as an error after a successful action.
+      if (showErrorToast) {
+        dispatch(toastNotification(intl.formatMessage({ id: 'alert.fail' })));
+      }
     },
   );
 };

--- a/src/screens/editor/container/editorContainer.tsx
+++ b/src/screens/editor/container/editorContainer.tsx
@@ -96,6 +96,10 @@ class EditorContainer extends Component<EditorContainerProps, any> {
 
   _isSubmitting = false;
 
+  // Set once a post is published so the unmount/autosave draft write is skipped
+  // and can't recreate the server draft the publish flow just deleted.
+  _isPublished = false;
+
   _postingAuthorityPromptShown = false;
 
   constructor(props) {
@@ -551,6 +555,13 @@ class EditorContainer extends Component<EditorContainerProps, any> {
   };
 
   _saveDraftToDB = async (fields, saveAsNew = false) => {
+    // After a successful publish the source draft is deleted and its caches are
+    // cleared; skip any further save (e.g. the unmount autosave) so it isn't
+    // recreated locally or on the server.
+    if (this._isPublished) {
+      return;
+    }
+
     const { isDraftSaved, draftId, thumbUrl, isReply, rewardType, postDescription } = this.state;
     const { currentAccount, dispatch, intl, queryClient, pinCode } = this.props;
 
@@ -990,6 +1001,10 @@ class EditorContainer extends Component<EditorContainerProps, any> {
           // must not stay true (or a fast in-window reentry would be
           // blocked by `_handleSubmit`).
           this._isSubmitting = false;
+          // Mark published before the unmount so the draft save triggered by
+          // `componentWillUnmount` is skipped and the just-deleted draft isn't
+          // recreated.
+          this._isPublished = true;
           setTimeout(() => {
             this.setState({
               isPostSending: false,

--- a/src/screens/editor/container/editorContainer.tsx
+++ b/src/screens/editor/container/editorContainer.tsx
@@ -64,7 +64,10 @@ import {
   useReblogMutation,
   useGrantPostingPermissionMutation,
 } from '../../../providers/sdk/mutations';
-import { useAddScheduleMutation } from '../../../providers/queries/draftQueries';
+import {
+  useAddScheduleMutation,
+  useDraftDeleteMutation,
+} from '../../../providers/queries/draftQueries';
 import { PostTypes } from '../../../constants/postTypes';
 
 import { enforceThreeSpeakBeneficiary } from '../../../providers/speak/beneficiary';
@@ -965,6 +968,14 @@ class EditorContainer extends Component<EditorContainerProps, any> {
           dispatch(removeEditorCache(DEFAULT_USER_DRAFT_ID));
           if (draftId) {
             dispatch(removeEditorCache(draftId));
+            // The post is published, so remove the server-side draft it was
+            // composed from (a loaded draft or one created by autosave) — these
+            // would otherwise pile up in the user's drafts list. Fire-and-forget:
+            // the publish already succeeded, so a cleanup failure must not block
+            // navigation or surface as an error (toast suppressed in the hook).
+            this.props.deleteDraftMutation
+              .mutateAsync({ draftId })
+              .catch((err) => console.warn('Failed to delete published draft', err));
           }
 
           dispatch(
@@ -1695,6 +1706,9 @@ const useEditorQueryProps = () => ({
   reblogMutation: useReblogMutation(),
   grantPostingPermissionMutation: useGrantPostingPermissionMutation(),
   addScheduleMutation: useAddScheduleMutation(),
+  // Background cleanup of a published post's source draft; suppress the failure
+  // toast so it never surfaces as an error after a successful publish.
+  deleteDraftMutation: useDraftDeleteMutation({ showErrorToast: false }),
 });
 
 export default gestureHandlerRootHOC(


### PR DESCRIPTION
## Problem

When a post is published immediately, the editor only cleared its **local** draft caches and never deleted the **server-side** draft the post was composed from. That draft could be one the user loaded from their Drafts list, or one the editor created automatically via autosave. As a result, drafts quietly accumulated in the user's Drafts list after every publish.

## Fix

On a successful immediate publish, the editor now deletes the source server draft as a background cleanup (fire-and-forget — the post is already published, so a cleanup failure never blocks navigation or surfaces as an error). The shared draft-delete hook gains a small, backward-compatible option to suppress its failure toast for this background-cleanup use, so a cleanup hiccup can't flash an error right after the success toast.

## Scope

- Only the immediate-publish path; the value deleted is always a real server draft id for that path.
- The existing Drafts-screen delete button keeps its current toast-on-error behavior.
- Scheduling a post from a draft is unchanged in this PR (separate path, possible follow-up).

## Testing

- `yarn lint` clean on changed files
- `yarn test:ci` — 339 passed, 1 skipped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Drafts are now automatically deleted upon successful post publication, significantly streamlining the overall content creation and management workflow.
  * Error handling for draft deletion is now configurable and flexible, enabling background cleanup operations to appropriately suppress error notifications while fully preserving all existing draft management, query synchronization, and operational functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->