### PR TITLE
feat(leaderboard): surface daily quest finishers at the top

### DIFF
--- a/src/components/leaderboard/container/leaderboardContainer.tsx
+++ b/src/components/leaderboard/container/leaderboardContainer.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 
 // Constants
 import { useDispatch } from 'react-redux';
@@ -26,6 +26,21 @@ const LeaderboardContainer = () => {
   const [duration, setDuration] = useState(FILTER_OPTIONS[selectedIndex]);
 
   const leaderboardQuery = leaderboardQuries.useGetLeaderboardQuery(duration);
+
+  // On the daily board, float users who completed their quests to the top so
+  // they're more visible. Stable partition — relative (point) order within each
+  // group is preserved. quests_done only exists on the daily duration, so the
+  // weekly/monthly boards stay in their original ranking.
+  const users = useMemo(() => {
+    const { data } = leaderboardQuery;
+    if (selectedIndex !== 0 || !Array.isArray(data)) {
+      return data;
+    }
+    const done = [];
+    const rest = [];
+    data.forEach((item) => (item?.quests_done ? done : rest).push(item));
+    return [...done, ...rest];
+  }, [leaderboardQuery.data, selectedIndex]);
 
   // surface fetch errors as a toast
   useEffect(() => {
@@ -65,7 +80,7 @@ const LeaderboardContainer = () => {
 
   return (
     <LeaderboardView
-      users={leaderboardQuery.data}
+      users={users}
       refreshing={leaderboardQuery.isFetching}
       fetchLeaderBoard={_fetchLeaderBoard}
       handleOnUserPress={_handleOnUserPress}

--- a/src/components/leaderboard/view/leaderboardStyles.ts
+++ b/src/components/leaderboard/view/leaderboardStyles.ts
@@ -21,7 +21,7 @@ export default EStyleSheet.create({
   // Fixed-width left slot so the avatar column lines up uniformly whether the
   // row shows a checkmark (quest done) or a rank number of any digit count.
   rankWrapper: {
-    width: 22,
+    width: 28,
     alignItems: 'center',
     justifyContent: 'center',
     marginRight: 13,

--- a/src/components/leaderboard/view/leaderboardStyles.ts
+++ b/src/components/leaderboard/view/leaderboardStyles.ts
@@ -18,8 +18,17 @@ export default EStyleSheet.create({
   rewardText: {
     color: '$primaryBlue',
   },
-  questBadge: {
-    marginLeft: 6,
+  // Fixed-width left slot so the avatar column lines up uniformly whether the
+  // row shows a checkmark (quest done) or a rank number of any digit count.
+  rankWrapper: {
+    width: 22,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginRight: 13,
+  },
+  rankText: {
+    color: '$primaryDarkGray',
+    fontSize: 11,
   },
   columnTitleWrapper: {
     flexDirection: 'row',

--- a/src/components/leaderboard/view/leaderboardView.tsx
+++ b/src/components/leaderboard/view/leaderboardView.tsx
@@ -35,21 +35,23 @@ class LeaderboardView extends PureComponent {
         rightText={get(item, 'points')}
         middleText={get(item, 'count')}
         isLoggedIn
-        itemIndex={index + 1}
         handleOnPress={() => handleOnUserPress(get(item, '_id'))}
         rightTextStyle={styles.rewardText}
         rightTooltipText={intl.formatMessage({ id: 'leaderboard.tooltip_earn' })}
-        rightItemRenderer={() =>
-          selectedIndex === 0 && get(item, 'quests_done') ? (
-            <Icon
-              style={styles.questBadge}
-              name="check-circle"
-              iconType="MaterialCommunityIcons"
-              color={EStyleSheet.value('$primaryGreen')}
-              size={18}
-            />
-          ) : null
-        }
+        leftItemRenderer={() => (
+          <View style={styles.rankWrapper}>
+            {selectedIndex === 0 && get(item, 'quests_done') ? (
+              <Icon
+                name="check-circle"
+                iconType="MaterialCommunityIcons"
+                color={EStyleSheet.value('$primaryGreen')}
+                size={16}
+              />
+            ) : (
+              <Text style={styles.rankText}>{index + 1}</Text>
+            )}
+          </View>
+        )}
       />
     );
   };


### PR DESCRIPTION
## What

On the **Daily** leaderboard:

- **Quest finishers float to the top.** Users who completed their daily quests now sort above the rest so they're more visible. It's a stable partition — point ranking is preserved within each group, and Weekly/Monthly boards are untouched (they have no quest state).
- **Checkmark replaces the rank number.** A finisher's row now shows the green check *in place of* their rank number; users who haven't finished keep a number. The check moved out of the Reward column — where it widened those rows and knocked the reward values out of alignment — into a fixed-width left slot, so avatars and the Reward column now line up uniformly regardless of checkmark vs. number or digit count.

## Files

- `leaderboardContainer.tsx` — `useMemo` stable-partition of finishers to top (daily only)
- `leaderboardView.tsx` — checkmark/number rendered in the left rank slot; right-side badge removed
- `leaderboardStyles.ts` — fixed-width `rankWrapper` for uniform alignment

## Notes

- Non-finishers display their position in the reordered list (continuous numbering). Easy to switch to true points-rank if preferred.
- Lint passes (the one `no-unstable-nested-components` warning is pre-existing from the prior render-prop usage).
- Not yet verified on a simulator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Daily leaderboard now intelligently reorders users based on quest completion status, elevating those with completed quests.

* **Style**
  * Refined rank indicator styling and positioning in leaderboard display for enhanced visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->