### PR TITLE
fix(speak): stop duplicate 3Speak video uploads (use token embed URL)

### DIFF
--- a/src/providers/speak/speak.test.ts
+++ b/src/providers/speak/speak.test.ts
@@ -66,80 +66,125 @@ describe('getUploadTuning', () => {
   });
 });
 
-describe('uploadVideoEmbed', () => {
-  const media = (size: number) =>
-    ({ path: 'file:///tmp/video.mp4', size, filename: 'video.mp4' } as any);
+const media = (size: number) =>
+  ({ path: 'file:///tmp/video.mp4', size, filename: 'video.mp4' } as any);
 
+// Token request returns a usable token (+ optional permlink/embed_url); the
+// local-file fetch (used to build the Blob) returns a minimal blob-like object.
+function stubFetch(tokenExtra: Record<string, unknown> = {}) {
+  global.fetch = jest.fn((url: any) => {
+    if (String(url).includes('/api/threespeak/upload-token')) {
+      return Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            token: 'tok',
+            upload_url: 'https://embed.test/uploads',
+            ...tokenExtra,
+          }),
+      });
+    }
+    return Promise.resolve({ blob: () => Promise.resolve({ size: 0 }) });
+  }) as any;
+}
+
+describe('uploadVideoEmbed with a token-bound permlink (preferred path)', () => {
   beforeEach(() => {
     mockTus.runUpload = () => {};
-    // Token request returns a usable token + endpoint; the local-file fetch
-    // (used to build the Blob) returns a minimal blob-like object.
-    global.fetch = jest.fn((url: any) => {
-      if (String(url).includes('/api/threespeak/upload-token')) {
-        return Promise.resolve({
-          ok: true,
-          json: () => Promise.resolve({ token: 'tok', upload_url: 'https://embed.test/uploads' }),
-        });
-      }
-      return Promise.resolve({ blob: () => Promise.resolve({ size: 0 }) });
-    }) as any;
+    stubFetch({ permlink: 'TOK12345', embed_url: 'https://play.3speak.tv/embed?v=a/TOK12345' });
   });
 
-  it('falls back to sequential when the parallel attempt has no final-concat URL', async () => {
+  it('keeps parallel uploads on for big files and resolves with the token URL', async () => {
+    let seenParallel = -1;
     mockTus.runUpload = (options: any) => {
-      if (options.parallelUploads > 1) {
-        // Parallel attempt: only a partial-creation URL, no final concat -> rejects.
-        options.onAfterResponse(
-          mockReq('partial'),
-          mockRes('https://play.3speak.tv/embed?v=a/PART01'),
-        );
-        options.onSuccess();
-      } else {
-        // Sequential retry: backend returns a usable embed URL.
-        options.onAfterResponse(mockReq(), mockRes('https://play.3speak.tv/embed?v=a/SEQFALL01'));
-        options.onSuccess();
-      }
-    };
-    await expect(uploadVideoEmbed(media(11 * MB), 'a', 'token', false, () => {})).resolves.toEqual({
-      embedUrl: 'https://play.3speak.tv/embed?v=a/SEQFALL01',
-      permlink: 'SEQFALL01',
-    });
-  });
-
-  it('resolves a parallel upload to the final-concat embed URL', async () => {
-    mockTus.runUpload = (options: any) => {
-      options.onAfterResponse(
-        mockReq('partial'),
-        mockRes('https://play.3speak.tv/embed?v=a/PART01'),
-      );
-      options.onAfterResponse(
-        mockReq('final;https://embed.test/a https://embed.test/b'),
-        mockRes('https://play.3speak.tv/embed?v=a/FINAL567'),
-      );
+      seenParallel = options.parallelUploads;
       options.onSuccess();
     };
     await expect(uploadVideoEmbed(media(11 * MB), 'a', 'token', false, () => {})).resolves.toEqual({
-      embedUrl: 'https://play.3speak.tv/embed?v=a/FINAL567',
-      permlink: 'FINAL567',
+      embedUrl: 'https://play.3speak.tv/embed?v=a/TOK12345',
+      permlink: 'TOK12345',
     });
+    expect(seenParallel).toBe(3);
   });
 
-  it('uses the last-seen embed URL for a sequential upload (no concat step)', async () => {
+  it('uploads small files sequentially and resolves with the token URL', async () => {
+    let seenParallel = -1;
     mockTus.runUpload = (options: any) => {
-      options.onAfterResponse(mockReq(), mockRes('https://play.3speak.tv/embed?v=a/SEQ12345'));
+      seenParallel = options.parallelUploads;
       options.onSuccess();
     };
     await expect(uploadVideoEmbed(media(1024), 'a', 'token', false, () => {})).resolves.toEqual({
-      embedUrl: 'https://play.3speak.tv/embed?v=a/SEQ12345',
-      permlink: 'SEQ12345',
+      embedUrl: 'https://play.3speak.tv/embed?v=a/TOK12345',
+      permlink: 'TOK12345',
     });
+    expect(seenParallel).toBe(1);
   });
 
-  it('propagates the error when both the parallel and sequential attempts fail', async () => {
+  it('never re-uploads: a failed upload rejects without a second attempt', async () => {
+    let attempts = 0;
     mockTus.runUpload = (options: any) => {
+      attempts += 1;
       options.onError(new Error('network down'));
     };
     await expect(uploadVideoEmbed(media(11 * MB), 'a', 'token', false, () => {})).rejects.toThrow(
+      /network down/,
+    );
+    expect(attempts).toBe(1);
+  });
+});
+
+describe('uploadVideoEmbed against a legacy backend (header fallback)', () => {
+  beforeEach(() => {
+    mockTus.runUpload = () => {};
+    stubFetch(); // no permlink/embed_url in the token response
+  });
+
+  it('uploads sequentially even for big files and reads the X-Embed-URL header', async () => {
+    let seenParallel = -1;
+    mockTus.runUpload = (options: any) => {
+      seenParallel = options.parallelUploads;
+      options.onAfterResponse(mockReq(), mockRes('https://play.3speak.tv/embed?v=a/SEQ12345'));
+      options.onSuccess();
+    };
+    await expect(uploadVideoEmbed(media(11 * MB), 'a', 'token', false, () => {})).resolves.toEqual({
+      embedUrl: 'https://play.3speak.tv/embed?v=a/SEQ12345',
+      permlink: 'SEQ12345',
+    });
+    // Legacy path must avoid the racy parallel/concat header delivery.
+    expect(seenParallel).toBe(1);
+  });
+
+  it('falls back to the header path when the token carries only a permlink', async () => {
+    // Partial token response (permlink but no embed_url) must not be used as the
+    // result — it should fall through to the sequential header path.
+    stubFetch({ permlink: 'TOK12345' });
+    let seenParallel = -1;
+    mockTus.runUpload = (options: any) => {
+      seenParallel = options.parallelUploads;
+      options.onAfterResponse(mockReq(), mockRes('https://play.3speak.tv/embed?v=a/SEQ99999'));
+      options.onSuccess();
+    };
+    await expect(uploadVideoEmbed(media(11 * MB), 'a', 'token', false, () => {})).resolves.toEqual({
+      embedUrl: 'https://play.3speak.tv/embed?v=a/SEQ99999',
+      permlink: 'SEQ99999',
+    });
+    expect(seenParallel).toBe(1);
+  });
+
+  it('rejects when the backend returns no embed URL header', async () => {
+    mockTus.runUpload = (options: any) => {
+      options.onSuccess();
+    };
+    await expect(uploadVideoEmbed(media(1024), 'a', 'token', false, () => {})).rejects.toThrow(
+      /no embed URL was returned/,
+    );
+  });
+
+  it('propagates the upload error', async () => {
+    mockTus.runUpload = (options: any) => {
+      options.onError(new Error('network down'));
+    };
+    await expect(uploadVideoEmbed(media(1024), 'a', 'token', false, () => {})).rejects.toThrow(
       /network down/,
     );
   });

--- a/src/providers/speak/speak.ts
+++ b/src/providers/speak/speak.ts
@@ -228,6 +228,8 @@ async function uploadFromHeader(
       headers: { Authorization: `Bearer ${token}` },
       metadata: { filename: file.name },
       onError(error: Error) {
+        // Cancel any in-progress retry before rejecting, mirroring runTusUpload.
+        upload.abort().catch(() => {});
         reject(error);
       },
       onProgress(bytesUploaded: number, bytesTotal: number) {

--- a/src/providers/speak/speak.ts
+++ b/src/providers/speak/speak.ts
@@ -88,11 +88,16 @@ export function getUploadTuning(size: number): { chunkSize: number; parallelUplo
 /**
  * Upload a video file using the new 3Speak embed architecture.
  *
- * Flow:
- * 1. Request a short-lived upload token from the Ecency proxy.
- * 2. Upload the file via the TUS resumable protocol.
- * 3. Read the embed URL from the `x-embed-url` response header.
- * 4. Return { embedUrl, permlink }.
+ * The upload token carries the video's permlink and canonical embed URL
+ * (assigned by the backend at token issuance), so the result no longer depends
+ * on reading an X-Embed-URL response header. That is what makes parallel (TUS
+ * Concatenation) uploads reliable: previously, when the final-concat response
+ * didn't surface that header, the client treated a completed upload as a
+ * failure and re-uploaded the whole file, producing duplicate uploads.
+ *
+ * Against an older backend that doesn't return a permlink with the token, we
+ * fall back to a sequential, header-based upload. Neither path ever re-uploads,
+ * so duplicates can't happen.
  */
 export async function uploadVideoEmbed(
   media: Video | Image,
@@ -137,118 +142,114 @@ export async function uploadVideoEmbed(
   file.name = filename;
   file.size = media.size;
 
-  // Adaptive chunking + parallelism (TUS Concatenation extension).
-  const { chunkSize, parallelUploads } = getUploadTuning(media.size);
+  const { token, upload_url, permlink, embed_url } = await requestUploadToken(
+    owner,
+    accessToken,
+    isShort,
+  );
+  const endpoint = upload_url || `${EMBED_ENDPOINT}/uploads`;
 
-  try {
-    return await uploadOnce(
-      file,
-      owner,
-      accessToken,
-      isShort,
-      chunkSize,
-      parallelUploads,
-      progressCallback,
-    );
-  } catch (err) {
-    if (parallelUploads > 1) {
-      // Parallel uploads require the 3Speak tusd backend to support the
-      // Concatenation extension AND return X-Embed-URL on the final concat
-      // response. If that doesn't hold, retry once on the proven sequential
-      // path (with a fresh token) rather than failing the upload.
-      console.warn('[3Speak] Parallel upload failed; retrying sequentially.', err);
-      progressCallback(0);
-      return uploadOnce(file, owner, accessToken, isShort, chunkSize, 1, progressCallback);
-    }
-    throw err;
+  // Preferred path: the backend assigned the permlink/embed URL up front, so we
+  // run a single upload (parallel for files > 10MB) and resolve with the known
+  // URL on success — no header to capture, no re-upload.
+  if (permlink && embed_url) {
+    const { chunkSize, parallelUploads } = getUploadTuning(media.size);
+    await runTusUpload(file, token, endpoint, chunkSize, parallelUploads, progressCallback);
+    return { embedUrl: embed_url, permlink };
   }
+
+  // Legacy backend: the embed URL only comes back via the X-Embed-URL header.
+  // Use the sequential path — its single create→response keeps the header
+  // reliable, and because it never re-uploads, a missing header surfaces as an
+  // error instead of silently duplicating the upload.
+  const { chunkSize } = getUploadTuning(media.size);
+  return uploadFromHeader(file, token, endpoint, chunkSize, progressCallback);
 }
 
+const TUS_RETRY_DELAYS = [0, 3000, 5000, 10000, 20000];
+
 /**
- * Perform a single TUS upload attempt with an explicit chunk size / parallelism.
- * Obtains a fresh short-lived upload token, then uploads directly to 3Speak.
+ * Run a TUS upload to completion. Resolves on success, rejects on error.
+ * Aborts in-flight parts on error so a failed parallel upload doesn't keep
+ * pushing bytes in the background.
  */
-async function uploadOnce(
+async function runTusUpload(
   file: any,
-  owner: string,
-  accessToken: string,
-  isShort: boolean,
+  token: string,
+  endpoint: string,
   chunkSize: number,
   parallelUploads: number,
   progressCallback: (percentage: number) => void,
-): Promise<VideoUploadResult> {
-  const { token, upload_url } = await requestUploadToken(owner, accessToken, isShort);
-  const endpoint = upload_url || `${EMBED_ENDPOINT}/uploads`;
-
-  return new Promise<VideoUploadResult>((resolve, reject) => {
-    // With parallelUploads the partial creation responses each carry their own
-    // X-Embed-URL; the canonical one is on the final concatenation request
-    // (Upload-Concat: final). Prefer it, falling back to the last-seen URL so
-    // the sequential path (parallelUploads = 1) keeps its previous behaviour.
-    let embedUrl = '';
-    let finalEmbedUrl = '';
-
+): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
     const upload = new tus.Upload(file, {
       endpoint,
       chunkSize,
       parallelUploads,
-      retryDelays: [0, 3000, 5000, 10000, 20000],
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
-      metadata: {
-        filename: file.name,
-      },
+      retryDelays: TUS_RETRY_DELAYS,
+      headers: { Authorization: `Bearer ${token}` },
+      metadata: { filename: file.name },
       onError(error: Error) {
-        // Stop any still-in-flight parallel parts so they don't keep uploading
-        // while the caller retries sequentially.
         upload.abort().catch(() => {});
         reject(error);
       },
       onProgress(bytesUploaded: number, bytesTotal: number) {
-        const percentage = Number(((bytesUploaded / bytesTotal) * 100).toFixed(2));
-        progressCallback(percentage);
+        progressCallback(Number(((bytesUploaded / bytesTotal) * 100).toFixed(2)));
       },
       onSuccess() {
-        // The canonical embed URL is the one returned by the final
-        // concatenation request (Upload-Concat: final). In parallel mode we
-        // REQUIRE it: partial creation responses carry their own non-canonical
-        // URLs, so falling back to one would link the post to a transient
-        // partial resource. The sequential path has no concat step, so the
-        // last-seen URL (the final PATCH) is canonical and used as the fallback.
-        if (parallelUploads > 1 && !finalEmbedUrl) {
-          reject(
-            new Error(
-              '[3Speak] Parallel upload finished without an X-Embed-URL on the final concatenation ' +
-                'response; refusing to fall back to a partial-upload URL.',
-            ),
-          );
-          return;
-        }
-        const resolvedUrl = finalEmbedUrl || embedUrl;
-        if (resolvedUrl) {
-          const permlink = extractPermlink(resolvedUrl);
-          if (!permlink) {
-            reject(new Error('[3Speak] Upload succeeded but permlink could not be extracted'));
-            return;
-          }
-          resolve({ embedUrl: resolvedUrl, permlink });
-        } else {
-          reject(new Error('[3Speak] Upload succeeded but no embed URL was returned'));
-        }
+        resolve();
       },
-      onAfterResponse(req: any, res: any) {
-        const headerUrl = res.getHeader?.('x-embed-url') || res.getHeader?.('X-Embed-URL');
-        if (!headerUrl) {
+    });
+
+    upload.start();
+  });
+}
+
+/**
+ * Legacy fallback for backends that don't return a permlink with the token.
+ * Uploads sequentially (parallelUploads = 1) and reads the embed URL from the
+ * X-Embed-URL header on the create response.
+ */
+async function uploadFromHeader(
+  file: any,
+  token: string,
+  endpoint: string,
+  chunkSize: number,
+  progressCallback: (percentage: number) => void,
+): Promise<VideoUploadResult> {
+  return new Promise<VideoUploadResult>((resolve, reject) => {
+    let embedUrl = '';
+
+    const upload = new tus.Upload(file, {
+      endpoint,
+      chunkSize,
+      parallelUploads: 1,
+      retryDelays: TUS_RETRY_DELAYS,
+      headers: { Authorization: `Bearer ${token}` },
+      metadata: { filename: file.name },
+      onError(error: Error) {
+        reject(error);
+      },
+      onProgress(bytesUploaded: number, bytesTotal: number) {
+        progressCallback(Number(((bytesUploaded / bytesTotal) * 100).toFixed(2)));
+      },
+      onSuccess() {
+        if (!embedUrl) {
+          reject(new Error('[3Speak] Upload succeeded but no embed URL was returned'));
           return;
         }
-        // Prefer the embed URL from the final concatenation request; partial
-        // creation responses (Upload-Concat: partial) may carry their own.
-        const concat = String(req.getHeader?.('Upload-Concat') ?? '');
-        if (concat.startsWith('final')) {
-          finalEmbedUrl = headerUrl;
+        const permlink = extractPermlink(embedUrl);
+        if (!permlink) {
+          reject(new Error('[3Speak] Upload succeeded but permlink could not be extracted'));
+          return;
         }
-        embedUrl = headerUrl;
+        resolve({ embedUrl, permlink });
+      },
+      onAfterResponse(_req: any, res: any) {
+        const headerUrl = res.getHeader?.('x-embed-url') || res.getHeader?.('X-Embed-URL');
+        if (headerUrl) {
+          embedUrl = headerUrl;
+        }
       },
     });
 

--- a/src/providers/speak/speak.types.ts
+++ b/src/providers/speak/speak.types.ts
@@ -10,4 +10,12 @@ export interface VideoUploadResult {
 export interface UploadTokenResponse {
   token: string;
   upload_url?: string;
+  /**
+   * Video permlink assigned by the backend at token issuance. When present the
+   * client knows the embed URL before uploading, so it never needs to read the
+   * X-Embed-URL response header (unreliable for parallel/Concatenation uploads).
+   */
+  permlink?: string;
+  /** Canonical embed URL, returned alongside `permlink` by newer backends. */
+  embed_url?: string;
 }


### PR DESCRIPTION
## Problem

Same duplicate-upload bug as the web app (ecency/vision-next#920, reported by @menobass): uploading one video created multiple identical uploads on 3Speak.

For files > 10 MB the app uses parallel uploads (`tus-js-client` `parallelUploads: 3`, TUS Concatenation). `uploadVideoEmbed` **required** an `X-Embed-URL` header on the final-concat response and, when the embed backend didn't surface it, treated the *already-completed* upload as a failure and re-uploaded the entire file with a fresh token (the parallel→sequential `uploadOnce` fallback). The header is delivered server-side via a global, unkeyed FIFO that desyncs under concurrency, and a Concatenation final emits no `204`, so the header was frequently missed — turning each large parallel upload into 2-3 full uploads.

## Fix

The embed backend now assigns the permlink at token issuance and returns `permlink` + `embed_url` alongside the token (backend PR: Mantequilla-Soft/embedvideos#24). The embed URL is therefore known before a single byte is uploaded. `uploadVideoEmbed` now:

- **Preferred path** (token carries a permlink): runs one upload (parallel stays on for large files) and resolves with the token's `embed_url`/`permlink` on success — no header to capture, **no re-upload**.
- **Legacy path** (older backend, no permlink in the token): uploads sequentially and reads the `X-Embed-URL` header. Sequential's single create→response keeps the header reliable, and it never re-uploads — a missing header surfaces as an error instead of silently duplicating.

Neither path re-uploads, so duplicates can't occur regardless of which backend version is deployed. The Ecency `/api/threespeak/upload-token` proxy already forwards the backend response verbatim, so no proxy change is needed.

This mirrors the web fix in ecency/vision-next#933.

## Tests

`speak.test.ts` rewritten to cover both paths: token-bound permlink (parallel kept on for big files, sequential for small, never re-uploads on error) and the legacy header fallback (sequential even for big files, partial-token fallthrough, rejects when no header, propagates errors). `jest` green (12 tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded video upload test coverage with scenarios for both modern and legacy backend support.

* **Refactor**
  * Improved video upload architecture for enhanced reliability and backend compatibility, including better error handling and fallback mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->