### PR TITLE
feat(transfer): recipient favorites, QR-to-recipient, and scheduled transfers

### DIFF
--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -124,6 +124,7 @@ import { PostingAuthoritySheet } from './postingAuthoritySheet';
 import { HiveAuthBroadcastSheet } from './hiveAuthBroadcastSheet';
 import EmojiPickerSheet from './emojiPickerSheet';
 import { AuthUpgradeSheet } from './authUpgradeSheet';
+import TransferFavoritesSheet from './transferFavoritesSheet/transferFavoritesSheet';
 
 // Basic UI Elements
 import {
@@ -303,4 +304,5 @@ export {
   HiveAuthBroadcastSheet,
   EmojiPickerSheet,
   AuthUpgradeSheet,
+  TransferFavoritesSheet,
 };

--- a/src/components/qrModal/qrModalView.tsx
+++ b/src/components/qrModal/qrModalView.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Alert, PermissionsAndroid, Platform, View, useWindowDimensions } from 'react-native';
-import ActionSheet, { SheetManager } from 'react-native-actions-sheet';
+import ActionSheet, { SheetManager, SheetProps } from 'react-native-actions-sheet';
 import EStyleSheet from 'react-native-extended-stylesheet';
 import { check, request, PERMISSIONS, RESULTS, openSettings } from 'react-native-permissions';
 import { useCameraDevice, Camera, useCodeScanner } from 'react-native-vision-camera';
@@ -8,26 +8,40 @@ import styles from './qrModalStyles';
 import { SheetNames } from '../../navigation/sheets';
 import { useLinkProcessor } from '../../hooks';
 
