### PR TITLE
feat(transfer): exchange-aware warnings on the transfer screen

### DIFF
--- a/src/config/locales/en-US.json
+++ b/src/config/locales/en-US.json
@@ -1426,7 +1426,9 @@
     "power_up_spk": "Stake LARYNX",
     "amount_select_desc_limit": " and must be greater than 0.001",
     "undelegate_engine": "Undelegate Token",
-    "to_bad_actor": "Use caution sending to this account. Please double check your spelling for possible phishing."
+    "to_bad_actor": "Use caution sending to this account. Please double check your spelling for possible phishing.",
+    "exchange_recurrent_warning": "{exchange} is an exchange and may not support recurring transfers — funds sent on a schedule can be lost. Use a one-time transfer instead.",
+    "exchange_memo_required": "Sending to {exchange} requires a memo. Without the exchange-provided memo your funds may be lost."
   },
   "login": {
     "cancel": "cancel",

--- a/src/constants/exchangeAccounts.ts
+++ b/src/constants/exchangeAccounts.ts
@@ -1,0 +1,32 @@
+// Known Hive exchange deposit accounts.
+//
+// Exchanges credit a deposit only when they observe a plain `transfer` operation
+// whose memo identifies the user's account. Two failure modes follow:
+//   1. A missing memo on a HIVE/HBD send means the deposit can't be attributed and
+//      the funds are typically lost.
+//   2. A `recurrent_transfer` settles through `fill_recurrent_transfer` *virtual*
+//      operations, which exchange deposit systems do not monitor, so recurring
+//      sends to an exchange may never be credited.
+//
+// Mirrors vision-next's apps/web/src/consts/exchange-accounts.ts — keep in sync when
+// the web list changes.
+export const EXCHANGE_ACCOUNTS = [
+  'deepcrypto8',
+  'gateiodeposit',
+  'probithive',
+  'mxchive',
+  'huobi-pro',
+  'coinexdeposit',
+  'bittrex',
+  'blocktrades',
+  'changelly',
+  'gopax-deposit',
+  'hitbtc-exchange',
+  'poloniex',
+  'upbit-exchange',
+  'onepagex',
+  'bdhivesteem',
+];
+
+export const isExchangeAccount = (username?: string | null) =>
+  !!username && EXCHANGE_ACCOUNTS.includes(username.trim().toLowerCase());

--- a/src/screens/transfer/screen/transferScreen.tsx
+++ b/src/screens/transfer/screen/transferScreen.tsx
@@ -746,7 +746,9 @@ const TransferView = ({
 
   // Exchanges settle recurrent_transfer through fill_recurrent_transfer virtual ops, which
   // their deposit systems don't watch — advise (without blocking) switching to one-time.
-  const exchangeRecurrentWarning = isRecurrentTransfer && !!exchangeDestination;
+  // Scheduling is only reachable for native HIVE/HBD, but gate on isNativeFund anyway so
+  // the notice can never surface for a non-native token.
+  const exchangeRecurrentWarning = isRecurrentTransfer && isNativeFund && !!exchangeDestination;
 
   const nextBtnDisabled = !(
     (isEngineToken ? amount > 0 : amount >= 0.001) &&

--- a/src/screens/transfer/screen/transferScreen.tsx
+++ b/src/screens/transfer/screen/transferScreen.tsx
@@ -31,6 +31,7 @@ import TokenLayers from '../../../constants/tokenLayers';
 import { EngineActions } from '../../../providers/hive-engine/hiveEngine.types';
 import { toastNotification } from '../../../redux/actions/uiAction';
 import { dateToFormatted } from '../../../utils/time';
+import { isExchangeAccount } from '../../../constants/exchangeAccounts';
 
 // Hive's recurrent_transfer operation requires at least 2 executions.
 const MIN_RECURRENT_EXECUTIONS = 2;
@@ -119,7 +120,7 @@ const TransferView = ({
 
   const [amount, setAmount] = useState(initialAmount != null ? `${initialAmount}` : '');
   const [memo, setMemo] = useState(
-    transferType === 'purchase_estm' ? 'estm-purchase' : initialMemo,
+    transferType === 'purchase_estm' ? 'estm-purchase' : initialMemo ?? '',
   );
   const [recurrence, setRecurrence] = useState('');
   const [executions, setExecutions] = useState('');
@@ -676,6 +677,22 @@ const TransferView = ({
   };
 
   const _onNextPress = async () => {
+    // Defense-in-depth: nextBtnDisabled already blocks this, but never broadcast a
+    // memo-less HIVE/HBD send to an exchange (the deposit is lost) regardless of which
+    // signing path _handleTransferAction takes.
+    if (exchangeMemoRequired) {
+      Alert.alert(
+        intl.formatMessage(
+          {
+            id: 'transfer.exchange_memo_required',
+            defaultMessage:
+              'Sending to {exchange} requires a memo. Without the exchange-provided memo your funds may be lost.',
+          },
+          { exchange: exchangeDestination },
+        ),
+      );
+      return false;
+    }
     const parsedDestinations = destination
       .trim()
       .split(/[\s,]+/)
@@ -699,6 +716,38 @@ const TransferView = ({
     }
   };
 
+  const destinationUsernames = useMemo(
+    () =>
+      destination
+        .trim()
+        .toLowerCase()
+        .split(/[\s,]+/)
+        .filter(Boolean),
+    [destination],
+  );
+
+  const badActorUsername = useMemo(
+    () => (badActors ? destinationUsernames.find((u) => badActors.has(u)) ?? null : null),
+    [destinationUsernames, badActors],
+  );
+
+  // First known exchange deposit account among the recipients, if any. Exchanges credit
+  // only plain `transfer` operations identified by a memo, which drives the two
+  // recipient-specific notices below.
+  const exchangeDestination = useMemo(
+    () => destinationUsernames.find((u) => isExchangeAccount(u)) ?? null,
+    [destinationUsernames],
+  );
+
+  // Sending HIVE/HBD to an exchange without a memo means the deposit can't be attributed
+  // and is typically lost — block submit until a memo is added (parity with ecency web).
+  const isNativeFund = fundType === 'HIVE' || fundType === 'HBD';
+  const exchangeMemoRequired = !!exchangeDestination && isNativeFund && !memo?.trim();
+
+  // Exchanges settle recurrent_transfer through fill_recurrent_transfer virtual ops, which
+  // their deposit systems don't watch — advise (without blocking) switching to one-time.
+  const exchangeRecurrentWarning = isRecurrentTransfer && !!exchangeDestination;
+
   const nextBtnDisabled = !(
     (isEngineToken ? amount > 0 : amount >= 0.001) &&
     isUsernameValid &&
@@ -707,6 +756,8 @@ const TransferView = ({
     // Wait for the Engine token's precision to load so the amount can't be
     // broadcast with the fallback 8-decimal precision before it is known.
     (!isEngineToken || tokenPrecision !== undefined) &&
+    // A HIVE/HBD send to an exchange must carry a memo or the deposit is lost.
+    !exchangeMemoRequired &&
     (!isRecurrentTransfer ||
       (!!recurrence &&
         Number.isInteger(Number(executions)) &&
@@ -773,16 +824,6 @@ const TransferView = ({
     allowMultipleDest,
     _findRecurrentTransferOfUser,
   ]);
-
-  const badActorUsername = useMemo(() => {
-    if (!destination || !badActors) return null;
-    const usernames = destination
-      .trim()
-      .toLowerCase()
-      .split(/[\s,]+/)
-      .filter(Boolean);
-    return usernames.find((u) => badActors.has(u)) || null;
-  }, [destination, badActors]);
 
   return (
     <SafeAreaView style={styles.container}>
@@ -933,6 +974,32 @@ const TransferView = ({
             {badActorUsername && (
               <Text style={styles.badActorWarning}>
                 {intl.formatMessage({ id: 'transfer.to_bad_actor' })}
+              </Text>
+            )}
+
+            {exchangeRecurrentWarning && (
+              <Text style={styles.exchangeWarning}>
+                {intl.formatMessage(
+                  {
+                    id: 'transfer.exchange_recurrent_warning',
+                    defaultMessage:
+                      '{exchange} is an exchange and may not support recurring transfers — funds sent on a schedule can be lost. Use a one-time transfer instead.',
+                  },
+                  { exchange: exchangeDestination },
+                )}
+              </Text>
+            )}
+
+            {exchangeMemoRequired && (
+              <Text style={styles.exchangeBlockingWarning}>
+                {intl.formatMessage(
+                  {
+                    id: 'transfer.exchange_memo_required',
+                    defaultMessage:
+                      'Sending to {exchange} requires a memo. Without the exchange-provided memo your funds may be lost.',
+                  },
+                  { exchange: exchangeDestination },
+                )}
               </Text>
             )}
           </View>

--- a/src/screens/transfer/screen/transferStyles.ts
+++ b/src/screens/transfer/screen/transferStyles.ts
@@ -314,6 +314,20 @@ export default EStyleSheet.create({
     marginTop: 8,
     textAlign: 'center',
   },
+  // Advisory (non-blocking) exchange notice, e.g. recurring sends to an exchange.
+  exchangeWarning: {
+    color: '#e6a819',
+    fontSize: 12,
+    marginTop: 8,
+    textAlign: 'center',
+  },
+  // Blocking exchange notice, e.g. a missing memo that would lose the deposit.
+  exchangeBlockingWarning: {
+    color: '$primaryRed',
+    fontSize: 12,
+    marginTop: 8,
+    textAlign: 'center',
+  },
 
   // --- Recurrent Transfer ---
   deleteRecurrentText: {


### PR DESCRIPTION
## What

Adds exchange-account awareness to the unified transfer/recurrent screen so users get the right guidance when sending to a known exchange deposit account.

- **New `EXCHANGE_ACCOUNTS` constant** (`src/constants/exchangeAccounts.ts`) plus an `isExchangeAccount()` helper. The list mirrors ecency web's `exchange-accounts.ts` — keep the two in sync.
- **Recurring → exchange (advisory):** when a schedule is selected and the recipient is an exchange, an inline notice explains that exchanges credit one-time transfers and recurring sends may not arrive, suggesting a one-time transfer. Non-blocking.
- **Memo required for HIVE/HBD → exchange (blocking):** sending HIVE/HBD to an exchange without a memo now shows an inline notice and disables the submit button, so the deposit can be attributed to the user's account. A matching guard in the submit handler covers every signing path (key / HiveAuth / HiveSigner).
- Minor: initialize the `memo` field state to a string to avoid an uncontrolled-input edge case.

The existing bad-actor (watchmen) caution is unchanged — it remains a soft, non-blocking warning.

## Notes

- Two new i18n strings added to `en-US.json` (`transfer.exchange_recurrent_warning`, `transfer.exchange_memo_required`); other locales fall back to the built-in default messages.

## Testing

- `yarn lint` — clean (no new errors)
- `tsc --noEmit` — no new type errors
- Transfer/wallet Jest suites — 83/83 pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Require memos for native token transfers to exchange accounts (blocks send when missing).
  * Show advisory warning for recurring transfers to exchange accounts.

* **Localization**
  * Added localized warning and memo-required messages for exchange transfers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->