### PR TITLE
Spotlight: filter by guestsOnly (guest-only audience)

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@babel/preset-typescript": "^7.26.0",
     "@babel/runtime": "^7.26.7",
     "@ecency/render-helper": "^2.5.10",
-    "@ecency/sdk": "^2.3.10",
+    "@ecency/sdk": "^2.3.11",
     "@esteemapp/react-native-autocomplete-input": "^4.2.1",
     "@esteemapp/react-native-multi-slider": "^1.1.0",
     "@native-html/iframe-plugin": "^2.6.1",

--- a/src/components/featureSpotlightCard/container/featureSpotlightCard.tsx
+++ b/src/components/featureSpotlightCard/container/featureSpotlightCard.tsx
@@ -24,14 +24,14 @@ export const FeatureSpotlightCard = () => {
   const spotlightsQuery = useQuery(getSpotlightsQueryOptions());
 
   // Apply the client-side rules the server leaves to clients: platform (mobile),
-  // auth (default logged-in only; auth:false also shows to guests), and per-id
+  // audience (logged-in by default; guestsOnly shows to signed-out visitors), and per-id
   // dismissal; then pick the highest weight (tie-break: earliest start). `path` is a
   // web-routing concept and is ignored here.
   const spotlight = useMemo(() => {
     const username = currentAccount?.name;
     const candidates = (spotlightsQuery.data ?? [])
       .filter((s) => !s.platforms || s.platforms.includes('mobile'))
-      .filter((s) => (s.auth === false ? true : !!username))
+      .filter((s) => (s.guestsOnly ? !username : !!username))
       .filter((s) => !spotlightMeta?.[`${s.id}_${username || 'guest'}`]?.dismissed);
 
     if (candidates.length === 0) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1270,10 +1270,10 @@
     url "^0.11.0"
     xss "^1.0.9"
 
-"@ecency/sdk@^2.3.10":
-  version "2.3.10"
-  resolved "https://registry.yarnpkg.com/@ecency/sdk/-/sdk-2.3.10.tgz#d7898477d00ab304227d05187fe4a3a50098a700"
-  integrity sha512-As/UJUPBMXI23lIpysFLF0QD/9YTFimYBzj9CTyIxaA4sygEuSvoSzwdpxbw5qcDOPPG+qbgH9RM9YM+izVjQA==
+"@ecency/sdk@^2.3.11":
+  version "2.3.11"
+  resolved "https://registry.yarnpkg.com/@ecency/sdk/-/sdk-2.3.11.tgz#2961920b1beb61c3b50f224d651c8f13a2d9ae0b"
+  integrity sha512-UAnJJeMhUh6K/IArGihL/yPZl4emzI1la55IeqhZeNpniMs9CC8xDAb5F8MSc6v7dw3aLkD+o84GJeVdIoyMxg==
   dependencies:
     "@noble/ciphers" "^2.1.1"
     "@noble/curves" "^2.0.1"


### PR DESCRIPTION
Brings the mobile spotlight card in line with the new audience model (vision-next #917, vapi #30).

- Filter changes from `s.auth === false ? true : !!username` to `s.guestsOnly ? !username : !!username` - logged-in users by default, `guestsOnly` cards only to signed-out visitors.
- Bumps `@ecency/sdk` to `^2.3.11`, which replaced the boolean `auth` with `guestsOnly` on the Spotlight type.

With the vapi guest funnel, signed-out users on the mobile feed see the signup hooks (and dismissing one reveals the next), while logged-in users only ever see the educational rotation. tsc + eslint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
* Enhanced feature spotlight visibility logic to ensure spotlights are correctly displayed based on user authentication status. Guest-only spotlights now appear to unauthenticated users, while other spotlights are shown to logged-in users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->