### PR TITLE
fix(wallet): make recurrent transfer cancellation valid on-chain

### DIFF
--- a/src/providers/queries/walletQueries/walletQueries.ts
+++ b/src/providers/queries/walletQueries/walletQueries.ts
@@ -726,13 +726,21 @@ export const useDeleteRecurrentTransferMutation = () => {
         .trim()
         .split(/\s+/);
       const amountSymbol = amountParts[1] || 'HIVE';
+      // A recurrent transfer is cancelled by broadcasting it again with a zero
+      // amount. Hive's recurrent_transfer_operation::validate() still runs and
+      // requires recurrence >= 24 and executions >= 2 *unconditionally* (even
+      // when amount is 0), so sending executions: 0 made the node reject the op
+      // — the cancellation never landed and the schedule kept showing in the
+      // wallet. Once amount is 0 the evaluator just deletes the schedule, so
+      // these counts only need to pass validation; their values are otherwise
+      // ignored.
       await recurrentTransferBroadcast.mutateAsync({
         from: recurrentTransfer.from,
         to: recurrentTransfer.to,
         amount: `0.000 ${amountSymbol}`,
         memo: recurrentTransfer.memo || '',
-        recurrence: recurrentTransfer.recurrence || 0,
-        executions: 0,
+        recurrence: Math.max(24, recurrentTransfer.recurrence || 0),
+        executions: 2,
       });
       return true;
     },


### PR DESCRIPTION
## Problem

Users report that **cancelling a recurrent transfer doesn't work** — after confirming the cancel, the schedule still shows in the wallet's *Recurrent Transfers* list (reported by multiple users).

## Root cause

A recurrent transfer is cancelled by broadcasting the `recurrent_transfer` op again with a **zero amount**. The delete mutation (`useDeleteRecurrentTransferMutation` in `walletQueries.ts`) built that op with:

```ts
recurrence: recurrentTransfer.recurrence || 0,
executions: 0,
```

But Hive's `recurrent_transfer_operation::validate()` runs for **every** recurrent_transfer op and asserts, *unconditionally* (even when `amount` is 0):

- `recurrence >= HIVE_MIN_RECURRENT_TRANSFERS_RECURRENCE` (24 hours)
- `executions >= 2` — *"Executions must be at least 2, if you set executions to 1 the recurrent transfer will execute immediately and delete itself."*

So `executions: 0` makes the node **reject the cancellation op at broadcast**. The schedule is never deleted, and since the list is backed by `condenser_api.find_recurrent_transfers` (live chain), it reappears on the next refetch. Because the broadcast is `async`, the optimistic UI/toast can mask the rejection. This fails for **every** cancel, which matches the multiple reports.

(Source: `recurrent_transfer_operation::validate()` in `openhive-network/hive`, `libraries/protocol/hive_operations.cpp`.)

## Fix

Send validation-passing counts for the zero-amount cancel:

```ts
recurrence: Math.max(24, recurrentTransfer.recurrence || 0),
executions: 2,
```

Once `amount` is 0 the evaluator simply deletes the schedule, so these counts only need to clear validation — their values are otherwise ignored.

## Notes / scope

- One-line behavioural change; the optimistic cache removal (by `id`) and the modal's refetch-on-open are unchanged.
- **Known limitation (out of scope):** the SDK's `buildRecurrentTransferOp` builds the op with `extensions: []`, so the cancel always targets `pair_id 0`. Ecency only ever creates `pair_id 0` schedules, so this covers Ecency-created transfers; a schedule created elsewhere with a non-zero `pair_id` would still need its `pair_id` echoed in the cancel (would require SDK builder support).

## Testing

- `yarn lint` clean on the changed file.
- Needs a quick on-chain check: create a recurrent transfer, cancel it, confirm it disappears from *Recurrent Transfers* (and stays gone after reopening/refetch).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed recurrent transfer cancellation to ensure operations are properly processed by the blockchain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->