### PR TITLE
fix(vote-slider): stop thumb slipping to 100% mid-drag on Android

### DIFF
--- a/src/components/upvotePopover/children/upvoteStyles.ts
+++ b/src/components/upvotePopover/children/upvoteStyles.ts
@@ -43,15 +43,25 @@ export default EStyleSheet.create({
     shadowOpacity: 0.35,
     elevation: 3,
   },
+  // minWidth keeps the estimate from reflowing the flex slider track as the
+  // value changes while dragging (the track width/origin feeds the gesture
+  // math in voteSlider.tsx); left-aligned so it still reads naturally.
   amount: {
     fontSize: 10,
     fontWeight: 'bold',
     color: '$primaryDarkGray',
     marginLeft: 8,
+    minWidth: 42,
+    textAlign: 'left',
   },
+  // Fixed-width readout: the percent label is the slider track's right-hand
+  // sibling, so a stable width ("-100%" is the widest value) stops the track
+  // from resizing mid-drag and keeps the ✎ pencil from jittering.
   percent: {
     fontWeight: 'bold',
     color: '$primaryDarkGray',
+    minWidth: 44,
+    textAlign: 'center',
   },
   slider: {
     flex: 1,

--- a/src/components/upvotePopover/children/voteSlider.tsx
+++ b/src/components/upvotePopover/children/voteSlider.tsx
@@ -1,5 +1,5 @@
 import React, { useRef, useState } from 'react';
-import { View, PanResponder, GestureResponderEvent } from 'react-native';
+import { View, PanResponder, GestureResponderEvent, PanResponderGestureState } from 'react-native';
 
 import styles from './upvoteStyles';
 
@@ -9,9 +9,9 @@ import styles from './upvoteStyles';
  * Replaces the thin native @react-native-community/slider (a ~16px thumb on a
  * 2px track, which many users struggled to grab precisely) with a fat
  * drag-anywhere fill bar: tapping or dragging anywhere along the track sets the
- * value from the finger's absolute X position, giving the whole bar height as a
- * touch target. A colored fill (blue for upvote, red for downvote) grows from
- * the left and a thumb sits at the fill edge as an affordance.
+ * value from the finger's position, giving the whole bar height as a touch
+ * target. A colored fill (blue for upvote, red for downvote) grows from the
+ * left and a thumb sits at the fill edge as an affordance.
  *
  * This handles the easy/coarse case. For an exact value, the popover's NN%
  * label is tappable and opens a keyboard-free numeric keypad (see
@@ -22,6 +22,16 @@ import styles from './upvoteStyles';
  * Built on PanResponder rather than react-native-gesture-handler because the
  * popover renders inside a React Native Modal, where gesture-handler needs its
  * own GestureHandlerRootView; PanResponder works there with no extra setup.
+ *
+ * Finger position is mapped from the gesture's ABSOLUTE window X
+ * (gestureState.moveX) against the track's measured window-left, NOT from the
+ * per-event `evt.nativeEvent.locationX`. On Android, locationX on move events
+ * intermittently arrives relative to a parent/window origin instead of the
+ * track itself; dividing that by the track width overshot the value by exactly
+ * trackLeft/trackWidth (~0.56) and clamped it to 100%, so the thumb visibly
+ * "slipped" forward and stuck there while the finger stayed mid-track. moveX
+ * and measureInWindow() share the same window coordinate space, so the ratio is
+ * unambiguous regardless of which native view the OS hit-tests under the finger.
  */
 
 interface VoteSliderProps {
@@ -51,20 +61,39 @@ const VoteSlider = ({
   // visible at both ends; widthRef mirrors it for the (memoised) PanResponder.
   const [trackWidth, setTrackWidth] = useState(0);
   // 0 = not yet measured (onLayout hasn't fired). Mirrors trackWidth for the
-  // memoised PanResponder; see _ratioFromX for the pre-layout guard.
+  // memoised PanResponder; see _ratioFromPageX for the pre-layout guard.
   const widthRef = useRef(0);
+  // Track's left edge in WINDOW coordinates — the origin the absolute-X gesture
+  // mapping subtracts from gestureState.moveX. Refreshed on layout and at each
+  // gesture start so it stays correct even as the row reflows (the $estimate and
+  // NN% labels are variable-width siblings of this flex track and change width
+  // as the user votes).
+  const trackLeftRef = useRef(0);
+  const trackRef = useRef<View>(null);
   const minRef = useRef(minValue);
   minRef.current = minValue;
   const onChangeRef = useRef(onValueChange);
   onChangeRef.current = onValueChange;
 
-  const _ratioFromX = (locationX: number) => {
+  // Cache the track's window geometry from a fresh native measurement.
+  const _measureTrack = () => {
+    trackRef.current?.measureInWindow((x: number, _y: number, w: number) => {
+      if (typeof x === 'number') {
+        trackLeftRef.current = x;
+      }
+      if (w) {
+        widthRef.current = w;
+      }
+    });
+  };
+
+  const _ratioFromPageX = (pageX: number) => {
     // Ignore touches before the track is measured — dividing by a sentinel
     // width would otherwise snap the first touch straight to 100%.
     if (!widthRef.current) {
       return minRef.current;
     }
-    const ratio = locationX / widthRef.current;
+    const ratio = (pageX - trackLeftRef.current) / widthRef.current;
     return Math.min(1, Math.max(minRef.current, ratio));
   };
 
@@ -74,11 +103,17 @@ const VoteSlider = ({
       onMoveShouldSetPanResponder: () => true,
       // Keep the gesture even if an ancestor scroll view wants it.
       onPanResponderTerminationRequest: () => false,
-      onPanResponderGrant: (evt: GestureResponderEvent) => {
-        onChangeRef.current(_ratioFromX(evt.nativeEvent.locationX));
+      onPanResponderGrant: (
+        _evt: GestureResponderEvent,
+        gestureState: PanResponderGestureState,
+      ) => {
+        // Re-measure at touch-down for the freshest origin, then map the initial
+        // touch — x0 is the grant's absolute window X (== moveX at grant).
+        _measureTrack();
+        onChangeRef.current(_ratioFromPageX(gestureState.x0));
       },
-      onPanResponderMove: (evt: GestureResponderEvent) => {
-        onChangeRef.current(_ratioFromX(evt.nativeEvent.locationX));
+      onPanResponderMove: (_evt: GestureResponderEvent, gestureState: PanResponderGestureState) => {
+        onChangeRef.current(_ratioFromPageX(gestureState.moveX));
       },
     }),
   ).current;
@@ -100,10 +135,13 @@ const VoteSlider = ({
   return (
     <View style={styles.voteSliderRow}>
       <View
+        ref={trackRef}
         style={styles.voteSliderTrack}
         onLayout={(e) => {
           widthRef.current = e.nativeEvent.layout.width;
           setTrackWidth(e.nativeEvent.layout.width);
+          // layout.x is parent-relative; capture the window-left for the gesture.
+          _measureTrack();
         }}
         accessible
         accessibilityRole="adjustable"

--- a/src/components/upvotePopover/children/voteSlider.tsx
+++ b/src/components/upvotePopover/children/voteSlider.tsx
@@ -75,15 +75,24 @@ const VoteSlider = ({
   const onChangeRef = useRef(onValueChange);
   onChangeRef.current = onValueChange;
 
-  // Cache the track's window geometry from a fresh native measurement.
-  const _measureTrack = () => {
-    trackRef.current?.measureInWindow((x: number, _y: number, w: number) => {
+  // Cache the track's window geometry from a fresh native measurement, then run
+  // `after` once it has been applied — so a caller (gesture grant) can map the
+  // touch from up-to-date geometry rather than the last onLayout. Falls back to
+  // running `after` immediately when the native measure isn't available.
+  const _measureTrack = (after?: () => void) => {
+    const node = trackRef.current;
+    if (!node?.measureInWindow) {
+      after?.();
+      return;
+    }
+    node.measureInWindow((x: number, _y: number, w: number) => {
       if (typeof x === 'number') {
         trackLeftRef.current = x;
       }
-      if (w) {
+      if (w > 0) {
         widthRef.current = w;
       }
+      after?.();
     });
   };
 
@@ -107,10 +116,10 @@ const VoteSlider = ({
         _evt: GestureResponderEvent,
         gestureState: PanResponderGestureState,
       ) => {
-        // Re-measure at touch-down for the freshest origin, then map the initial
-        // touch — x0 is the grant's absolute window X (== moveX at grant).
-        _measureTrack();
-        onChangeRef.current(_ratioFromPageX(gestureState.x0));
+        // Map the tap-down from within a fresh measurement so the initial
+        // position uses up-to-date geometry, not just the last onLayout — x0 is
+        // the grant's absolute window X (== moveX at grant).
+        _measureTrack(() => onChangeRef.current(_ratioFromPageX(gestureState.x0)));
       },
       onPanResponderMove: (_evt: GestureResponderEvent, gestureState: PanResponderGestureState) => {
         onChangeRef.current(_ratioFromPageX(gestureState.moveX));

--- a/src/components/upvotePopover/container/upvotePopover.tsx
+++ b/src/components/upvotePopover/container/upvotePopover.tsx
@@ -598,7 +598,9 @@ const UpvotePopover = forwardRef(({}, ref) => {
                   name={iconName}
                 />
               </TouchableOpacity>
-              <Text style={styles.amount}>{_amount}</Text>
+              <Text style={styles.amount} numberOfLines={1}>
+                {_amount}
+              </Text>
               <VoteSlider
                 color={sliderColor}
                 minValue={_minSliderVal}
@@ -613,7 +615,9 @@ const UpvotePopover = forwardRef(({}, ref) => {
                 accessibilityRole="button"
                 accessibilityLabel={`Edit vote percentage, currently ${_percent}`}
               >
-                <Text style={styles.percent}>{_percent}</Text>
+                <Text style={styles.percent} numberOfLines={1}>
+                  {_percent}
+                </Text>
                 <Icon
                   size={11}
                   style={styles.percentEditIcon}


### PR DESCRIPTION
## Problem

Users reported the upvote slider **slipping** — while dragging, the thumb jumps forward and **sticks at 100%** for a moment, even though the finger is still mid-track. Reproduced from a user screen-recording (Android, "show touches" on): the finger indicator stays around the middle of the track while the rendered value snaps to 100% and holds ~0.5s before recovering.

## Root cause

The drag-anywhere slider mapped finger → value with:

```ts
const ratio = evt.nativeEvent.locationX / trackWidth;
```

On Android, `locationX` on PanResponder **move** events intermittently arrives relative to a parent/window origin instead of the track itself. Frame-by-frame measurement of the recording (track left ≈ 122px, width ≈ 216px) matches the symptom exactly: a bad sample adds `trackLeft / trackWidth` (≈ +0.565) to the ratio, which then clamps to `1.0`:

- true 64% → 120% → **clamps 100%**
- true 53% → 109% → **clamps 100%**

The `$estimate` and `NN%` labels are variable-width siblings of the `flex: 1` track, so the wider `"100%"` string shrinks the track — a positive feedback loop that makes the overshoot *stick* until the finger moves far enough left to break out. `pointerEvents="none"` on the fill/thumb does **not** prevent this.

## Fix

- Map finger position from the gesture's **absolute window X** (`gestureState.moveX` / `x0`) minus the track's `measureInWindow()` window-left. `moveX` and `measureInWindow()` share the same window coordinate space, so the ratio is unambiguous regardless of which native view the OS hit-tests under the finger. The track origin is re-measured on layout and at each gesture start.
- Give the `$estimate` and `NN%` labels stable min-widths (`-100%` is the widest percent value) so the flex track no longer resizes mid-drag — removing the residual reflow jitter and keeping the ✎ pencil from jumping around.

Normal-case behaviour is unchanged; only the glitch path is eliminated.

## Testing

- `yarn lint` clean on the changed files; types resolve (`PanResponderGestureState`, `measureInWindow`).
- ⚠️ Needs an **on-device Android** check (the input glitch is Android-specific and doesn't reproduce in a simulator): drag up and down repeatedly across the 50–90% range — the thumb should track the finger with no jumps to 100%. iOS regression check that drag + tap-to-position still set the expected value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved upvote slider drag responsiveness and accuracy by using absolute gesture coordinates and stable track measurements.
  * Stabilized slider layout during dragging with fixed minimum widths and enforced text alignment.
  * Prevented vote amount and percentage labels from wrapping by constraining them to a single rendered line.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->