### PR TITLE
Default search sort to relevance (match web)

### DIFF
--- a/src/providers/queries/searchQueries.ts
+++ b/src/providers/queries/searchQueries.ts
@@ -21,7 +21,7 @@ export const getSearchQueryOptions =
  */
 export const useSearchQuery = (
   query: string,
-  sort: string = 'newest',
+  sort: string = 'relevance',
   hideLowRated: boolean = false,
 ) => {
   return useQuery({

--- a/src/screens/searchResult/screen/tabs/best/container/postsResultsContainer.tsx
+++ b/src/screens/searchResult/screen/tabs/best/container/postsResultsContainer.tsx
@@ -21,7 +21,7 @@ const PostsResultsContainer = ({ children, searchValue }) => {
   const postsCacherPrimer = postQueries.usePostsCachePrimer();
 
   const [data, setData] = useState<any>([]);
-  const [sort] = useState('newest');
+  const [sort] = useState('relevance');
   const [scrollId, setScrollId] = useState('');
   const [noResult, setNoResult] = useState(false);
   const [isLoadingMore, setIsLoadingMore] = useState(false);


### PR DESCRIPTION
## Why

We improved the search ranking in the API (relevance is now BM25 weighted by post value), and defaulted ecency.com to it. Mobile uses the same `@ecency/sdk` search, so it already benefits from the backend change — but it defaulted to **sort=newest**, so users got chronological results and never hit the improved Relevance ranking.

## Change

Default the post-search sort to **relevance** in:
- `searchResult` best tab container (`postsResultsContainer`)
- `useSearchQuery` hook default

Mobile already searches **all-time** (it sends no `since`), so no date change is needed — this matches the web's new default (relevance + all-time).

2-line change, no API/contract change.

## Follow-up

A settings/⚙️ entry point to expose advanced options (sort: relevance/popularity/newest, hide-low, NSFW) via a bottom sheet — to mirror the website's Advanced search — is planned as a separate PR.