### PR TITLE
Transfer schedule header dropdown + recurrent transfers in history

### DIFF
--- a/src/components/transaction/transactionView.tsx
+++ b/src/components/transaction/transactionView.tsx
@@ -23,7 +23,7 @@ const TransactionView = ({ item, index, cancelling, onCancelPress, onRepeatPress
   // Recurrent-transfer rows carry their cadence/remaining count instead of a plain
   // timestamp, mirroring how the schedule reads on the web wallet.
   const recurrentSubtitle =
-    item.textKey === 'recurrent_transfer'
+    item.textKey === 'recurrent_transfer' && item.executions && item.recurrence
       ? intl.formatMessage(
           {
             id: 'recurrent.schedule_summary',
@@ -31,7 +31,7 @@ const TransactionView = ({ item, index, cancelling, onCancelPress, onRepeatPress
           },
           { executions: item.executions, hours: item.recurrence },
         )
-      : item.textKey === 'fill_recurrent_transfer'
+      : item.textKey === 'fill_recurrent_transfer' && item.executions
       ? intl.formatMessage(
           { id: 'recurrent.remaining_executions' },
           { executions: item.executions },

--- a/src/components/transaction/transactionView.tsx
+++ b/src/components/transaction/transactionView.tsx
@@ -21,9 +21,14 @@ const TransactionView = ({ item, index, cancelling, onCancelPress, onRepeatPress
     : getHumanReadableKeyString(item.textKey);
 
   // Recurrent-transfer rows carry their cadence/remaining count instead of a plain
-  // timestamp, mirroring how the schedule reads on the web wallet.
+  // timestamp, mirroring how the schedule reads on the web wallet. A real schedule needs
+  // a positive cadence and run count; treat 0/blank (e.g. a cancellation, which grooms
+  // executions to '0') as "no schedule" and fall back to the timestamp rather than
+  // rendering "0 transfers, each every N hours".
   const recurrentSubtitle =
-    item.textKey === 'recurrent_transfer' && item.executions && item.recurrence
+    item.textKey === 'recurrent_transfer' &&
+    Number(item.executions) > 0 &&
+    Number(item.recurrence) > 0
       ? intl.formatMessage(
           {
             id: 'recurrent.schedule_summary',

--- a/src/components/transaction/transactionView.tsx
+++ b/src/components/transaction/transactionView.tsx
@@ -20,6 +20,24 @@ const TransactionView = ({ item, index, cancelling, onCancelPress, onRepeatPress
       })
     : getHumanReadableKeyString(item.textKey);
 
+  // Recurrent-transfer rows carry their cadence/remaining count instead of a plain
+  // timestamp, mirroring how the schedule reads on the web wallet.
+  const recurrentSubtitle =
+    item.textKey === 'recurrent_transfer'
+      ? intl.formatMessage(
+          {
+            id: 'recurrent.schedule_summary',
+            defaultMessage: '{executions} transfers, each every {hours} hours',
+          },
+          { executions: item.executions, hours: item.recurrence },
+        )
+      : item.textKey === 'fill_recurrent_transfer'
+      ? intl.formatMessage(
+          { id: 'recurrent.remaining_executions' },
+          { executions: item.executions },
+        )
+      : null;
+
   const _onRepeatPress = () => {
     if (onRepeatPress) {
       onRepeatPress();
@@ -32,8 +50,9 @@ const TransactionView = ({ item, index, cancelling, onCancelPress, onRepeatPress
       index={index + 1}
       text={title}
       description={
+        recurrentSubtitle ||
         (item.expires ? `${intl.formatMessage({ id: 'wallet.expires' })} ` : '') +
-        getTimeFromNow(item.expires || item.created)
+          getTimeFromNow(item.expires || item.created)
       }
       isCircleIcon
       isThin

--- a/src/config/locales/en-US.json
+++ b/src/config/locales/en-US.json
@@ -361,7 +361,8 @@
     "transfer_in": "Transfer {time}",
     "delete_success": "Recurrent transfer deleted successfully",
     "unsubscribe_confirmation": "Unsubscribe recurrent transfer to {username}?",
-    "remaining_executions": "Remaining {executions} transfers"
+    "remaining_executions": "Remaining {executions} transfers",
+    "schedule_summary": "{executions} transfers, each every {hours} hours"
   },
   "similar_entries": {
     "title": "Read next"
@@ -1232,6 +1233,7 @@
     "steemconnect_title": "Hivesigner Transfer",
     "hivepegged_withdraw": "HIVE Withdrawn",
     "recurrent_transfer": "Recurrent Transfer",
+    "fill_recurrent_transfer": "Recurrent Transfer Occurred",
     "delegations_in": "Delegations In",
     "withdraw_hive": "Withdraw Savings",
     "reblog_desc": "Share what post you like with your friends and earn points.",
@@ -1335,6 +1337,7 @@
   },
   "transfer": {
     "custom_schedule": "Custom ({hours}h)",
+    "close": "Close",
     "favorite_username_placeholder": "Username",
     "invalid_recipient_qr": "Could not find a username in this QR code.",
     "one_time": "One Time",

--- a/src/screens/transfer/screen/transferScreen.tsx
+++ b/src/screens/transfer/screen/transferScreen.tsx
@@ -428,7 +428,7 @@ const TransferView = ({
     if (recurrenceIndex > -1) {
       setRecurrence(`${RECURRENCE_TYPES[recurrenceIndex].hours}`);
     }
-  }, [recurrence, isRecurrentTransfer]);
+  }, [recurrence]);
 
   useEffect(() => {
     if (!isRecurrentTransfer) return;

--- a/src/screens/transfer/screen/transferScreen.tsx
+++ b/src/screens/transfer/screen/transferScreen.tsx
@@ -4,6 +4,7 @@ import { WebView } from 'react-native-webview';
 import { useIntl } from 'react-intl';
 import { get, debounce } from 'lodash';
 import { useDispatch } from 'react-redux';
+import { useNavigation } from '@react-navigation/native';
 
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -13,7 +14,7 @@ import EStyleSheet from 'react-native-extended-stylesheet';
 import { hsOptions } from '../../../constants/hsOptions';
 import AUTH_TYPE from '../../../constants/authType';
 
-import { BasicHeader, MainButton, Modal, TextInput, UserAvatar, Icon } from '../../../components';
+import { MainButton, Modal, TextInput, UserAvatar, Icon } from '../../../components';
 import DropdownButton from '../../../components/dropdownButton';
 import { RECURRENCE_TYPES } from '../../../components/transferAmountInputSection/transferAmountInputSection';
 
@@ -33,6 +34,12 @@ import { dateToFormatted } from '../../../utils/time';
 
 // Hive's recurrent_transfer operation requires at least 2 executions.
 const MIN_RECURRENT_EXECUTIONS = 2;
+
+// The preset cadence labels reuse the shared leaderboard.* strings, which are ALL CAPS
+// (e.g. "DAILY"). Title-case them so the compact header pill reads "Daily" alongside the
+// title-cased "One Time"/"Custom" entries instead of a jarring "DAILY".
+const toTitleCase = (value: string) =>
+  value.replace(/\S+/g, (word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase());
 
 interface TransferViewProps {
   currentAccountName: string;
@@ -91,6 +98,7 @@ const TransferView = ({
 }: TransferViewProps) => {
   const intl = useIntl();
   const dispatch = useDispatch();
+  const navigation = useNavigation();
 
   const [from] = useState(currentAccountName);
   const [destination, setDestination] = useState(
@@ -119,6 +127,7 @@ const TransferView = ({
   const [isScheduledTransfer, setIsScheduledTransfer] = useState(
     transferType === TransferTypes.RECURRENT_TRANSFER,
   );
+  const [showScheduleMenu, setShowScheduleMenu] = useState(false);
 
   const [isUsernameValid, setIsUsernameValid] = useState(false);
   const [usersResult, setUsersResult] = useState<string[]>([]);
@@ -127,7 +136,6 @@ const TransferView = ({
 
   const destinationRef = useRef<string[]>([]);
   const hasInitializedRef = useRef(false);
-  const dpRef = useRef();
   // Tracks the recipient whose existing on-chain schedule we last autofilled, so a
   // different recipient without a schedule can be reset without wiping manual input.
   const lastHydratedRecipientRef = useRef<string | null>(null);
@@ -193,7 +201,7 @@ const TransferView = ({
   const scheduleOptions = useMemo(() => {
     const options = [
       intl.formatMessage({ id: 'transfer.one_time', defaultMessage: 'One Time' }),
-      ...RECURRENCE_TYPES.map((item) => intl.formatMessage({ id: item.intlId })),
+      ...RECURRENCE_TYPES.map((item) => toTitleCase(intl.formatMessage({ id: item.intlId }))),
     ];
     if (isOffGridRecurrence) {
       // Surface the real (non-preset) cadence instead of mislabeling it as the first
@@ -413,14 +421,12 @@ const TransferView = ({
     }
   };
 
-  // Keep `recurrence` normalized to a canonical preset value and sync the dropdown
-  // highlight. Reuses the render-scope recurrenceIndex/scheduleSelectedIndex.
+  // Keep `recurrence` normalized to a canonical preset value. The schedule pill in the
+  // header reads scheduleOptions[scheduleSelectedIndex] directly, so it stays in sync
+  // without any imperative dropdown handle.
   useEffect(() => {
     if (recurrenceIndex > -1) {
       setRecurrence(`${RECURRENCE_TYPES[recurrenceIndex].hours}`);
-    }
-    if (dpRef?.current) {
-      dpRef.current.select(scheduleSelectedIndex);
     }
   }, [recurrence, isRecurrentTransfer]);
 
@@ -780,10 +786,47 @@ const TransferView = ({
 
   return (
     <SafeAreaView style={styles.container}>
-      <BasicHeader
-        title={intl.formatMessage({ id: `wallet.${oneTimeTransferType}` })}
-        backIconName="close"
-      />
+      <View style={styles.header}>
+        <TouchableOpacity
+          style={styles.headerSide}
+          onPress={() => navigation.goBack()}
+          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+          accessibilityRole="button"
+          accessibilityLabel={intl.formatMessage({ id: 'transfer.close', defaultMessage: 'Close' })}
+        >
+          <Icon iconType="MaterialIcons" name="close" size={26} style={styles.headerCloseIcon} />
+        </TouchableOpacity>
+
+        <View style={styles.headerCenter}>
+          <Text style={styles.headerTitle} numberOfLines={1}>
+            {intl.formatMessage({ id: `wallet.${oneTimeTransferType}` })}
+          </Text>
+          {canScheduleTransfer && (
+            <TouchableOpacity
+              style={styles.scheduleTrigger}
+              onPress={() => setShowScheduleMenu((prev) => !prev)}
+              activeOpacity={0.7}
+              accessibilityRole="button"
+              accessibilityState={{ expanded: showScheduleMenu }}
+              accessibilityLabel={`${intl.formatMessage({ id: 'transfer.schedule' })}, ${
+                scheduleOptions[scheduleSelectedIndex]
+              }`}
+            >
+              <Text style={styles.scheduleTriggerText} numberOfLines={1}>
+                {scheduleOptions[scheduleSelectedIndex]}
+              </Text>
+              <Icon
+                iconType="MaterialCommunityIcons"
+                name={showScheduleMenu ? 'chevron-up' : 'chevron-down'}
+                size={18}
+                style={styles.scheduleChevron}
+              />
+            </TouchableOpacity>
+          )}
+        </View>
+
+        <View style={styles.headerSide} />
+      </View>
 
       <KeyboardAwareScrollView
         keyboardShouldPersistTaps="always"
@@ -791,26 +834,6 @@ const TransferView = ({
         extraScrollHeight={80}
         contentContainerStyle={styles.scrollContent}
       >
-        {canScheduleTransfer && (
-          <View style={styles.scheduleSection}>
-            <Text style={styles.fieldLabel}>
-              {intl.formatMessage({ id: 'transfer.schedule', defaultMessage: 'Schedule' })}
-            </Text>
-            <DropdownButton
-              dropdownButtonStyle={styles.scheduleButton}
-              rowTextStyle={styles.dropdownRowText}
-              style={styles.dropdownWrapper}
-              dropdownStyle={styles.dropdownMenu}
-              textStyle={styles.scheduleButtonText}
-              options={scheduleOptions}
-              defaultText={scheduleOptions[0]}
-              selectedOptionIndex={scheduleSelectedIndex}
-              onSelect={_handleScheduleSelect}
-              dropdownRef={dpRef}
-            />
-          </View>
-        )}
-
         {/* --- Recipient Section --- */}
         {!destinationLocked && (
           <View style={styles.recipientSection}>
@@ -1061,6 +1084,50 @@ const TransferView = ({
                 </Text>
               </TouchableOpacity>
             ))}
+          </View>
+        </TouchableOpacity>
+      )}
+
+      {/* Schedule Dropdown Menu (drops from the header title area) */}
+      {showScheduleMenu && (
+        <TouchableOpacity
+          style={styles.scheduleMenuOverlay}
+          activeOpacity={1}
+          onPress={() => setShowScheduleMenu(false)}
+        >
+          <View style={styles.scheduleMenuCard}>
+            {scheduleOptions.map((option, index) => {
+              const isActive = index === scheduleSelectedIndex;
+              return (
+                <TouchableOpacity
+                  key={option}
+                  style={[styles.scheduleMenuItem, isActive && styles.scheduleMenuItemActive]}
+                  onPress={() => {
+                    setShowScheduleMenu(false);
+                    _handleScheduleSelect(index);
+                  }}
+                  accessibilityRole="button"
+                  accessibilityState={{ selected: isActive }}
+                >
+                  <Text
+                    style={[
+                      styles.scheduleMenuItemText,
+                      isActive && styles.scheduleMenuItemTextActive,
+                    ]}
+                  >
+                    {option}
+                  </Text>
+                  {isActive && (
+                    <Icon
+                      iconType="MaterialCommunityIcons"
+                      name="check"
+                      size={18}
+                      style={styles.scheduleMenuCheck}
+                    />
+                  )}
+                </TouchableOpacity>
+              );
+            })}
           </View>
         </TouchableOpacity>
       )}

--- a/src/screens/transfer/screen/transferStyles.ts
+++ b/src/screens/transfer/screen/transferStyles.ts
@@ -13,6 +13,53 @@ export default EStyleSheet.create({
     backgroundColor: '$primaryBackgroundColor',
   },
 
+  // --- Header (close + centered title with schedule subtitle) ---
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 8,
+    paddingVertical: 8,
+    backgroundColor: '$primaryBackgroundColor',
+  },
+  headerSide: {
+    width: 44,
+    height: 44,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  headerCloseIcon: {
+    fontSize: 26,
+    color: '$iconColor',
+  },
+  headerCenter: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  headerTitle: {
+    fontSize: 17,
+    fontWeight: '700',
+    color: '$primaryBlack',
+    textAlign: 'center',
+  },
+  scheduleTrigger: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    alignSelf: 'center',
+    marginTop: 2,
+    paddingVertical: 2,
+    paddingHorizontal: 4,
+  },
+  scheduleTriggerText: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: '$iconColor',
+  },
+  scheduleChevron: {
+    color: '$iconColor',
+    marginLeft: 2,
+  },
+
   // --- Recipient Section ---
   recipientSection: {
     paddingVertical: 16,
@@ -94,23 +141,55 @@ export default EStyleSheet.create({
     paddingHorizontal: 14,
   },
 
-  // --- Schedule ---
-  scheduleSection: {
-    marginBottom: 16,
+  // --- Schedule dropdown menu (anchored under the header title) ---
+  scheduleMenuOverlay: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    alignItems: 'center',
+    justifyContent: 'flex-start',
+    paddingTop: 64,
+    zIndex: 100,
   },
-  scheduleButton: {
+  scheduleMenuCard: {
+    backgroundColor: '$primaryBackgroundColor',
+    borderRadius: 14,
+    paddingVertical: 6,
+    minWidth: 220,
     borderWidth: 1,
     borderColor: '$borderColor',
-    borderRadius: 12,
-    paddingHorizontal: 14,
-    paddingVertical: 12,
-    backgroundColor: '$primaryLightBackground',
-    minHeight: 48,
+    shadowColor: '$shadowColor',
+    shadowOpacity: 0.18,
+    shadowOffset: { width: 0, height: 6 },
+    shadowRadius: 12,
+    elevation: 8,
   },
-  scheduleButtonText: {
-    fontSize: 16,
+  scheduleMenuItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingVertical: 12,
+    paddingHorizontal: 18,
+    borderRadius: 10,
+    marginHorizontal: 6,
+  },
+  scheduleMenuItemActive: {
+    backgroundColor: '$primaryLightBackground',
+  },
+  scheduleMenuItemText: {
+    fontSize: 15,
+    fontWeight: '500',
     color: '$primaryBlack',
-    paddingHorizontal: 0,
+  },
+  scheduleMenuItemTextActive: {
+    color: '$primaryBlue',
+    fontWeight: '700',
+  },
+  scheduleMenuCheck: {
+    color: '$primaryBlue',
+    marginLeft: 16,
   },
 
   // --- Amount ---

--- a/src/utils/wallet.test.ts
+++ b/src/utils/wallet.test.ts
@@ -92,6 +92,7 @@ describe('groomingTransactionData', () => {
       expect(result!.icon).toBe('autorenew');
       expect(result!.details).toBe('@alice to @bob');
       expect(result!.executions).toBe('2');
+      expect(result!.recurrence).toBe('');
     });
 
     it('parses transfer_to_savings', () => {

--- a/src/utils/wallet.test.ts
+++ b/src/utils/wallet.test.ts
@@ -51,6 +51,49 @@ describe('groomingTransactionData', () => {
       expect(result!.memo).toBe('test memo');
     });
 
+    it('parses recurrent_transfer with cadence and execution count', () => {
+      const tx = {
+        type: 'recurrent_transfer',
+        timestamp: '2024-01-01T00:00:00',
+        num: 21,
+        amount: '1.000 HIVE',
+        memo: 'rent',
+        from: 'alice',
+        to: 'bob',
+        recurrence: 24,
+        executions: 3,
+      };
+      const result = groomingTransactionData(tx, hivePerMVests);
+      expect(result!.textKey).toBe('recurrent_transfer');
+      expect(result!.value).toBe('1.000 HIVE');
+      expect(result!.icon).toBe('autorenew');
+      expect(result!.details).toBe('@alice to @bob');
+      expect(result!.sender).toBe('alice');
+      expect(result!.receiver).toBe('bob');
+      expect(result!.memo).toBe('rent');
+      expect(result!.recurrence).toBe('24');
+      expect(result!.executions).toBe('3');
+    });
+
+    it('parses fill_recurrent_transfer with remaining executions', () => {
+      const tx = {
+        type: 'fill_recurrent_transfer',
+        timestamp: '2024-01-02T00:00:00',
+        num: 22,
+        amount: '1.000 HIVE',
+        memo: 'rent',
+        from: 'alice',
+        to: 'bob',
+        remaining_executions: 2,
+      };
+      const result = groomingTransactionData(tx, hivePerMVests);
+      expect(result!.textKey).toBe('fill_recurrent_transfer');
+      expect(result!.value).toBe('1.000 HIVE');
+      expect(result!.icon).toBe('autorenew');
+      expect(result!.details).toBe('@alice to @bob');
+      expect(result!.executions).toBe('2');
+    });
+
     it('parses transfer_to_savings', () => {
       const tx = {
         type: 'transfer_to_savings',

--- a/src/utils/wallet.ts
+++ b/src/utils/wallet.ts
@@ -22,6 +22,8 @@ export const transferTypes = [
   'comment_benefactor_reward',
   'claim_reward_balance',
   'transfer',
+  'recurrent_transfer',
+  'fill_recurrent_transfer',
   'transfer_to_savings',
   'transfer_from_savings',
   'transfer_to_vesting',
@@ -122,6 +124,35 @@ export const groomingTransactionData = (transaction, hivePerMVests): CoinActivit
       result.receiver = to;
       result.memo = memo || null;
       break;
+    case 'recurrent_transfer': {
+      // The on-chain operation that sets up a schedule. `recurrence` is the gap between
+      // executions in hours and `executions` is the total scheduled count; both are
+      // surfaced as the row subtitle by the transaction view.
+      const { amount: rtAmount, memo: rtMemo, from: rtFrom, to: rtTo } = opData;
+      result.value = `${rtAmount}`;
+      result.icon = 'autorenew';
+      result.details = rtFrom && rtTo ? `@${rtFrom} to @${rtTo}` : null;
+      result.sender = rtFrom;
+      result.receiver = rtTo;
+      result.memo = rtMemo || null;
+      result.recurrence = opData.recurrence != null ? `${opData.recurrence}` : '';
+      result.executions = opData.executions != null ? `${opData.executions}` : '';
+      break;
+    }
+    case 'fill_recurrent_transfer': {
+      // Virtual operation emitted on each scheduled execution. It only carries how many
+      // executions remain, which we keep in `executions` for the "Remaining N" subtitle.
+      const { amount: frtAmount, memo: frtMemo, from: frtFrom, to: frtTo } = opData;
+      result.value = `${frtAmount}`;
+      result.icon = 'autorenew';
+      result.details = frtFrom && frtTo ? `@${frtFrom} to @${frtTo}` : null;
+      result.sender = frtFrom;
+      result.receiver = frtTo;
+      result.memo = frtMemo || null;
+      result.executions =
+        opData.remaining_executions != null ? `${opData.remaining_executions}` : '';
+      break;
+    }
     case 'withdraw_vesting':
       const { acc } = opData;
       let { vesting_shares: opVestingShares } = opData;

--- a/src/utils/wallet.ts
+++ b/src/utils/wallet.ts
@@ -149,6 +149,8 @@ export const groomingTransactionData = (transaction, hivePerMVests): CoinActivit
       result.sender = frtFrom;
       result.receiver = frtTo;
       result.memo = frtMemo || null;
+      // A fill op carries no cadence; keep the field present so the CoinActivity shape stays consistent.
+      result.recurrence = '';
       result.executions =
         opData.remaining_executions != null ? `${opData.remaining_executions}` : '';
       break;


### PR DESCRIPTION
## Summary

Two related wallet/transfer improvements:

### Transfer schedule selector → header dropdown
Replaces the bulky full-width "SCHEDULE" box on the transfer screen with a compact, centered header — a bold title with a tappable **"One Time" schedule pill** beneath it that opens an anchored dropdown menu from the title area (One Time / Daily / Weekly / Monthly).

- Reuses the existing schedule logic; the selector is now fully controlled (drops the modal-dropdown and its imperative selection sync).
- Title-cases the preset cadence labels (Daily/Weekly/Monthly) so they read consistently with "One Time".
- Adds the missing `transfer.close` locale string (removes a missing-message warning).

### Recurrent transfers in wallet history
Recurrent transfers now appear in a token's **Activities** list, matching the web wallet:

- **Recurrent Transfer** — the schedule setup, with subtitle *"N transfers, each every X hours"*.
- **Recurrent Transfer Occurred** — each scheduled execution, with subtitle *"Remaining N transfers"*.

Adds `recurrent_transfer` and `fill_recurrent_transfer` to the history allow-list and grooming, plus the corresponding locale strings.

## Test plan
- [x] `yarn lint` — no new errors
- [x] `tsc --noEmit` — no new type errors
- [x] Unit tests pass, including new `groomingTransactionData` cases for `recurrent_transfer` / `fill_recurrent_transfer`
- [ ] Manual: transfer screen schedule pill + dropdown; HIVE Activities list shows recurrent transfer rows with cadence/remaining subtitles

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Recurrent transfers now show execution schedule summaries on transaction cards.
  * Filled recurrent transfers display remaining execution counts.
  * Transfer screen uses a header-triggered overlay menu for schedule selection.

* **Improvements**
  * Recurrence options and labels now render in title case with an improved header layout.

* **Localization**
  * Added UI strings for recurrence summaries and transfer labels.

* **Tests**
  * Added tests for recurrent transfer parsing and display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->