-export const QRModal = () => {
+export const QRModal = ({ sheetId, payload }: SheetProps<SheetNames.QR_SCAN>) => {
   const dim = useWindowDimensions();
   const linkProcessor = useLinkProcessor(() => SheetManager.hide(SheetNames.QR_SCAN));
 
   const device = useCameraDevice('back');
   const [isScannerActive, setIsScannerActive] = useState(true);
+  // Re-entry latch: vision-camera can deliver several already-queued frames before
+  // setIsScannerActive(false) deactivates the camera, so handle a scan only once.
+  const handledRef = useRef(false);
 
   const codeScanner = useCodeScanner({
     codeTypes: ['qr'],
     onCodeScanned: (codes) => {
       console.log(`Scanned ${codes.length} codes!`, codes);
-      if (codes[0].value) {
+      const scannedValue = codes[0]?.value;
+      if (scannedValue) {
+        if (handledRef.current) {
+          return;
+        }
+        handledRef.current = true;
         setIsScannerActive(false);
-        linkProcessor.handleLink(codes[0].value);
+        if (payload?.onScan) {
+          payload.onScan(scannedValue);
+          SheetManager.hide(sheetId || SheetNames.QR_SCAN, { payload: scannedValue });
+          return;
+        }
+        linkProcessor.handleLink(scannedValue);
       }
     },
   });
 
   useEffect(() => {
     requestCameraPermission();
+    handledRef.current = false;
     setIsScannerActive(true);
 
     return () => {
@@ -92,11 +106,12 @@ export const QRModal = () => {
   };
 
   const _onClose = () => {
-    SheetManager.hide(SheetNames.QR_SCAN);
+    SheetManager.hide(sheetId || SheetNames.QR_SCAN);
   };
 
   return (
     <ActionSheet
+      id={sheetId || SheetNames.QR_SCAN}
       gestureEnabled={true}
       snapPoints={[90]}
       containerStyle={{ ...styles.sheetContent, height: dim.height }}

--- a/src/components/qrModal/qrModalView.tsx
+++ b/src/components/qrModal/qrModalView.tsx
@@ -39,6 +39,9 @@ export const QRModal = ({ sheetId, payload }: SheetProps<SheetNames.QR_SCAN>) =>
     },
   });
 
+  // Registered sheets stay mounted across hide/show, so re-arm the camera and clear
+  // the one-shot scan latch on every open (keyed on `payload`) — not just on mount —
+  // otherwise the scanner stays frozen and silently drops scans after the first one.
   useEffect(() => {
     requestCameraPermission();
     handledRef.current = false;
@@ -47,7 +50,7 @@ export const QRModal = ({ sheetId, payload }: SheetProps<SheetNames.QR_SCAN>) =>
     return () => {
       setIsScannerActive(false);
     };
-  }, []);
+  }, [payload]);
 
   const requestCameraPermission = async () => {
     if (Platform.OS === 'ios') {

--- a/src/components/qrModal/qrModalView.tsx
+++ b/src/components/qrModal/qrModalView.tsx
@@ -10,7 +10,7 @@ import { useLinkProcessor } from '../../hooks';
 
 export const QRModal = ({ sheetId, payload }: SheetProps<SheetNames.QR_SCAN>) => {
   const dim = useWindowDimensions();
-  const linkProcessor = useLinkProcessor(() => SheetManager.hide(SheetNames.QR_SCAN));
+  const linkProcessor = useLinkProcessor(() => SheetManager.hide(sheetId || SheetNames.QR_SCAN));
 
   const device = useCameraDevice('back');
   const [isScannerActive, setIsScannerActive] = useState(true);

--- a/src/components/transferFavoritesSheet/transferFavoritesSheet.tsx
+++ b/src/components/transferFavoritesSheet/transferFavoritesSheet.tsx
@@ -3,9 +3,11 @@ import { ActivityIndicator, FlatList, Text, TextInput, TouchableOpacity, View } 
 import ActionSheet, { SheetManager, SheetProps } from 'react-native-actions-sheet';
 import EStyleSheet from 'react-native-extended-stylesheet';
 import { useIntl } from 'react-intl';
+import { useDispatch } from 'react-redux';
 import { Icon } from '../icon';
 import { UserAvatar } from '../userAvatar';
 import { useAddFavouriteMutation, useGetFavouritesQuery } from '../../providers/queries';
+import { toastNotification } from '../../redux/actions/uiAction';
 
 const FALLBACK_SHEET_ID = 'transfer_favorites';
 
@@ -18,6 +20,7 @@ const TransferFavoritesSheet: React.FC<SheetProps<'transfer_favorites'>> = ({
   payload,
 }) => {
   const intl = useIntl();
+  const dispatch = useDispatch();
   const closedRef = useRef(false);
   const [search, setSearch] = useState('');
   const [isAdding, setIsAdding] = useState(false);
@@ -60,6 +63,14 @@ const TransferFavoritesSheet: React.FC<SheetProps<'transfer_favorites'>> = ({
       refetch();
     } catch (error) {
       console.warn('[TransferFavoritesSheet] Failed to add favorite', error);
+      dispatch(
+        toastNotification(
+          intl.formatMessage({
+            id: 'favorites.add_error',
+            defaultMessage: 'Could not add favorite',
+          }),
+        ),
+      );
     }
   };
 

--- a/src/components/transferFavoritesSheet/transferFavoritesSheet.tsx
+++ b/src/components/transferFavoritesSheet/transferFavoritesSheet.tsx
@@ -79,6 +79,12 @@ const TransferFavoritesSheet: React.FC<SheetProps<'transfer_favorites'>> = ({
             style={styles.iconButton}
             onPress={() => setIsAdding((value) => !value)}
             activeOpacity={0.7}
+            accessibilityRole="button"
+            accessibilityLabel={intl.formatMessage(
+              isAdding
+                ? { id: 'favorites.cancel_add', defaultMessage: 'Cancel adding favorite' }
+                : { id: 'favorites.add', defaultMessage: 'Add a favorite' },
+            )}
           >
             <Icon
               iconType="MaterialCommunityIcons"
@@ -108,6 +114,11 @@ const TransferFavoritesSheet: React.FC<SheetProps<'transfer_favorites'>> = ({
               onPress={_handleAddFavorite}
               activeOpacity={0.7}
               disabled={isAddFavoritePending || !normalizeUsername(newFavorite)}
+              accessibilityRole="button"
+              accessibilityLabel={intl.formatMessage({
+                id: 'favorites.confirm_add',
+                defaultMessage: 'Save favorite',
+              })}
             >
               <Icon iconType="MaterialCommunityIcons" name="check" size={22} color="#fff" />
             </TouchableOpacity>

--- a/src/components/transferFavoritesSheet/transferFavoritesSheet.tsx
+++ b/src/components/transferFavoritesSheet/transferFavoritesSheet.tsx
@@ -1,0 +1,255 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { ActivityIndicator, FlatList, Text, TextInput, TouchableOpacity, View } from 'react-native';
+import ActionSheet, { SheetManager, SheetProps } from 'react-native-actions-sheet';
+import EStyleSheet from 'react-native-extended-stylesheet';
+import { useIntl } from 'react-intl';
+import { Icon } from '../icon';
+import { UserAvatar } from '../userAvatar';
+import { useAddFavouriteMutation, useGetFavouritesQuery } from '../../providers/queries';
+
+const FALLBACK_SHEET_ID = 'transfer_favorites';
+
+const normalizeUsername = (value = '') => value.trim().replace(/^@/, '').toLowerCase();
+
+const getFavoriteUsername = (item: any) => item?.account || '';
+
+const TransferFavoritesSheet: React.FC<SheetProps<'transfer_favorites'>> = ({
+  sheetId,
+  payload,
+}) => {
+  const intl = useIntl();
+  const closedRef = useRef(false);
+  const [search, setSearch] = useState('');
+  const [isAdding, setIsAdding] = useState(false);
+  const [newFavorite, setNewFavorite] = useState('');
+  const { data: favorites = [], isLoading, refetch } = useGetFavouritesQuery(payload?.limit ?? 50);
+  const addFavoriteMutation = useAddFavouriteMutation();
+  const isAddFavoritePending = addFavoriteMutation.isPending;
+
+  useEffect(() => {
+    closedRef.current = false;
+    setSearch('');
+    setIsAdding(false);
+    setNewFavorite('');
+  }, [payload]);
+
+  const filteredFavorites = useMemo(() => {
+    const query = normalizeUsername(search);
+    return favorites
+      .map((item) => getFavoriteUsername(item))
+      .filter(Boolean)
+      .filter((username, index, list) => list.indexOf(username) === index)
+      .filter((username) => !query || username.includes(query));
+  }, [favorites, search]);
+
+  const _close = (username?: string) => {
+    if (closedRef.current) return;
+    closedRef.current = true;
+    SheetManager.hide(sheetId || FALLBACK_SHEET_ID, { payload: username });
+  };
+
+  const _handleAddFavorite = async () => {
+    const username = normalizeUsername(newFavorite);
+    if (!username) return;
+
+    try {
+      await addFavoriteMutation.mutateAsync(username);
+      setSearch(username);
+      setNewFavorite('');
+      setIsAdding(false);
+      refetch();
+    } catch (error) {
+      console.warn('[TransferFavoritesSheet] Failed to add favorite', error);
+    }
+  };
+
+  return (
+    <ActionSheet
+      id={sheetId || FALLBACK_SHEET_ID}
+      gestureEnabled
+      closeOnTouchBackdrop
+      containerStyle={styles.sheetContainer}
+    >
+      <View style={styles.container}>
+        <View style={styles.headerRow}>
+          <Text style={styles.title}>
+            {intl.formatMessage({ id: 'favorites.title', defaultMessage: 'Favorites' })}
+          </Text>
+          <TouchableOpacity
+            style={styles.iconButton}
+            onPress={() => setIsAdding((value) => !value)}
+            activeOpacity={0.7}
+          >
+            <Icon
+              iconType="MaterialCommunityIcons"
+              name={isAdding ? 'close' : 'account-plus-outline'}
+              size={22}
+              color={EStyleSheet.value('$primaryBlue')}
+            />
+          </TouchableOpacity>
+        </View>
+
+        {isAdding && (
+          <View style={styles.addRow}>
+            <TextInput
+              style={styles.input}
+              value={newFavorite}
+              onChangeText={setNewFavorite}
+              placeholder={intl.formatMessage({
+                id: 'transfer.favorite_username_placeholder',
+                defaultMessage: 'Username',
+              })}
+              placeholderTextColor={EStyleSheet.value('$iconColor')}
+              autoCapitalize="none"
+              autoCorrect={false}
+            />
+            <TouchableOpacity
+              style={styles.addButton}
+              onPress={_handleAddFavorite}
+              activeOpacity={0.7}
+              disabled={isAddFavoritePending || !normalizeUsername(newFavorite)}
+            >
+              <Icon iconType="MaterialCommunityIcons" name="check" size={22} color="#fff" />
+            </TouchableOpacity>
+          </View>
+        )}
+
+        <TextInput
+          style={styles.searchInput}
+          value={search}
+          onChangeText={setSearch}
+          placeholder={intl.formatMessage({
+            id: 'favorites.search',
+            defaultMessage: 'Search in favorites',
+          })}
+          placeholderTextColor={EStyleSheet.value('$iconColor')}
+          autoCapitalize="none"
+          autoCorrect={false}
+        />
+
+        {isLoading ? (
+          <View style={styles.loadingContainer}>
+            <ActivityIndicator color={EStyleSheet.value('$primaryBlue')} />
+          </View>
+        ) : (
+          <FlatList
+            data={filteredFavorites}
+            keyExtractor={(item) => `transfer-favorite-${item}`}
+            keyboardShouldPersistTaps="handled"
+            style={styles.list}
+            ListEmptyComponent={
+              <Text style={styles.emptyText}>
+                {intl.formatMessage({
+                  id: 'favorites.empty_list',
+                  defaultMessage: 'No favorites yet',
+                })}
+              </Text>
+            }
+            renderItem={({ item }) => (
+              <TouchableOpacity
+                style={styles.favoriteRow}
+                onPress={() => _close(item)}
+                activeOpacity={0.7}
+              >
+                <UserAvatar username={item} size="medium" noAction />
+                <Text style={styles.favoriteText}>@{item}</Text>
+              </TouchableOpacity>
+            )}
+          />
+        )}
+      </View>
+    </ActionSheet>
+  );
+};
+
+export default TransferFavoritesSheet;
+
+const styles = EStyleSheet.create({
+  sheetContainer: {
+    backgroundColor: '$primaryBackgroundColor',
+    borderTopLeftRadius: 20,
+    borderTopRightRadius: 20,
+  },
+  container: {
+    paddingHorizontal: 20,
+    paddingTop: 16,
+    paddingBottom: 36,
+    minHeight: 360,
+    maxHeight: 560,
+  },
+  headerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: 12,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: '$primaryBlack',
+  },
+  iconButton: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '$primaryLightBackground',
+  },
+  addRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    marginBottom: 10,
+  },
+  input: {
+    flex: 1,
+    minHeight: 44,
+    borderRadius: 10,
+    paddingHorizontal: 12,
+    color: '$primaryBlack',
+    backgroundColor: '$primaryLightBackground',
+  },
+  addButton: {
+    width: 44,
+    height: 44,
+    borderRadius: 10,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '$primaryBlue',
+  },
+  searchInput: {
+    minHeight: 44,
+    borderRadius: 10,
+    paddingHorizontal: 12,
+    color: '$primaryBlack',
+    backgroundColor: '$primaryLightBackground',
+    marginBottom: 12,
+  },
+  loadingContainer: {
+    minHeight: 180,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  list: {
+    maxHeight: 360,
+  },
+  favoriteRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    minHeight: 54,
+    paddingVertical: 8,
+  },
+  favoriteText: {
+    marginLeft: 12,
+    fontSize: 16,
+    fontWeight: '600',
+    color: '$primaryBlack',
+  },
+  emptyText: {
+    paddingVertical: 32,
+    textAlign: 'center',
+    color: '$iconColor',
+    fontSize: 14,
+  },
+});

--- a/src/config/locales/en-US.json
+++ b/src/config/locales/en-US.json
@@ -114,6 +114,7 @@
   },
   "favorites": {
     "add": "Add a favorite",
+    "add_error": "Could not add favorite",
     "cancel_add": "Cancel adding favorite",
     "confirm_add": "Save favorite",
     "empty_list": "Nothing here",

--- a/src/config/locales/en-US.json
+++ b/src/config/locales/en-US.json
@@ -1330,6 +1330,10 @@
     "dropdown_label": "AI Image"
   },
   "transfer": {
+    "favorite_username_placeholder": "Username",
+    "invalid_recipient_qr": "Could not find a username in this QR code.",
+    "one_time": "One Time",
+    "schedule": "Schedule",
     "select_token": "Select Token",
     "powering_down_subheading": "You are currently unstaking.",
     "power_down": "Unstake",

--- a/src/config/locales/en-US.json
+++ b/src/config/locales/en-US.json
@@ -113,6 +113,9 @@
     "attach_poll": "Attach Poll"
   },
   "favorites": {
+    "add": "Add a favorite",
+    "cancel_add": "Cancel adding favorite",
+    "confirm_add": "Save favorite",
     "empty_list": "Nothing here",
     "search": "Search in favorites",
     "load_error": "Could not load favorites",
@@ -1330,9 +1333,12 @@
     "dropdown_label": "AI Image"
   },
   "transfer": {
+    "custom_schedule": "Custom ({hours}h)",
     "favorite_username_placeholder": "Username",
     "invalid_recipient_qr": "Could not find a username in this QR code.",
     "one_time": "One Time",
+    "pick_from_favorites": "Choose recipient from favorites",
+    "scan_qr_recipient": "Scan a QR code for the recipient",
     "schedule": "Schedule",
     "select_token": "Select Token",
     "powering_down_subheading": "You are currently unstaking.",

--- a/src/containers/transferContainer.ts
+++ b/src/containers/transferContainer.ts
@@ -25,6 +25,81 @@ import { fetchTokenBalances } from '../providers/hive-engine/hiveEngine';
 import TransferTypes from '../constants/transferTypes';
 import { fetchSpkMarkets } from '../providers/hive-spk/hiveSpk';
 import TokenLayers from '../constants/tokenLayers';
+
+const normalizeTransferType = (transferType) => {
+  switch (transferType) {
+    case 'transfer_token':
+      return TransferTypes.TRANSFER;
+    case 'withdraw_hive':
+    case 'withdraw_hbd':
+      return TransferTypes.TRANSFER_FROM_SAVINGS;
+    default:
+      return transferType;
+  }
+};
+
+const parseAccountAssetBalance = (value, fundType) => {
+  if (value === undefined || value === null || value === '') {
+    return undefined;
+  }
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : undefined;
+  }
+
+  const parsed = Number(String(value).replace(fundType, '').trim());
+  return Number.isFinite(parsed) ? parsed : undefined;
+};
+
+const getNativeAccountBalance = (account, transferType, fundType) => {
+  if (!account) {
+    return undefined;
+  }
+
+  const normalizedTransferType = normalizeTransferType(transferType);
+
+  if (fundType === 'HIVE') {
+    if (normalizedTransferType === TransferTypes.TRANSFER_FROM_SAVINGS) {
+      return parseAccountAssetBalance(
+        get(account, 'savings_balance') ?? get(account, 'savingBalance'),
+        fundType,
+      );
+    }
+
+    if (
+      normalizedTransferType === TransferTypes.TRANSFER ||
+      normalizedTransferType === TransferTypes.RECURRENT_TRANSFER ||
+      normalizedTransferType === TransferTypes.TRANSFER_TO_SAVINGS ||
+      normalizedTransferType === TransferTypes.TRANSFER_TO_VESTING ||
+      transferType === 'purchase_estm'
+    ) {
+      return parseAccountAssetBalance(get(account, 'balance'), fundType);
+    }
+  }
+
+  if (fundType === 'HBD') {
+    if (normalizedTransferType === TransferTypes.TRANSFER_FROM_SAVINGS) {
+      return parseAccountAssetBalance(
+        get(account, 'savings_hbd_balance') ?? get(account, 'savingBalanceHbd'),
+        fundType,
+      );
+    }
+
+    if (
+      normalizedTransferType === TransferTypes.TRANSFER ||
+      normalizedTransferType === TransferTypes.RECURRENT_TRANSFER ||
+      normalizedTransferType === TransferTypes.CONVERT ||
+      normalizedTransferType === TransferTypes.TRANSFER_TO_SAVINGS ||
+      transferType === 'purchase_estm'
+    ) {
+      return parseAccountAssetBalance(
+        get(account, 'hbd_balance') ?? get(account, 'hbdBalance'),
+        fundType,
+      );
+    }
+  }
+
+  return undefined;
+};
 /*
  *            Props Name        Description                                     Value
  *@props -->  props name here   description here                                Value Type Here
@@ -34,16 +109,24 @@ import TokenLayers from '../constants/tokenLayers';
 class TransferContainer extends Component {
   constructor(props) {
     super(props);
+    const routeParams = props.route.params ?? {};
+    const transferType = normalizeTransferType(routeParams.transferType ?? '');
+    const fundType = routeParams.fundType ?? '';
+    const initialBalance =
+      routeParams.balance ??
+      getNativeAccountBalance(props.currentAccount, transferType, fundType) ??
+      '';
+
     this.state = {
-      fundType: props.route.params?.fundType ?? '',
-      balance: props.route.params?.balance ?? '',
-      tokenAddress: props.route.params?.tokenAddress ?? '',
-      transferType: props.route.params?.transferType ?? '',
-      referredUsername: props.route.params?.referredUsername,
+      fundType,
+      balance: initialBalance,
+      tokenAddress: routeParams.tokenAddress ?? '',
+      transferType,
+      referredUsername: routeParams.referredUsername,
       selectedAccount: props.currentAccount,
       spkMarkets: [],
-      initialAmount: props.route.params?.initialAmount,
-      initialMemo: props.route.params?.initialMemo,
+      initialAmount: routeParams.initialAmount,
+      initialMemo: routeParams.initialMemo,
       recurrentTransfers: [],
       tokenPrecision: undefined,
     };
@@ -79,14 +162,17 @@ class TransferContainer extends Component {
       });
   };
 
-  fetchBalance = (username) => {
+  fetchBalance = async (username) => {
     const { fundType, transferType, tokenAddress } = this.state;
 
     // Fetch account using SDK
     const queryClient = getQueryClient();
 
-    queryClient.fetchQuery(getAccountsQueryOptions([username])).then(async (accounts) => {
-      const account = accounts[0];
+    try {
+      const accountQuery = getAccountsQueryOptions([username]);
+      await queryClient.invalidateQueries({ queryKey: accountQuery.queryKey, exact: true });
+      const accounts = await queryClient.fetchQuery(accountQuery);
+      const account = accounts?.[0] ?? {};
       let balance;
       let enginePrecision;
 
@@ -117,31 +203,9 @@ class TransferContainer extends Component {
         });
         this.setState({ tokenPrecision: enginePrecision });
       } else {
-        if (
-          (transferType === 'purchase_estm' || transferType === 'transfer_token') &&
-          fundType === 'HIVE'
-        ) {
-          balance = account.balance.replace(fundType, '');
-        }
-        if (
-          (transferType === 'purchase_estm' ||
-            transferType === 'convert' ||
-            transferType === 'transfer_token') &&
-          fundType === 'HBD'
-        ) {
-          balance = account.hbd_balance.replace(fundType, '');
-        }
+        balance = getNativeAccountBalance(account, transferType, fundType);
         if (transferType === TransferTypes.ECENCY_POINT_TRANSFER && fundType === 'POINT') {
           this._getUserPointsBalance(username);
-        }
-        if (transferType === TransferTypes.TRANSFER_TO_SAVINGS && fundType === 'HIVE') {
-          balance = account.balance.replace(fundType, '');
-        }
-        if (transferType === 'transfer_to_savings' && fundType === 'HBD') {
-          balance = account.hbd_balance.replace(fundType, '');
-        }
-        if (transferType === 'transfer_to_vesting' && fundType === 'HIVE') {
-          balance = account.balance.replace(fundType, '');
         }
         if (transferType === 'address_view' && fundType === 'BTC') {
           // TODO implement transfer of custom tokens
@@ -151,14 +215,27 @@ class TransferContainer extends Component {
 
       const local = await getUserDataWithUsername(username);
 
-      if (balance) {
-        this.setState({ balance: Number(balance) });
+      // Drop the result if the user switched fund type while this request was in
+      // flight, so a stale fundType's balance can't clobber the newer selection.
+      if (this.state.fundType !== fundType) {
+        return;
+      }
+
+      // An empty/missing account yields `undefined` here (handled above), so a
+      // freshly-fetched 0 is a real on-chain balance and must be honored.
+      if (balance !== undefined && balance !== null && balance !== '') {
+        const nextBalance = Number(balance);
+        if (Number.isFinite(nextBalance)) {
+          this.setState({ balance: nextBalance });
+        }
       }
 
       this.setState({
         selectedAccount: { ...account, local: local[0] },
       });
-    });
+    } catch (error) {
+      console.warn('[TransferContainer] Failed to fetch transfer balance', error);
+    }
   };
 
   _fetchSpkMarkets = async () => {
@@ -193,6 +270,7 @@ class TransferContainer extends Component {
     // Also update route params so _transferToAccount picks up the new fundType
     if (this.props.route?.params) {
       this.props.route.params.fundType = newFundType;
+      this.props.route.params.balance = undefined;
     }
   };
 
@@ -209,6 +287,9 @@ class TransferContainer extends Component {
       // Re-invalidate portfolio as safety net for blockchain propagation
       queryClient.invalidateQueries({
         queryKey: ['wallet', 'portfolio', 'v2', currentAccount.name],
+      });
+      queryClient.invalidateQueries({
+        queryKey: getAccountsQueryOptions([currentAccount.name]).queryKey,
       });
 
       // Invalidate secondary data (lazy refetch on next view)
@@ -243,19 +324,18 @@ class TransferContainer extends Component {
     memo,
     recurrence = null,
     executions = 0,
+    overrideTransferType = null,
   ) => {
     const { navigation, dispatch, intl, route, mutations } = this.props;
 
-    let transferType = route.params?.transferType ?? '';
+    const transferType = normalizeTransferType(
+      overrideTransferType ?? route.params?.transferType ?? '',
+    );
     const fundType = route.params?.fundType ?? '';
     let tokenLayer = route.params?.assetLayer ?? route.params?.tokenLayer ?? '';
 
-    // Normalize transfer_token to standard transfer type and default layer
-    if (transferType === 'transfer_token') {
-      transferType = TransferTypes.TRANSFER;
-      if (!tokenLayer && (fundType === 'HIVE' || fundType === 'HBD')) {
-        tokenLayer = TokenLayers.HIVE;
-      }
+    if (!tokenLayer && (fundType === 'HIVE' || fundType === 'HBD')) {
+      tokenLayer = TokenLayers.HIVE;
     }
 
     const data: any = { from, destination, amount, memo, fundType };
@@ -629,11 +709,12 @@ class TransferContainer extends Component {
     } = this.state;
 
     const rawTransferType = route.params?.transferType ?? '';
-    // Normalize legacy 'transfer_token' so the screen sees TRANSFER for memo/UI gates,
-    // while the submit path still re-normalizes from raw route params.
-    const transferType =
-      rawTransferType === 'transfer_token' ? TransferTypes.TRANSFER : rawTransferType;
-    const tokenLayer = route.params?.assetLayer ?? route.params?.tokenLayer ?? '';
+    // Normalize legacy route aliases so the screen and submit path use operation names.
+    const transferType = normalizeTransferType(rawTransferType);
+    const tokenLayer =
+      route.params?.assetLayer ??
+      route.params?.tokenLayer ??
+      (fundType === 'HIVE' || fundType === 'HBD' ? TokenLayers.HIVE : '');
 
     return (
       children &&

--- a/src/containers/transferContainer.ts
+++ b/src/containers/transferContainer.ts
@@ -152,6 +152,11 @@ class TransferContainer extends Component {
   _getUserPointsBalance = async (username) => {
     await getPointsSummary(username)
       .then((userPoints) => {
+        // Ignore a late points response if the fund type changed while it was in
+        // flight, so it can't clobber the newly-selected asset's balance.
+        if (this.state.fundType !== 'POINT') {
+          return;
+        }
         const balance = Math.round(Number(get(userPoints, 'points', 0)) * 1000) / 1000;
         this.setState({ balance });
       })

--- a/src/containers/transferContainer.ts
+++ b/src/containers/transferContainer.ts
@@ -25,81 +25,8 @@ import { fetchTokenBalances } from '../providers/hive-engine/hiveEngine';
 import TransferTypes from '../constants/transferTypes';
 import { fetchSpkMarkets } from '../providers/hive-spk/hiveSpk';
 import TokenLayers from '../constants/tokenLayers';
+import { normalizeTransferType, getNativeAccountBalance } from '../utils/transferBalance';
 
-const normalizeTransferType = (transferType) => {
-  switch (transferType) {
-    case 'transfer_token':
-      return TransferTypes.TRANSFER;
-    case 'withdraw_hive':
-    case 'withdraw_hbd':
-      return TransferTypes.TRANSFER_FROM_SAVINGS;
-    default:
-      return transferType;
-  }
-};
-
-const parseAccountAssetBalance = (value, fundType) => {
-  if (value === undefined || value === null || value === '') {
-    return undefined;
-  }
-  if (typeof value === 'number') {
-    return Number.isFinite(value) ? value : undefined;
-  }
-
-  const parsed = Number(String(value).replace(fundType, '').trim());
-  return Number.isFinite(parsed) ? parsed : undefined;
-};
-
-const getNativeAccountBalance = (account, transferType, fundType) => {
-  if (!account) {
-    return undefined;
-  }
-
-  const normalizedTransferType = normalizeTransferType(transferType);
-
-  if (fundType === 'HIVE') {
-    if (normalizedTransferType === TransferTypes.TRANSFER_FROM_SAVINGS) {
-      return parseAccountAssetBalance(
-        get(account, 'savings_balance') ?? get(account, 'savingBalance'),
-        fundType,
-      );
-    }
-
-    if (
-      normalizedTransferType === TransferTypes.TRANSFER ||
-      normalizedTransferType === TransferTypes.RECURRENT_TRANSFER ||
-      normalizedTransferType === TransferTypes.TRANSFER_TO_SAVINGS ||
-      normalizedTransferType === TransferTypes.TRANSFER_TO_VESTING ||
-      transferType === 'purchase_estm'
-    ) {
-      return parseAccountAssetBalance(get(account, 'balance'), fundType);
-    }
-  }
-
-  if (fundType === 'HBD') {
-    if (normalizedTransferType === TransferTypes.TRANSFER_FROM_SAVINGS) {
-      return parseAccountAssetBalance(
-        get(account, 'savings_hbd_balance') ?? get(account, 'savingBalanceHbd'),
-        fundType,
-      );
-    }
-
-    if (
-      normalizedTransferType === TransferTypes.TRANSFER ||
-      normalizedTransferType === TransferTypes.RECURRENT_TRANSFER ||
-      normalizedTransferType === TransferTypes.CONVERT ||
-      normalizedTransferType === TransferTypes.TRANSFER_TO_SAVINGS ||
-      transferType === 'purchase_estm'
-    ) {
-      return parseAccountAssetBalance(
-        get(account, 'hbd_balance') ?? get(account, 'hbdBalance'),
-        fundType,
-      );
-    }
-  }
-
-  return undefined;
-};
 /*
  *            Props Name        Description                                     Value
  *@props -->  props name here   description here                                Value Type Here

--- a/src/containers/walletContainer.ts
+++ b/src/containers/walletContainer.ts
@@ -26,6 +26,8 @@ import { getEstimatedAmount } from '../utils/vote';
 // Constants
 import ROUTES from '../constants/routeNames';
 import { ASSET_IDS } from '../constants/defaultAssets';
+import TransferTypes from '../constants/transferTypes';
+import TokenLayers from '../constants/tokenLayers';
 
 const HIVE_DROPDOWN = [
   'purchase_estm',
@@ -270,17 +272,27 @@ const WalletContainer = ({
 
   const _navigate = async (transferType, fundType) => {
     let balance;
+    let normalizedTransferType = transferType;
+    const isNativeAsset = fundType === 'HIVE' || fundType === 'HBD';
+
+    if (transferType === 'withdraw_hive' || transferType === 'withdraw_hbd') {
+      normalizedTransferType = TransferTypes.TRANSFER_FROM_SAVINGS;
+    }
 
     if (
-      (transferType === 'transfer_token' || transferType === 'purchase_estm') &&
+      (transferType === 'transfer_token' ||
+        transferType === 'purchase_estm' ||
+        transferType === TransferTypes.TRANSFER_TO_SAVINGS ||
+        transferType === TransferTypes.TRANSFER_TO_VESTING) &&
       fundType === 'HIVE'
     ) {
       balance = Math.round(walletData.balance * 1000) / 1000;
     }
     if (
       (transferType === 'transfer_token' ||
-        transferType === 'convert' ||
-        transferType === 'purchase_estm') &&
+        transferType === TransferTypes.CONVERT ||
+        transferType === 'purchase_estm' ||
+        transferType === TransferTypes.TRANSFER_TO_SAVINGS) &&
       fundType === 'HBD'
     ) {
       balance = Math.round(walletData.hbdBalance * 1000) / 1000;
@@ -292,18 +304,26 @@ const WalletContainer = ({
       balance = Math.round(walletData.savingBalanceHbd * 1000) / 1000;
     }
 
+    const navigateParams = {
+      transferType: normalizedTransferType,
+      fundType,
+      balance,
+      tokenAddress,
+      ...(isNativeAsset ? { assetLayer: TokenLayers.HIVE } : {}),
+    };
+
     if (isPinCodeOpen) {
       RootNavigation.navigate({
         name: ROUTES.SCREENS.PINCODE,
         params: {
           navigateTo: ROUTES.SCREENS.TRANSFER,
-          navigateParams: { transferType, fundType, balance, tokenAddress },
+          navigateParams,
         },
       });
     } else {
       RootNavigation.navigate({
         name: ROUTES.SCREENS.TRANSFER,
-        params: { transferType, fundType, balance, tokenAddress },
+        params: navigateParams,
       });
     }
   };

--- a/src/containers/walletContainer.ts
+++ b/src/containers/walletContainer.ts
@@ -28,6 +28,7 @@ import ROUTES from '../constants/routeNames';
 import { ASSET_IDS } from '../constants/defaultAssets';
 import TransferTypes from '../constants/transferTypes';
 import TokenLayers from '../constants/tokenLayers';
+import { normalizeTransferType } from '../utils/transferBalance';
 
 const HIVE_DROPDOWN = [
   'purchase_estm',
@@ -272,12 +273,8 @@ const WalletContainer = ({
 
   const _navigate = async (transferType, fundType) => {
     let balance;
-    let normalizedTransferType = transferType;
+    const normalizedTransferType = normalizeTransferType(transferType);
     const isNativeAsset = fundType === 'HIVE' || fundType === 'HBD';
-
-    if (transferType === 'withdraw_hive' || transferType === 'withdraw_hbd') {
-      normalizedTransferType = TransferTypes.TRANSFER_FROM_SAVINGS;
-    }
 
     if (
       (transferType === 'transfer_token' ||

--- a/src/hooks/useTransferMutations.ts
+++ b/src/hooks/useTransferMutations.ts
@@ -45,6 +45,7 @@ export function useTransferMutations() {
     return username;
   };
   const getWalletInvalidationKeys = (account: string) => [
+    QueryKeys.accounts.list(account),
     QueryKeys.accounts.full(account),
     ['ecency-wallets', 'asset-info', account],
     ['wallet', 'portfolio', 'v2', account],

--- a/src/navigation/sheets.tsx
+++ b/src/navigation/sheets.tsx
@@ -15,6 +15,7 @@ import {
   EmojiPickerSheet,
   AuthUpgradeSheet,
   AiAssistModal,
+  TransferFavoritesSheet,
 } from '../components';
 import { ShareIntentSheet } from '../components/shareIntentSheet';
 import SignConfirmSheet from '../screens/dappBrowser/components/signConfirmSheet';
@@ -45,6 +46,7 @@ export enum SheetNames {
   SIGN_CONFIRM = 'sign_confirm',
   RECEIVE_QR = 'receive_qr',
   BALANCE_ANALYTICS = 'balance_analytics',
+  TRANSFER_FAVORITES = 'transfer_favorites',
 }
 
 registerSheet(SheetNames.POST_TRANSLATION, PostTranslationModal);
@@ -67,6 +69,7 @@ registerSheet(SheetNames.SHARE_INTENT, ShareIntentSheet);
 registerSheet(SheetNames.SIGN_CONFIRM, SignConfirmSheet);
 registerSheet(SheetNames.RECEIVE_QR, ReceiveQrSheet);
 registerSheet(SheetNames.BALANCE_ANALYTICS, BalanceAnalyticsSheet);
+registerSheet(SheetNames.TRANSFER_FAVORITES, TransferFavoritesSheet);
 
 // We extend some of the types here to give us great intellisense
 // across the app for all registered sheets.
@@ -99,7 +102,12 @@ declare module 'react-native-actions-sheet' {
       returnValue: string | undefined;
     }>;
     [SheetNames.ACCOUNTS_SHEET]: SheetDefinition;
-    [SheetNames.QR_SCAN]: SheetDefinition;
+    [SheetNames.QR_SCAN]: SheetDefinition<{
+      payload?: {
+        onScan?: (value: string) => void;
+      };
+      returnValue: string | undefined;
+    }>;
     [SheetNames.CHAT_OPTIONS]: SheetDefinition<{
       payload: {
         post: any;
@@ -199,6 +207,12 @@ declare module 'react-native-actions-sheet' {
         coinType: string;
         username: string;
       };
+    }>;
+    [SheetNames.TRANSFER_FAVORITES]: SheetDefinition<{
+      payload?: {
+        limit?: number;
+      };
+      returnValue: string | undefined;
     }>;
   }
 }

--- a/src/screens/assetDetails/children/coinSummary.tsx
+++ b/src/screens/assetDetails/children/coinSummary.tsx
@@ -9,6 +9,7 @@ import { DataPair } from '../../../redux/reducers/walletReducer';
 import { selectCurrency } from '../../../redux/selectors';
 import { HorizontalIconList } from '../../../components';
 import POINTS, { POINTS_KEYS } from '../../../constants/options/points';
+import TransferTypes from '../../../constants/transferTypes';
 
 export interface CoinSummaryProps {
   tokenSymbol: string;
@@ -112,6 +113,7 @@ export const CoinSummary = ({
         ? actions
             .map((action: any) => (typeof action === 'string' ? action : action?.id))
             .filter((action): action is string => Boolean(action))
+            .filter((action) => action !== TransferTypes.RECURRENT_TRANSFER)
         : [],
     [actions],
   );

--- a/src/screens/transfer/screen/transferRecipientParser.test.ts
+++ b/src/screens/transfer/screen/transferRecipientParser.test.ts
@@ -40,6 +40,22 @@ describe('extractUsernameFromScannedValue', () => {
       expect(extractUsernameFromScannedValue(uri)).toBe('bob');
     });
 
+    it('extracts the recipient from a transfer_to_savings op', () => {
+      const uri = encode([
+        'transfer_to_savings',
+        { from: '__signer', to: 'savings-user', amount: '1.000 HIVE', memo: '' },
+      ]);
+      expect(extractUsernameFromScannedValue(uri)).toBe('savings-user');
+    });
+
+    it('extracts the recipient from a transfer_to_vesting op', () => {
+      const uri = encode([
+        'transfer_to_vesting',
+        { from: '__signer', to: 'vesting-user', amount: '1.000 HIVE' },
+      ]);
+      expect(extractUsernameFromScannedValue(uri)).toBe('vesting-user');
+    });
+
     it('does NOT mine a recipient from create_proposal.receiver', () => {
       const uri = encode([
         'create_proposal',

--- a/src/screens/transfer/screen/transferRecipientParser.test.ts
+++ b/src/screens/transfer/screen/transferRecipientParser.test.ts
@@ -1,0 +1,100 @@
+import * as hiveuri from 'hive-uri';
+import {
+  normalizeScannedUsername,
+  extractUsernameFromScannedValue,
+} from './transferRecipientParser';
+
+const encode = (op: [string, Record<string, any>]) => hiveuri.encodeOps([op]);
+
+describe('normalizeScannedUsername', () => {
+  it('trims, strips a leading @, and lowercases', () => {
+    expect(normalizeScannedUsername('  @Alice ')).toBe('alice');
+    expect(normalizeScannedUsername('BOB')).toBe('bob');
+    expect(normalizeScannedUsername(undefined)).toBe('');
+  });
+});
+
+describe('extractUsernameFromScannedValue', () => {
+  describe('hive-uri operations', () => {
+    it('extracts the recipient from a transfer op', () => {
+      const uri = encode([
+        'transfer',
+        { from: '__signer', to: 'alice', amount: '1.000 HIVE', memo: '' },
+      ]);
+      expect(extractUsernameFromScannedValue(uri)).toBe('alice');
+    });
+
+    it('extracts the recipient from a recurrent_transfer op', () => {
+      const uri = encode([
+        'recurrent_transfer',
+        {
+          from: '__signer',
+          to: 'bob',
+          amount: '1.000 HIVE',
+          memo: '',
+          recurrence: 24,
+          executions: 2,
+          extensions: [],
+        },
+      ]);
+      expect(extractUsernameFromScannedValue(uri)).toBe('bob');
+    });
+
+    it('does NOT mine a recipient from create_proposal.receiver', () => {
+      const uri = encode([
+        'create_proposal',
+        {
+          creator: '__signer',
+          receiver: 'attacker',
+          start_date: '2020-01-01T00:00:00',
+          end_date: '2020-02-01T00:00:00',
+          daily_pay: '1.000 HBD',
+          subject: 'x',
+          permlink: 'y',
+          extensions: [],
+        },
+      ]);
+      expect(extractUsernameFromScannedValue(uri)).toBe('');
+    });
+
+    it('does NOT mine a recipient from account_witness_vote.account', () => {
+      const uri = encode([
+        'account_witness_vote',
+        { account: '__signer', witness: 'attacker', approve: true },
+      ]);
+      expect(extractUsernameFromScannedValue(uri)).toBe('');
+    });
+
+    it('ignores an unresolved __signer placeholder in the recipient field', () => {
+      const uri = encode([
+        'transfer',
+        { from: 'alice', to: '__signer', amount: '1.000 HIVE', memo: '' },
+      ]);
+      expect(extractUsernameFromScannedValue(uri)).toBe('');
+    });
+  });
+
+  describe('non hive-uri values', () => {
+    it('reads ?to= / ?username= / ?account= query params', () => {
+      expect(extractUsernameFromScannedValue('https://ecency.com/transfer?to=Alice')).toBe('alice');
+      expect(extractUsernameFromScannedValue('app://x?username=bob&amount=1')).toBe('bob');
+      expect(extractUsernameFromScannedValue('?account=%40carol')).toBe('carol');
+    });
+
+    it('reads a profile/path username', () => {
+      expect(extractUsernameFromScannedValue('https://ecency.com/@dave')).toBe('dave');
+      expect(extractUsernameFromScannedValue('https://hive.blog/profile/eve')).toBe('eve');
+    });
+
+    it('accepts a bare valid username', () => {
+      expect(extractUsernameFromScannedValue('frank')).toBe('frank');
+      expect(extractUsernameFromScannedValue('@Grace')).toBe('grace');
+    });
+
+    it('rejects values that are not a plausible username', () => {
+      expect(extractUsernameFromScannedValue('ab')).toBe('');
+      expect(extractUsernameFromScannedValue('this-name-is-way-too-long')).toBe('');
+      expect(extractUsernameFromScannedValue('not a username!')).toBe('');
+    });
+  });
+});

--- a/src/screens/transfer/screen/transferRecipientParser.ts
+++ b/src/screens/transfer/screen/transferRecipientParser.ts
@@ -1,0 +1,58 @@
+import { get } from 'lodash';
+import * as hiveuri from 'hive-uri';
+
+// Hive operations whose payload carries a genuine fund recipient, mapped to the field
+// that holds it. A QR is only allowed to seed a recipient from one of these — never
+// from the first op of an arbitrary type (e.g. create_proposal.receiver,
+// account_witness_vote.account), which would let a non-payment QR pre-fill an
+// attacker-chosen account.
+const RECIPIENT_OP_FIELDS: Record<string, string> = {
+  transfer: 'to',
+  recurrent_transfer: 'to',
+  transfer_to_savings: 'to',
+  transfer_to_vesting: 'to',
+};
+
+export const normalizeScannedUsername = (value?: string) =>
+  (value || '').trim().replace(/^@/, '').toLowerCase();
+
+export const extractUsernameFromScannedValue = (value: string) => {
+  const scannedValue = value.trim();
+
+  try {
+    const decoded = hiveuri.decode(scannedValue);
+    const operation = get(decoded, 'tx.operations[0]', []);
+    const operationName = Array.isArray(operation) ? operation[0] : null;
+    const operationPayload = Array.isArray(operation) ? operation[1] : null;
+    const recipientField = operationName ? RECIPIENT_OP_FIELDS[operationName] : undefined;
+    if (recipientField) {
+      const username = get(operationPayload, recipientField);
+      // hive-uri leaves unresolved placeholders (e.g. the signer slot) literal, so a
+      // raw '__signer' is never a real recipient.
+      if (username && username !== '__signer') {
+        return normalizeScannedUsername(username);
+      }
+    }
+  } catch {
+    // Non hive-uri QR values are handled below.
+  }
+
+  const queryMatch = scannedValue.match(/[?&](?:to|username|account)=([^&#]+)/i);
+  if (queryMatch?.[1]) {
+    try {
+      return normalizeScannedUsername(decodeURIComponent(queryMatch[1]));
+    } catch {
+      return normalizeScannedUsername(queryMatch[1]);
+    }
+  }
+
+  const profileMatch =
+    scannedValue.match(/(?:^|\/)@([a-z0-9.-]+)/i) ||
+    scannedValue.match(/(?:^|\/)(?:profile|user|account)\/([a-z0-9.-]+)/i);
+  if (profileMatch?.[1]) {
+    return normalizeScannedUsername(profileMatch[1]);
+  }
+
+  const username = normalizeScannedUsername(scannedValue);
+  return /^[a-z0-9.-]{3,16}$/.test(username) ? username : '';
+};

--- a/src/screens/transfer/screen/transferScreen.tsx
+++ b/src/screens/transfer/screen/transferScreen.tsx
@@ -212,8 +212,7 @@ const TransferView = ({
   // Token switching is only available for basic transfers
   const canSwitchToken =
     !!setFundType &&
-    (oneTimeTransferType === 'transfer_token' ||
-      oneTimeTransferType === TransferTypes.TRANSFER ||
+    (oneTimeTransferType === TransferTypes.TRANSFER ||
       transferType === TransferTypes.RECURRENT_TRANSFER) &&
     isNativeTokenLayer;
   const canScheduleTransfer =
@@ -615,7 +614,7 @@ const TransferView = ({
     } else if (effectiveTransferType === TransferTypes.TRANSFER_FROM_SAVINGS) {
       path = `sign/transfer_from_savings?from=${from}&to=${destination}&amount=${encodeURIComponent(
         hsNativeAmount,
-      )}&request_id=${new Date().getTime() >>> 0}`;
+      )}&memo=${encodeURIComponent(memo ?? '')}&request_id=${new Date().getTime() >>> 0}`;
     } else if (effectiveTransferType === TransferTypes.CONVERT) {
       path = `sign/convert?owner=${from}&amount=${encodeURIComponent(hsNativeAmount)}&requestid=${
         new Date().getTime() >>> 0
@@ -743,6 +742,17 @@ const TransferView = ({
     },
     [isRecurrentTransfer, recurrentTransfers],
   );
+
+  // When Schedule is enabled after a recipient is already validated, hydrate any
+  // existing on-chain recurrent transfer for that recipient. The username-validation
+  // autofill only runs while already in scheduled mode, so a user who picks the
+  // recipient first and toggles Schedule afterwards would otherwise see the existing
+  // schedule's executions/start date stay blank.
+  useEffect(() => {
+    if (isRecurrentTransfer && isUsernameValid && destination && !allowMultipleDest) {
+      _findRecurrentTransferOfUser(destination);
+    }
+  }, [isRecurrentTransfer, recurrentTransfers]);
 
   const badActorUsername = useMemo(() => {
     if (!destination || !badActors) return null;

--- a/src/screens/transfer/screen/transferScreen.tsx
+++ b/src/screens/transfer/screen/transferScreen.tsx
@@ -29,12 +29,62 @@ import { EngineActions } from '../../../providers/hive-engine/hiveEngine.types';
 import { toastNotification } from '../../../redux/actions/uiAction';
 import { dateToFormatted } from '../../../utils/time';
 
+const normalizeScannedUsername = (value?: string) =>
+  (value || '').trim().replace(/^@/, '').toLowerCase();
+
+const extractUsernameFromScannedValue = (value: string) => {
+  const scannedValue = value.trim();
+
+  try {
+    const decoded = hiveuri.decode(scannedValue);
+    const operation = get(decoded, 'tx.operations[0]', []);
+    const operationPayload = Array.isArray(operation) ? operation[1] : null;
+    const username =
+      get(operationPayload, 'to') ||
+      get(operationPayload, 'receiver') ||
+      get(operationPayload, 'username') ||
+      get(operationPayload, 'account');
+    if (username) {
+      return normalizeScannedUsername(username);
+    }
+  } catch {
+    // Non hive-uri QR values are handled below.
+  }
+
+  const queryMatch = scannedValue.match(/[?&](?:to|username|account)=([^&#]+)/i);
+  if (queryMatch?.[1]) {
+    try {
+      return normalizeScannedUsername(decodeURIComponent(queryMatch[1]));
+    } catch {
+      return normalizeScannedUsername(queryMatch[1]);
+    }
+  }
+
+  const profileMatch =
+    scannedValue.match(/(?:^|\/)@([a-z0-9.-]+)/i) ||
+    scannedValue.match(/(?:^|\/)(?:profile|user|account)\/([a-z0-9.-]+)/i);
+  if (profileMatch?.[1]) {
+    return normalizeScannedUsername(profileMatch[1]);
+  }
+
+  const username = normalizeScannedUsername(scannedValue);
+  return /^[a-z0-9.-]{3,16}$/.test(username) ? username : '';
+};
+
 interface TransferViewProps {
   currentAccountName: string;
   transferType: string;
   getAccountsWithUsername: (username: string) => any;
   balance: number | string;
-  transferToAccount: (params: any) => void;
+  transferToAccount: (
+    from: string,
+    destination: string,
+    amount: string | number,
+    memo?: string,
+    recurrence?: string | number | null,
+    executions?: string | number | null,
+    transferType?: string,
+  ) => void;
   accountType: string;
   accounts: any[];
   handleOnModalClose: () => void;
@@ -45,7 +95,7 @@ interface TransferViewProps {
   referredUsername?: string;
   initialAmount?: string | number;
   initialMemo?: string;
-  fetchRecurrentTransfers?: () => void;
+  fetchRecurrentTransfers?: (username: string) => void;
   recurrentTransfers?: any;
   tokenLayer?: string;
   tokenPrecision?: number;
@@ -103,6 +153,9 @@ const TransferView = ({
   const [recurrence, setRecurrence] = useState('');
   const [executions, setExecutions] = useState('');
   const [startDate, setStartDate] = useState('');
+  const [isScheduledTransfer, setIsScheduledTransfer] = useState(
+    transferType === TransferTypes.RECURRENT_TRANSFER,
+  );
 
   const [isUsernameValid, setIsUsernameValid] = useState(false);
   const [usersResult, setUsersResult] = useState<string[]>([]);
@@ -113,12 +166,17 @@ const TransferView = ({
   const hasInitializedRef = useRef(false);
   const dpRef = useRef();
 
-  const isRecurrentTransfer = transferType === TransferTypes.RECURRENT_TRANSFER;
+  const oneTimeTransferType =
+    transferType === TransferTypes.RECURRENT_TRANSFER ? TransferTypes.TRANSFER : transferType;
+  const isRecurrentTransfer = isScheduledTransfer;
+  const effectiveTransferType = isRecurrentTransfer
+    ? TransferTypes.RECURRENT_TRANSFER
+    : oneTimeTransferType;
   const isEngineToken = tokenLayer === TokenLayers.ENGINE;
   const isSpkToken = tokenLayer === TokenLayers.SPK;
 
   const destinationLocked = useMemo(() => {
-    switch (transferType) {
+    switch (oneTimeTransferType) {
       case TransferTypes.CONVERT:
       case TransferTypes.UNSTAKE:
       case TransferTypes.POWER_UP_SPK:
@@ -127,30 +185,50 @@ const TransferView = ({
       default:
         return false;
     }
-  }, [transferType]);
+  }, [oneTimeTransferType]);
 
   const allowMultipleDest =
-    (tokenLayer === TokenLayers.HIVE && transferType === TransferTypes.TRANSFER) ||
-    (tokenLayer === TokenLayers.POINTS && transferType === TransferTypes.ECENCY_POINT_TRANSFER) ||
-    (tokenLayer === TokenLayers.ENGINE && transferType === TransferTypes.TRANSFER);
+    !isRecurrentTransfer &&
+    ((tokenLayer === TokenLayers.HIVE && effectiveTransferType === TransferTypes.TRANSFER) ||
+      (tokenLayer === TokenLayers.POINTS &&
+        effectiveTransferType === TransferTypes.ECENCY_POINT_TRANSFER) ||
+      (tokenLayer === TokenLayers.ENGINE && effectiveTransferType === TransferTypes.TRANSFER));
 
   const showMemo =
-    transferType === TransferTypes.ECENCY_POINT_TRANSFER ||
-    transferType === TransferTypes.TRANSFER ||
-    transferType === TransferTypes.RECURRENT_TRANSFER ||
-    transferType === TransferTypes.TRANSFER_TO_SAVINGS ||
-    transferType === TransferTypes.TRANSFER_SPK ||
-    transferType === TransferTypes.TRANSFER_LARYNX;
+    effectiveTransferType === TransferTypes.ECENCY_POINT_TRANSFER ||
+    effectiveTransferType === TransferTypes.TRANSFER ||
+    effectiveTransferType === TransferTypes.RECURRENT_TRANSFER ||
+    effectiveTransferType === TransferTypes.TRANSFER_TO_SAVINGS ||
+    effectiveTransferType === TransferTypes.TRANSFER_SPK ||
+    effectiveTransferType === TransferTypes.TRANSFER_LARYNX;
 
   const displayFundType = fundType === 'POINT' ? 'Points' : fundType;
+  const isNativeTokenLayer = !tokenLayer || tokenLayer === TokenLayers.HIVE;
+  // Balance is '' (or nullish) while the container is fetching/refetching it; treat
+  // that as a loading state rather than a usable 0 so the amount field stays usable
+  // and no false low-liquidity alert fires before the real balance arrives.
+  const isBalanceLoading = balance === '' || balance === undefined || balance === null;
 
   // Token switching is only available for basic transfers
   const canSwitchToken =
     !!setFundType &&
-    (transferType === 'transfer_token' ||
-      transferType === TransferTypes.TRANSFER ||
+    (oneTimeTransferType === 'transfer_token' ||
+      oneTimeTransferType === TransferTypes.TRANSFER ||
       transferType === TransferTypes.RECURRENT_TRANSFER) &&
-    !tokenLayer;
+    isNativeTokenLayer;
+  const canScheduleTransfer =
+    isNativeTokenLayer &&
+    (oneTimeTransferType === TransferTypes.TRANSFER ||
+      transferType === TransferTypes.RECURRENT_TRANSFER) &&
+    (fundType === 'HIVE' || fundType === 'HBD');
+
+  const scheduleOptions = useMemo(
+    () => [
+      intl.formatMessage({ id: 'transfer.one_time', defaultMessage: 'One Time' }),
+      ...RECURRENCE_TYPES.map((item) => intl.formatMessage({ id: item.intlId })),
+    ],
+    [intl],
+  );
 
   const [showTokenPicker, setShowTokenPicker] = useState(false);
   const transferableTokens = ['HIVE', 'HBD'];
@@ -247,20 +325,23 @@ const TransferView = ({
   }, [destination, allowMultipleDest, _debouncedValidateUsername]);
 
   // --- Handlers ---
-  const _handleDestinationChange = (val: string) => {
-    const trimmedLowercase = val.trim().toLowerCase();
-    const usernames = trimmedLowercase ? trimmedLowercase.split(/[\s,]+/).filter(Boolean) : [];
-    setIsUsernameValid(false);
-    _debouncedValidateUsername(
-      allowMultipleDest ? usernames : trimmedLowercase ? [trimmedLowercase] : [],
-    );
-    destinationRef.current = allowMultipleDest
-      ? usernames
-      : trimmedLowercase
-      ? [trimmedLowercase]
-      : [];
-    setDestination(trimmedLowercase);
-  };
+  const _handleDestinationChange = useCallback(
+    (val: string) => {
+      const trimmedLowercase = val.trim().toLowerCase();
+      const usernames = trimmedLowercase ? trimmedLowercase.split(/[\s,]+/).filter(Boolean) : [];
+      setIsUsernameValid(false);
+      _debouncedValidateUsername(
+        allowMultipleDest ? usernames : trimmedLowercase ? [trimmedLowercase] : [],
+      );
+      destinationRef.current = allowMultipleDest
+        ? usernames
+        : trimmedLowercase
+        ? [trimmedLowercase]
+        : [];
+      setDestination(trimmedLowercase);
+    },
+    [_debouncedValidateUsername, allowMultipleDest],
+  );
 
   const _handleUserSelect = useCallback(
     (username: string) => {
@@ -278,6 +359,42 @@ const TransferView = ({
     },
     [from, intl],
   );
+
+  const _handleScannedRecipient = useCallback(
+    (value: string) => {
+      const username = extractUsernameFromScannedValue(value);
+      if (!username) {
+        dispatch(
+          toastNotification(
+            intl.formatMessage({
+              id: 'transfer.invalid_recipient_qr',
+              defaultMessage: 'Could not find a username in this QR code.',
+            }),
+          ),
+        );
+        return;
+      }
+      _handleDestinationChange(username);
+    },
+    [dispatch, intl, _handleDestinationChange],
+  );
+
+  const _openQrScanner = useCallback(() => {
+    SheetManager.show(SheetNames.QR_SCAN, {
+      payload: {
+        onScan: _handleScannedRecipient,
+      },
+    });
+  }, [_handleScannedRecipient]);
+
+  const _openFavorites = useCallback(async () => {
+    const username = await SheetManager.show(SheetNames.TRANSFER_FAVORITES, {
+      payload: { limit: 50 },
+    });
+    if (username) {
+      _handleDestinationChange(username);
+    }
+  }, [_handleDestinationChange]);
 
   const _renderSuggestionItem = useCallback(
     ({ item: username }) => (
@@ -304,25 +421,57 @@ const TransferView = ({
     const parsed = parseFloat(newValue);
     if (newValue === '' || newValue === '.' || Number.isNaN(parsed)) {
       setAmount(newValue);
-    } else if (parsed <= parseFloat(String(balance))) {
+    } else if (isBalanceLoading || parsed <= parseFloat(String(balance))) {
       setAmount(newValue);
     }
   };
 
-  const [recurrenceIndex, setRecurrenceIndex] = useState(
-    RECURRENCE_TYPES.findIndex((r) => r.hours === recurrence),
-  );
+  // Derived from `recurrence` (the single source of truth) — RECURRENCE_TYPES.hours
+  // is numeric, so coerce the string state with +recurrence before matching.
+  const recurrenceIndex = RECURRENCE_TYPES.findIndex((r) => r.hours === +recurrence);
+  const scheduleSelectedIndex = isRecurrentTransfer ? Math.max(recurrenceIndex + 1, 1) : 0;
 
   useEffect(() => {
     const newSelectedIndex = RECURRENCE_TYPES.findIndex((r) => r.hours === +recurrence);
-    setRecurrenceIndex(newSelectedIndex);
     if (newSelectedIndex > -1) {
-      setRecurrence(RECURRENCE_TYPES[newSelectedIndex].hours);
+      setRecurrence(`${RECURRENCE_TYPES[newSelectedIndex].hours}`);
     }
     if (dpRef?.current) {
-      dpRef.current.select(newSelectedIndex);
+      dpRef.current.select(isRecurrentTransfer ? Math.max(newSelectedIndex + 1, 1) : 0);
     }
-  }, [recurrence]);
+  }, [recurrence, isRecurrentTransfer]);
+
+  useEffect(() => {
+    if (!isRecurrentTransfer) return;
+    if (!recurrence) {
+      setRecurrence(`${RECURRENCE_TYPES[0].hours}`);
+    }
+    if (!executions) {
+      setExecutions('2');
+    }
+  }, [executions, isRecurrentTransfer, recurrence]);
+
+  const _handleScheduleSelect = useCallback(
+    (index: number) => {
+      if (index === 0) {
+        setIsScheduledTransfer(false);
+        setRecurrence('');
+        setExecutions('');
+        setStartDate('');
+        return;
+      }
+
+      const selectedRecurrence = RECURRENCE_TYPES[index - 1];
+      if (!selectedRecurrence) return;
+
+      setIsScheduledTransfer(true);
+      setRecurrence(`${selectedRecurrence.hours}`);
+      if (!executions) {
+        setExecutions('2');
+      }
+    },
+    [executions],
+  );
 
   // --- Transfer Actions ---
   const _handleTransferAction = debounce(
@@ -333,7 +482,7 @@ const TransferView = ({
       if (accountType === AUTH_TYPE.STEEM_CONNECT) {
         setHsTransfer(true);
       } else if (accountType === AUTH_TYPE.HIVE_AUTH) {
-        const opArray = buildTransferOpsArray(transferType, {
+        const opArray = buildTransferOpsArray(effectiveTransferType, {
           from,
           to: destination,
           amount,
@@ -368,6 +517,7 @@ const TransferView = ({
           memo,
           isRecurrentTransfer ? recurrence : null,
           isRecurrentTransfer ? executions : null,
+          effectiveTransferType,
         );
       }
     },
@@ -381,7 +531,7 @@ const TransferView = ({
       if (accountType === AUTH_TYPE.STEEM_CONNECT) {
         setHsTransfer(true);
       } else {
-        transferToAccount(from, destination, '0', memo, 24, 2);
+        transferToAccount(from, destination, '0', memo, 24, 2, TransferTypes.RECURRENT_TRANSFER);
       }
     },
     300,
@@ -401,7 +551,7 @@ const TransferView = ({
       .filter(Boolean);
 
     if (isEngineToken) {
-      if (transferType === TransferTypes.TRANSFER && destinations.length > 1) {
+      if (effectiveTransferType === TransferTypes.TRANSFER && destinations.length > 1) {
         path = hiveuri
           .encodeOps(
             destinations.map((receiver) => [
@@ -426,7 +576,7 @@ const TransferView = ({
         path += '?authority=active';
       } else {
         const json = getEngineActionJSON(
-          transferType as EngineActions,
+          effectiveTransferType as EngineActions,
           destination,
           hsEngineAmount,
           fundType,
@@ -443,38 +593,38 @@ const TransferView = ({
       const json = getSpkActionJSON(Number(amount), destination, memo);
       path = `sign/custom-json?authority=active&required_auths=%5B%22${
         selectedAccount.name
-      }%22%5D&required_posting_auths=%5B%5D&id=${transferType}&json=${encodeURIComponent(
+      }%22%5D&required_posting_auths=%5B%5D&id=${effectiveTransferType}&json=${encodeURIComponent(
         JSON.stringify(json),
       )}`;
-    } else if (transferType === TransferTypes.RECURRENT_TRANSFER) {
+    } else if (effectiveTransferType === TransferTypes.RECURRENT_TRANSFER) {
       path = `sign/recurrent_transfer?from=${from}&to=${destination}&amount=${encodeURIComponent(
         hsNativeAmount,
       )}&memo=${encodeURIComponent(memo)}&recurrence=${recurrence}&executions=${executions}`;
-    } else if (transferType === TransferTypes.TRANSFER_TO_SAVINGS) {
+    } else if (effectiveTransferType === TransferTypes.TRANSFER_TO_SAVINGS) {
       path = `sign/transfer_to_savings?from=${from}&to=${destination}&amount=${encodeURIComponent(
         hsNativeAmount,
       )}&memo=${encodeURIComponent(memo)}`;
-    } else if (transferType === TransferTypes.DELEGATE_VESTING_SHARES) {
+    } else if (effectiveTransferType === TransferTypes.DELEGATE_VESTING_SHARES) {
       path = `sign/delegate_vesting_shares?delegator=${from}&delegatee=${destination}&vesting_shares=${encodeURIComponent(
         hsNativeAmount,
       )}`;
-    } else if (transferType === TransferTypes.TRANSFER_TO_VESTING) {
+    } else if (effectiveTransferType === TransferTypes.TRANSFER_TO_VESTING) {
       path = `sign/transfer_to_vesting?from=${from}&to=${destination}&amount=${encodeURIComponent(
         hsNativeAmount,
       )}`;
-    } else if (transferType === TransferTypes.TRANSFER_FROM_SAVINGS) {
+    } else if (effectiveTransferType === TransferTypes.TRANSFER_FROM_SAVINGS) {
       path = `sign/transfer_from_savings?from=${from}&to=${destination}&amount=${encodeURIComponent(
         hsNativeAmount,
       )}&request_id=${new Date().getTime() >>> 0}`;
-    } else if (transferType === TransferTypes.CONVERT) {
+    } else if (effectiveTransferType === TransferTypes.CONVERT) {
       path = `sign/convert?owner=${from}&amount=${encodeURIComponent(hsNativeAmount)}&requestid=${
         new Date().getTime() >>> 0
       }`;
-    } else if (transferType === TransferTypes.WITHDRAW_VESTING) {
+    } else if (effectiveTransferType === TransferTypes.WITHDRAW_VESTING) {
       path = `sign/withdraw_vesting?account=${from}&vesting_shares=${encodeURIComponent(
         hsNativeAmount,
       )}`;
-    } else if (transferType === TransferTypes.ECENCY_POINT_TRANSFER) {
+    } else if (effectiveTransferType === TransferTypes.ECENCY_POINT_TRANSFER) {
       path = hiveuri
         .encodeOps(
           destinations.map((receiver) => [
@@ -535,7 +685,7 @@ const TransferView = ({
     if (allowMultipleDest && parsedDestinations.length === 0) {
       return false;
     }
-    if (balance < amount * recipientCount) {
+    if (!isBalanceLoading && balance < amount * recipientCount) {
       Alert.alert(intl.formatMessage({ id: 'wallet.low_liquidity' }));
       return false;
     }
@@ -553,16 +703,19 @@ const TransferView = ({
   const nextBtnDisabled = !(
     (isEngineToken ? amount > 0 : amount >= 0.001) &&
     isUsernameValid &&
+    // Don't allow submit until the real balance has loaded (it is '' while fetching).
+    !isBalanceLoading &&
     // Wait for the Engine token's precision to load so the amount can't be
     // broadcast with the fallback 8-decimal precision before it is known.
-    (!isEngineToken || tokenPrecision !== undefined)
+    (!isEngineToken || tokenPrecision !== undefined) &&
+    (!isRecurrentTransfer || (!!recurrence && Number(executions) >= 2))
   );
 
   useEffect(() => {
     if (isRecurrentTransfer) {
-      fetchRecurrentTransfers(currentAccountName);
+      fetchRecurrentTransfers?.(currentAccountName);
     }
-  }, [isRecurrentTransfer]);
+  }, [currentAccountName, fetchRecurrentTransfers, isRecurrentTransfer]);
 
   const _findRecurrentTransferOfUser = useCallback(
     (userToFind) => {
@@ -570,30 +723,25 @@ const TransferView = ({
         return false;
       }
 
-      const existingRecurrentTransfer = recurrentTransfers.find((rt) => rt.to === userToFind);
+      const existingRecurrentTransfer = (recurrentTransfers || []).find(
+        (rt) => rt.to === userToFind,
+      );
 
-      let newMemo,
-        newAmount,
-        newRecurrence,
-        newStartDate,
-        newExecutions = '';
-
-      if (existingRecurrentTransfer) {
-        newMemo = existingRecurrentTransfer.memo;
-        newAmount = parseToken(existingRecurrentTransfer.amount).toString();
-        newRecurrence = existingRecurrentTransfer.recurrence.toString();
-        newExecutions = `${existingRecurrentTransfer.remaining_executions}`;
-        newStartDate = existingRecurrentTransfer.trigger_date;
+      if (!existingRecurrentTransfer) {
+        setStartDate('');
+        return false;
       }
-      setMemo(newMemo);
-      setAmount(newAmount);
-      setRecurrence(newRecurrence);
-      setExecutions(newExecutions);
-      setStartDate(newStartDate);
+
+      setIsScheduledTransfer(true);
+      setMemo(existingRecurrentTransfer.memo);
+      setAmount(parseToken(existingRecurrentTransfer.amount).toString());
+      setRecurrence(existingRecurrentTransfer.recurrence.toString());
+      setExecutions(`${existingRecurrentTransfer.remaining_executions}`);
+      setStartDate(existingRecurrentTransfer.trigger_date);
 
       return existingRecurrentTransfer;
     },
-    [recurrentTransfers],
+    [isRecurrentTransfer, recurrentTransfers],
   );
 
   const badActorUsername = useMemo(() => {
@@ -609,7 +757,7 @@ const TransferView = ({
   return (
     <SafeAreaView style={styles.container}>
       <BasicHeader
-        title={intl.formatMessage({ id: `wallet.${transferType}` })}
+        title={intl.formatMessage({ id: `wallet.${oneTimeTransferType}` })}
         backIconName="close"
       />
 
@@ -619,6 +767,26 @@ const TransferView = ({
         extraScrollHeight={80}
         contentContainerStyle={styles.scrollContent}
       >
+        {canScheduleTransfer && (
+          <View style={styles.scheduleSection}>
+            <Text style={styles.fieldLabel}>
+              {intl.formatMessage({ id: 'transfer.schedule', defaultMessage: 'Schedule' })}
+            </Text>
+            <DropdownButton
+              dropdownButtonStyle={styles.scheduleButton}
+              rowTextStyle={styles.dropdownRowText}
+              style={styles.dropdownWrapper}
+              dropdownStyle={styles.dropdownMenu}
+              textStyle={styles.scheduleButtonText}
+              options={scheduleOptions}
+              defaultText={scheduleOptions[0]}
+              selectedOptionIndex={scheduleSelectedIndex}
+              onSelect={_handleScheduleSelect}
+              dropdownRef={dpRef}
+            />
+          </View>
+        )}
+
         {/* --- Recipient Section --- */}
         {!destinationLocked && (
           <View style={styles.recipientSection}>
@@ -652,15 +820,43 @@ const TransferView = ({
                     onSelect={(_index, value) => _handleDestinationChange(value)}
                   />
                 ) : (
-                  <TextInput
-                    style={styles.inputField}
-                    onChangeText={_handleDestinationChange}
-                    value={destination}
-                    placeholder={intl.formatMessage({ id: 'transfer.to_placeholder' })}
-                    placeholderTextColor="#c1c5c7"
-                    autoCapitalize="none"
-                    autoCorrect={false}
-                  />
+                  <View style={styles.recipientInputControl}>
+                    <TextInput
+                      style={[styles.inputField, styles.recipientTextInput]}
+                      onChangeText={_handleDestinationChange}
+                      value={destination}
+                      placeholder={intl.formatMessage({ id: 'transfer.to_placeholder' })}
+                      placeholderTextColor="#c1c5c7"
+                      autoCapitalize="none"
+                      autoCorrect={false}
+                    />
+                    <View style={styles.recipientActionButtons}>
+                      <TouchableOpacity
+                        style={styles.recipientActionButton}
+                        onPress={_openFavorites}
+                        activeOpacity={0.7}
+                      >
+                        <Icon
+                          iconType="MaterialCommunityIcons"
+                          name="account-circle-outline"
+                          size={22}
+                          color="#8d969e"
+                        />
+                      </TouchableOpacity>
+                      <TouchableOpacity
+                        style={styles.recipientActionButton}
+                        onPress={_openQrScanner}
+                        activeOpacity={0.7}
+                      >
+                        <Icon
+                          iconType="MaterialCommunityIcons"
+                          name="qrcode-scan"
+                          size={20}
+                          color="#8d969e"
+                        />
+                      </TouchableOpacity>
+                    </View>
+                  </View>
                 )}
 
                 {destination !== '' && usersResult.length > 0 && !isUsernameValid && (
@@ -736,24 +932,6 @@ const TransferView = ({
               </TouchableOpacity>
             )}
             <Text style={styles.fieldLabel}>
-              {intl.formatMessage({ id: 'transfer.recurrence' })}
-            </Text>
-            <DropdownButton
-              dropdownButtonStyle={styles.inputField}
-              rowTextStyle={styles.dropdownRowText}
-              style={styles.dropdownWrapper}
-              dropdownStyle={styles.dropdownMenu}
-              textStyle={styles.inputText}
-              options={RECURRENCE_TYPES.map((k) => intl.formatMessage({ id: k.intlId }))}
-              defaultText={intl.formatMessage({ id: 'transfer.recurrence_placeholder' })}
-              selectedOptionIndex={recurrenceIndex}
-              onSelect={(index) => {
-                setRecurrenceIndex(index);
-                setRecurrence(RECURRENCE_TYPES[index].hours);
-              }}
-              dropdownRef={dpRef}
-            />
-            <Text style={[styles.fieldLabel, { marginTop: 12 }]}>
               {intl.formatMessage({ id: 'transfer.executions' })}
             </Text>
             <TextInput
@@ -787,7 +965,7 @@ const TransferView = ({
         )}
 
         {/* --- Convert Description --- */}
-        {transferType === TransferTypes.CONVERT && (
+        {effectiveTransferType === TransferTypes.CONVERT && (
           <View style={styles.fieldGroup}>
             <Text style={styles.convertDesc}>
               {intl.formatMessage({ id: 'transfer.convert_desc' })}

--- a/src/screens/transfer/screen/transferScreen.tsx
+++ b/src/screens/transfer/screen/transferScreen.tsx
@@ -165,6 +165,9 @@ const TransferView = ({
   const destinationRef = useRef<string[]>([]);
   const hasInitializedRef = useRef(false);
   const dpRef = useRef();
+  // Tracks the recipient whose existing on-chain schedule we last autofilled, so a
+  // different recipient without a schedule can be reset without wiping manual input.
+  const lastHydratedRecipientRef = useRef<string | null>(null);
 
   const oneTimeTransferType =
     transferType === TransferTypes.RECURRENT_TRANSFER ? TransferTypes.TRANSFER : transferType;
@@ -727,10 +730,22 @@ const TransferView = ({
       );
 
       if (!existingRecurrentTransfer) {
+        // This recipient has no on-chain schedule. If the fields were autofilled
+        // from a *different* recipient's existing schedule, reset them to a fresh
+        // schedule so that recipient's amount/memo/cadence don't bleed onto this
+        // one. Manually entered values (no prior autofill) are left untouched.
+        if (lastHydratedRecipientRef.current && lastHydratedRecipientRef.current !== userToFind) {
+          setMemo('');
+          setAmount('');
+          setRecurrence(`${RECURRENCE_TYPES[0].hours}`);
+          setExecutions('2');
+        }
+        lastHydratedRecipientRef.current = null;
         setStartDate('');
         return false;
       }
 
+      lastHydratedRecipientRef.current = userToFind;
       setIsScheduledTransfer(true);
       setMemo(existingRecurrentTransfer.memo);
       setAmount(parseToken(existingRecurrentTransfer.amount).toString());

--- a/src/screens/transfer/screen/transferScreen.tsx
+++ b/src/screens/transfer/screen/transferScreen.tsx
@@ -759,7 +759,14 @@ const TransferView = ({
     if (isRecurrentTransfer && isUsernameValid && destination && !allowMultipleDest) {
       _findRecurrentTransferOfUser(destination);
     }
-  }, [isRecurrentTransfer, recurrentTransfers]);
+  }, [
+    isRecurrentTransfer,
+    recurrentTransfers,
+    isUsernameValid,
+    destination,
+    allowMultipleDest,
+    _findRecurrentTransferOfUser,
+  ]);
 
   const badActorUsername = useMemo(() => {
     if (!destination || !badActors) return null;

--- a/src/screens/transfer/screen/transferScreen.tsx
+++ b/src/screens/transfer/screen/transferScreen.tsx
@@ -9,6 +9,7 @@ import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view
 import { SafeAreaView } from 'react-native-safe-area-context';
 import * as hiveuri from 'hive-uri';
 import { SheetManager } from 'react-native-actions-sheet';
+import EStyleSheet from 'react-native-extended-stylesheet';
 import { hsOptions } from '../../../constants/hsOptions';
 import AUTH_TYPE from '../../../constants/authType';
 
@@ -17,6 +18,7 @@ import DropdownButton from '../../../components/dropdownButton';
 import { RECURRENCE_TYPES } from '../../../components/transferAmountInputSection/transferAmountInputSection';
 
 import styles from './transferStyles';
+import { extractUsernameFromScannedValue } from './transferRecipientParser';
 import TransferTypes from '../../../constants/transferTypes';
 import { getEngineActionJSON } from '../../../providers/hive-engine/hiveEngineActions';
 import { getSpkActionJSON, SPK_NODE_ECENCY } from '../../../providers/hive-spk/hiveSpk';
@@ -29,47 +31,8 @@ import { EngineActions } from '../../../providers/hive-engine/hiveEngine.types';
 import { toastNotification } from '../../../redux/actions/uiAction';
 import { dateToFormatted } from '../../../utils/time';
 
-const normalizeScannedUsername = (value?: string) =>
-  (value || '').trim().replace(/^@/, '').toLowerCase();
-
-const extractUsernameFromScannedValue = (value: string) => {
-  const scannedValue = value.trim();
-
-  try {
-    const decoded = hiveuri.decode(scannedValue);
-    const operation = get(decoded, 'tx.operations[0]', []);
-    const operationPayload = Array.isArray(operation) ? operation[1] : null;
-    const username =
-      get(operationPayload, 'to') ||
-      get(operationPayload, 'receiver') ||
-      get(operationPayload, 'username') ||
-      get(operationPayload, 'account');
-    if (username) {
-      return normalizeScannedUsername(username);
-    }
-  } catch {
-    // Non hive-uri QR values are handled below.
-  }
-
-  const queryMatch = scannedValue.match(/[?&](?:to|username|account)=([^&#]+)/i);
-  if (queryMatch?.[1]) {
-    try {
-      return normalizeScannedUsername(decodeURIComponent(queryMatch[1]));
-    } catch {
-      return normalizeScannedUsername(queryMatch[1]);
-    }
-  }
-
-  const profileMatch =
-    scannedValue.match(/(?:^|\/)@([a-z0-9.-]+)/i) ||
-    scannedValue.match(/(?:^|\/)(?:profile|user|account)\/([a-z0-9.-]+)/i);
-  if (profileMatch?.[1]) {
-    return normalizeScannedUsername(profileMatch[1]);
-  }
-
-  const username = normalizeScannedUsername(scannedValue);
-  return /^[a-z0-9.-]{3,16}$/.test(username) ? username : '';
-};
+// Hive's recurrent_transfer operation requires at least 2 executions.
+const MIN_RECURRENT_EXECUTIONS = 2;
 
 interface TransferViewProps {
   currentAccountName: string;
@@ -120,7 +83,7 @@ const TransferView = ({
   initialAmount,
   initialMemo,
   fetchRecurrentTransfers,
-  recurrentTransfers,
+  recurrentTransfers = [],
   tokenLayer,
   tokenPrecision,
   badActors,
@@ -212,25 +175,47 @@ const TransferView = ({
   // and no false low-liquidity alert fires before the real balance arrives.
   const isBalanceLoading = balance === '' || balance === undefined || balance === null;
 
-  // Token switching is only available for basic transfers
+  // Token switching is only available for basic transfers. `oneTimeTransferType`
+  // already collapses RECURRENT_TRANSFER -> TRANSFER, so no separate clause is needed.
   const canSwitchToken =
-    !!setFundType &&
-    (oneTimeTransferType === TransferTypes.TRANSFER ||
-      transferType === TransferTypes.RECURRENT_TRANSFER) &&
-    isNativeTokenLayer;
+    !!setFundType && oneTimeTransferType === TransferTypes.TRANSFER && isNativeTokenLayer;
   const canScheduleTransfer =
     isNativeTokenLayer &&
-    (oneTimeTransferType === TransferTypes.TRANSFER ||
-      transferType === TransferTypes.RECURRENT_TRANSFER) &&
+    oneTimeTransferType === TransferTypes.TRANSFER &&
     (fundType === 'HIVE' || fundType === 'HBD');
 
-  const scheduleOptions = useMemo(
-    () => [
+  // Index of the current recurrence among the preset cadences (-1 when the schedule was
+  // created off-app with a non-preset interval, e.g. 48h). `recurrence` is string state,
+  // so coerce with +recurrence before matching the numeric RECURRENCE_TYPES.hours.
+  const recurrenceIndex = RECURRENCE_TYPES.findIndex((r) => r.hours === +recurrence);
+  const isOffGridRecurrence = isRecurrentTransfer && !!recurrence && recurrenceIndex === -1;
+
+  const scheduleOptions = useMemo(() => {
+    const options = [
       intl.formatMessage({ id: 'transfer.one_time', defaultMessage: 'One Time' }),
       ...RECURRENCE_TYPES.map((item) => intl.formatMessage({ id: item.intlId })),
-    ],
-    [intl],
-  );
+    ];
+    if (isOffGridRecurrence) {
+      // Surface the real (non-preset) cadence instead of mislabeling it as the first
+      // preset; selecting it is a no-op so the on-chain interval is preserved.
+      options.push(
+        intl.formatMessage(
+          { id: 'transfer.custom_schedule', defaultMessage: 'Custom ({hours}h)' },
+          { hours: recurrence },
+        ),
+      );
+    }
+    return options;
+  }, [intl, isOffGridRecurrence, recurrence]);
+
+  // 0 = One Time; 1..N = preset cadences; last = the synthetic Custom option (when shown).
+  const scheduleSelectedIndex = !isRecurrentTransfer
+    ? 0
+    : recurrenceIndex > -1
+    ? recurrenceIndex + 1
+    : isOffGridRecurrence
+    ? scheduleOptions.length - 1
+    : 1;
 
   const [showTokenPicker, setShowTokenPicker] = useState(false);
   const transferableTokens = ['HIVE', 'HBD'];
@@ -428,18 +413,14 @@ const TransferView = ({
     }
   };
 
-  // Derived from `recurrence` (the single source of truth) — RECURRENCE_TYPES.hours
-  // is numeric, so coerce the string state with +recurrence before matching.
-  const recurrenceIndex = RECURRENCE_TYPES.findIndex((r) => r.hours === +recurrence);
-  const scheduleSelectedIndex = isRecurrentTransfer ? Math.max(recurrenceIndex + 1, 1) : 0;
-
+  // Keep `recurrence` normalized to a canonical preset value and sync the dropdown
+  // highlight. Reuses the render-scope recurrenceIndex/scheduleSelectedIndex.
   useEffect(() => {
-    const newSelectedIndex = RECURRENCE_TYPES.findIndex((r) => r.hours === +recurrence);
-    if (newSelectedIndex > -1) {
-      setRecurrence(`${RECURRENCE_TYPES[newSelectedIndex].hours}`);
+    if (recurrenceIndex > -1) {
+      setRecurrence(`${RECURRENCE_TYPES[recurrenceIndex].hours}`);
     }
     if (dpRef?.current) {
-      dpRef.current.select(isRecurrentTransfer ? Math.max(newSelectedIndex + 1, 1) : 0);
+      dpRef.current.select(scheduleSelectedIndex);
     }
   }, [recurrence, isRecurrentTransfer]);
 
@@ -448,10 +429,12 @@ const TransferView = ({
     if (!recurrence) {
       setRecurrence(`${RECURRENCE_TYPES[0].hours}`);
     }
+    // Seed executions only when entering scheduled mode / changing cadence — deliberately
+    // NOT keyed on `executions`, so clearing the field to edit it doesn't snap it back.
     if (!executions) {
-      setExecutions('2');
+      setExecutions(`${MIN_RECURRENT_EXECUTIONS}`);
     }
-  }, [executions, isRecurrentTransfer, recurrence]);
+  }, [isRecurrentTransfer, recurrence]);
 
   const _handleScheduleSelect = useCallback(
     (index: number) => {
@@ -469,7 +452,7 @@ const TransferView = ({
       setIsScheduledTransfer(true);
       setRecurrence(`${selectedRecurrence.hours}`);
       if (!executions) {
-        setExecutions('2');
+        setExecutions(`${MIN_RECURRENT_EXECUTIONS}`);
       }
     },
     [executions],
@@ -533,7 +516,15 @@ const TransferView = ({
       if (accountType === AUTH_TYPE.STEEM_CONNECT) {
         setHsTransfer(true);
       } else {
-        transferToAccount(from, destination, '0', memo, 24, 2, TransferTypes.RECURRENT_TRANSFER);
+        transferToAccount(
+          from,
+          destination,
+          '0',
+          memo,
+          RECURRENCE_TYPES[0].hours,
+          MIN_RECURRENT_EXECUTIONS,
+          TransferTypes.RECURRENT_TRANSFER,
+        );
       }
     },
     300,
@@ -710,7 +701,10 @@ const TransferView = ({
     // Wait for the Engine token's precision to load so the amount can't be
     // broadcast with the fallback 8-decimal precision before it is known.
     (!isEngineToken || tokenPrecision !== undefined) &&
-    (!isRecurrentTransfer || (!!recurrence && Number(executions) >= 2))
+    (!isRecurrentTransfer ||
+      (!!recurrence &&
+        Number.isInteger(Number(executions)) &&
+        Number(executions) >= MIN_RECURRENT_EXECUTIONS))
   );
 
   useEffect(() => {
@@ -725,9 +719,7 @@ const TransferView = ({
         return false;
       }
 
-      const existingRecurrentTransfer = (recurrentTransfers || []).find(
-        (rt) => rt.to === userToFind,
-      );
+      const existingRecurrentTransfer = recurrentTransfers.find((rt) => rt.to === userToFind);
 
       if (!existingRecurrentTransfer) {
         // This recipient has no on-chain schedule. If the fields were autofilled
@@ -738,7 +730,7 @@ const TransferView = ({
           setMemo('');
           setAmount('');
           setRecurrence(`${RECURRENCE_TYPES[0].hours}`);
-          setExecutions('2');
+          setExecutions(`${MIN_RECURRENT_EXECUTIONS}`);
         }
         lastHydratedRecipientRef.current = null;
         setStartDate('');
@@ -860,24 +852,34 @@ const TransferView = ({
                         style={styles.recipientActionButton}
                         onPress={_openFavorites}
                         activeOpacity={0.7}
+                        accessibilityRole="button"
+                        accessibilityLabel={intl.formatMessage({
+                          id: 'transfer.pick_from_favorites',
+                          defaultMessage: 'Choose recipient from favorites',
+                        })}
                       >
                         <Icon
                           iconType="MaterialCommunityIcons"
                           name="account-circle-outline"
                           size={22}
-                          color="#8d969e"
+                          color={EStyleSheet.value('$iconColor')}
                         />
                       </TouchableOpacity>
                       <TouchableOpacity
                         style={styles.recipientActionButton}
                         onPress={_openQrScanner}
                         activeOpacity={0.7}
+                        accessibilityRole="button"
+                        accessibilityLabel={intl.formatMessage({
+                          id: 'transfer.scan_qr_recipient',
+                          defaultMessage: 'Scan a QR code for the recipient',
+                        })}
                       >
                         <Icon
                           iconType="MaterialCommunityIcons"
                           name="qrcode-scan"
                           size={20}
-                          color="#8d969e"
+                          color={EStyleSheet.value('$iconColor')}
                         />
                       </TouchableOpacity>
                     </View>

--- a/src/screens/transfer/screen/transferStyles.ts
+++ b/src/screens/transfer/screen/transferStyles.ts
@@ -44,6 +44,27 @@ export default EStyleSheet.create({
     color: '$iconColor',
     marginHorizontal: 8,
   },
+  recipientInputControl: {
+    position: 'relative',
+  },
+  recipientTextInput: {
+    paddingRight: 88,
+  },
+  recipientActionButtons: {
+    position: 'absolute',
+    top: 0,
+    right: 6,
+    bottom: 0,
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  recipientActionButton: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
 
   // --- Fields ---
   fieldGroup: {
@@ -71,6 +92,25 @@ export default EStyleSheet.create({
     fontSize: 16,
     color: '$primaryBlack',
     paddingHorizontal: 14,
+  },
+
+  // --- Schedule ---
+  scheduleSection: {
+    marginBottom: 16,
+  },
+  scheduleButton: {
+    borderWidth: 1,
+    borderColor: '$borderColor',
+    borderRadius: 12,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    backgroundColor: '$primaryLightBackground',
+    minHeight: 48,
+  },
+  scheduleButtonText: {
+    fontSize: 16,
+    color: '$primaryBlack',
+    paddingHorizontal: 0,
   },
 
   // --- Amount ---

--- a/src/utils/transferBalance.test.ts
+++ b/src/utils/transferBalance.test.ts
@@ -1,0 +1,97 @@
+import {
+  normalizeTransferType,
+  parseAccountAssetBalance,
+  getNativeAccountBalance,
+} from './transferBalance';
+import TransferTypes from '../constants/transferTypes';
+
+describe('normalizeTransferType', () => {
+  it('maps the transfer_token alias to TRANSFER', () => {
+    expect(normalizeTransferType('transfer_token')).toBe(TransferTypes.TRANSFER);
+  });
+
+  it('maps savings-withdrawal aliases to TRANSFER_FROM_SAVINGS', () => {
+    expect(normalizeTransferType('withdraw_hive')).toBe(TransferTypes.TRANSFER_FROM_SAVINGS);
+    expect(normalizeTransferType('withdraw_hbd')).toBe(TransferTypes.TRANSFER_FROM_SAVINGS);
+  });
+
+  it('passes through canonical and unknown types unchanged', () => {
+    expect(normalizeTransferType(TransferTypes.RECURRENT_TRANSFER)).toBe(
+      TransferTypes.RECURRENT_TRANSFER,
+    );
+    expect(normalizeTransferType('purchase_estm')).toBe('purchase_estm');
+    expect(normalizeTransferType('')).toBe('');
+  });
+});
+
+describe('parseAccountAssetBalance', () => {
+  it('strips the asset suffix and parses to a number', () => {
+    expect(parseAccountAssetBalance('10.000 HIVE', 'HIVE')).toBe(10);
+    expect(parseAccountAssetBalance('5.500 HBD', 'HBD')).toBe(5.5);
+  });
+
+  it('honors a real zero balance', () => {
+    expect(parseAccountAssetBalance('0.000 HIVE', 'HIVE')).toBe(0);
+  });
+
+  it('returns a finite number as-is', () => {
+    expect(parseAccountAssetBalance(12.3, 'HIVE')).toBe(12.3);
+  });
+
+  it('returns undefined for empty, nullish, NaN, or unparsable values', () => {
+    expect(parseAccountAssetBalance('', 'HIVE')).toBeUndefined();
+    expect(parseAccountAssetBalance(null, 'HIVE')).toBeUndefined();
+    expect(parseAccountAssetBalance(undefined, 'HIVE')).toBeUndefined();
+    expect(parseAccountAssetBalance(NaN, 'HIVE')).toBeUndefined();
+    expect(parseAccountAssetBalance('abc HIVE', 'HIVE')).toBeUndefined();
+  });
+});
+
+describe('getNativeAccountBalance', () => {
+  const account = {
+    balance: '10.000 HIVE',
+    hbd_balance: '4.000 HBD',
+    savings_balance: '2.000 HIVE',
+    savings_hbd_balance: '1.000 HBD',
+  };
+
+  it('returns undefined when the account is missing', () => {
+    expect(getNativeAccountBalance(null, TransferTypes.TRANSFER, 'HIVE')).toBeUndefined();
+    expect(getNativeAccountBalance(undefined, TransferTypes.TRANSFER, 'HBD')).toBeUndefined();
+  });
+
+  it('selects the liquid HIVE balance for transfer, recurrent, to-savings and to-vesting', () => {
+    expect(getNativeAccountBalance(account, TransferTypes.TRANSFER, 'HIVE')).toBe(10);
+    expect(getNativeAccountBalance(account, TransferTypes.RECURRENT_TRANSFER, 'HIVE')).toBe(10);
+    expect(getNativeAccountBalance(account, TransferTypes.TRANSFER_TO_SAVINGS, 'HIVE')).toBe(10);
+    expect(getNativeAccountBalance(account, TransferTypes.TRANSFER_TO_VESTING, 'HIVE')).toBe(10);
+  });
+
+  it('selects the liquid HBD balance for transfer, recurrent and convert', () => {
+    expect(getNativeAccountBalance(account, TransferTypes.TRANSFER, 'HBD')).toBe(4);
+    expect(getNativeAccountBalance(account, TransferTypes.RECURRENT_TRANSFER, 'HBD')).toBe(4);
+    expect(getNativeAccountBalance(account, TransferTypes.CONVERT, 'HBD')).toBe(4);
+  });
+
+  it('selects savings balances for withdrawals, including the legacy aliases', () => {
+    expect(getNativeAccountBalance(account, TransferTypes.TRANSFER_FROM_SAVINGS, 'HIVE')).toBe(2);
+    expect(getNativeAccountBalance(account, TransferTypes.TRANSFER_FROM_SAVINGS, 'HBD')).toBe(1);
+    expect(getNativeAccountBalance(account, 'withdraw_hive', 'HIVE')).toBe(2);
+    expect(getNativeAccountBalance(account, 'withdraw_hbd', 'HBD')).toBe(1);
+  });
+
+  it('falls back to the camelCase savings fields', () => {
+    const camel = { savingBalance: '7.000 HIVE', savingBalanceHbd: '3.000 HBD' };
+    expect(getNativeAccountBalance(camel, TransferTypes.TRANSFER_FROM_SAVINGS, 'HIVE')).toBe(7);
+    expect(getNativeAccountBalance(camel, TransferTypes.TRANSFER_FROM_SAVINGS, 'HBD')).toBe(3);
+  });
+
+  it('returns undefined for unsupported type/asset combinations', () => {
+    expect(
+      getNativeAccountBalance(account, TransferTypes.DELEGATE_VESTING_SHARES, 'HIVE'),
+    ).toBeUndefined();
+    // CONVERT is HBD-only; there is no HIVE convert balance.
+    expect(getNativeAccountBalance(account, TransferTypes.CONVERT, 'HIVE')).toBeUndefined();
+    expect(getNativeAccountBalance(account, TransferTypes.TRANSFER, 'POINT')).toBeUndefined();
+  });
+});

--- a/src/utils/transferBalance.ts
+++ b/src/utils/transferBalance.ts
@@ -1,0 +1,82 @@
+import get from 'lodash/get';
+import TransferTypes from '../constants/transferTypes';
+
+/**
+ * Normalize legacy/route transfer-type aliases to canonical Hive operation names.
+ * Shared by the wallet navigation path and the transfer container so both agree on
+ * a single mapping instead of re-deriving it inline.
+ */
+export const normalizeTransferType = (transferType) => {
+  switch (transferType) {
+    case 'transfer_token':
+      return TransferTypes.TRANSFER;
+    case 'withdraw_hive':
+    case 'withdraw_hbd':
+      return TransferTypes.TRANSFER_FROM_SAVINGS;
+    default:
+      return transferType;
+  }
+};
+
+export const parseAccountAssetBalance = (value, fundType) => {
+  if (value === undefined || value === null || value === '') {
+    return undefined;
+  }
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : undefined;
+  }
+
+  const parsed = Number(String(value).replace(fundType, '').trim());
+  return Number.isFinite(parsed) ? parsed : undefined;
+};
+
+export const getNativeAccountBalance = (account, transferType, fundType) => {
+  if (!account) {
+    return undefined;
+  }
+
+  const normalizedTransferType = normalizeTransferType(transferType);
+
+  if (fundType === 'HIVE') {
+    if (normalizedTransferType === TransferTypes.TRANSFER_FROM_SAVINGS) {
+      return parseAccountAssetBalance(
+        get(account, 'savings_balance') ?? get(account, 'savingBalance'),
+        fundType,
+      );
+    }
+
+    if (
+      normalizedTransferType === TransferTypes.TRANSFER ||
+      normalizedTransferType === TransferTypes.RECURRENT_TRANSFER ||
+      normalizedTransferType === TransferTypes.TRANSFER_TO_SAVINGS ||
+      normalizedTransferType === TransferTypes.TRANSFER_TO_VESTING ||
+      transferType === 'purchase_estm'
+    ) {
+      return parseAccountAssetBalance(get(account, 'balance'), fundType);
+    }
+  }
+
+  if (fundType === 'HBD') {
+    if (normalizedTransferType === TransferTypes.TRANSFER_FROM_SAVINGS) {
+      return parseAccountAssetBalance(
+        get(account, 'savings_hbd_balance') ?? get(account, 'savingBalanceHbd'),
+        fundType,
+      );
+    }
+
+    if (
+      normalizedTransferType === TransferTypes.TRANSFER ||
+      normalizedTransferType === TransferTypes.RECURRENT_TRANSFER ||
+      normalizedTransferType === TransferTypes.CONVERT ||
+      normalizedTransferType === TransferTypes.TRANSFER_TO_SAVINGS ||
+      transferType === 'purchase_estm'
+    ) {
+      return parseAccountAssetBalance(
+        get(account, 'hbd_balance') ?? get(account, 'hbdBalance'),
+        fundType,
+      );
+    }
+  }
+
+  return undefined;
+};


### PR DESCRIPTION
## Summary

Improves the transfer screen with faster ways to pick a recipient and first-class support for scheduled (recurrent) transfers.

- **Recipient favorites** — a bottom sheet to choose a saved account as the recipient, with an inline option to add a new favorite.
- **Scan QR to fill recipient** — the QR scanner can now return a username back to the transfer screen, parsing hive-uri ops, profile URLs, and `?to=`/`?username=` links.
- **Scheduled transfers** — a single "Schedule" dropdown (One Time / Daily / Weekly / Monthly) drives one-time vs. recurrent transfers, replacing the previous inline recurrence picker.
- **Balance handling refactor** — native HIVE/HBD balance parsing is centralized in shared helpers (`normalizeTransferType` / `getNativeAccountBalance`); `fetchBalance` is now async with error handling and account-cache invalidation; the wallet navigation path normalizes savings/vesting transfer types and tags the native asset layer.

## Notes

- The amount field now treats an as-yet-unloaded balance as a loading state, so typing isn't dropped and no premature low-liquidity warning appears before the balance arrives.
- A real on-chain zero balance is shown as zero rather than retaining a previous value; in-flight balance requests are dropped if the user switches fund type.
- The QR scanner handles a scan once per open to avoid duplicate fills.

## Testing

- `yarn tsc --noEmit` — clean on changed files
- `yarn lint` — no new warnings/errors
- `yarn test:ci` — 346 passed, 1 skipped

## Follow-up

- The four new `transfer.*` strings are in `en-US` with inline default messages (so other locales render English until translated); they should be picked up by the translation pipeline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Transfer Favorites sheet for selecting or adding frequent recipients
  * QR scanner accepts callbacks and can route scanned recipients into the transfer flow
  * Username extractor to parse recipients from scanned/URL inputs

* **Improvements**
  * Unified one-time vs scheduled/recurrent transfer UI and validation
  * Recipient input supports normalized search, favorites, QR, and inline actions
  * Extended balance selection logic and navigation payload consistency

* **Tests**
  * New unit tests covering recipient parsing and balance utilities
<!-- end of auto-generated comment: release notes by coderabbit.ai -->