### PR TITLE
fix(rating): prevent startup crash when appRating state is missing

### DIFF
--- a/src/redux/actions/applicationActions.ts
+++ b/src/redux/actions/applicationActions.ts
@@ -273,11 +273,15 @@ export const updateAppRatingMeta = (payload: {
  * review prompt eligibility check relies on.
  */
 export const recordAppSession = () => (dispatch, getState) => {
+  // appRating can be undefined for users upgrading from a build before this
+  // feature: redux-persist's autoMergeLevel1 replaces the whole persisted
+  // `application` slice, so the new key isn't defaulted from initialState until
+  // the first write. Guard the read so this mount-time thunk can't crash launch.
   const { appRating } = getState().application;
   dispatch(
     updateAppRatingMeta({
-      firstUseTime: appRating.firstUseTime ?? Date.now(),
-      sessionCount: (appRating.sessionCount ?? 0) + 1,
+      firstUseTime: appRating?.firstUseTime ?? Date.now(),
+      sessionCount: (appRating?.sessionCount ?? 0) + 1,
     }),
   );
 };
@@ -290,7 +294,7 @@ export const recordAppSession = () => (dispatch, getState) => {
  */
 export const maybeRequestReview = () => (dispatch, getState) => {
   const { appRating } = getState().application;
-  const { firstUseTime, sessionCount, hasRequestedReview } = appRating;
+  const { firstUseTime, sessionCount = 0, hasRequestedReview } = appRating ?? {};
 
   if (hasRequestedReview || reviewRequestInFlight || !firstUseTime) {
     return;

--- a/src/redux/store/store.ts
+++ b/src/redux/store/store.ts
@@ -36,7 +36,7 @@ const persistConfig = {
   key: 'root',
   // Storage Method (React Native)
   storage: AsyncStorage,
-  version: 16, // v16: Backfill new account.globalProps fields for vote estimation
+  version: 17, // v17: Backfill application.appRating so launch can't deref undefined
   // // Blacklist (Don't Save Specific Reducers)
   blacklist: ['communities', 'user', 'ui'],
   transforms: [transformCacheVoteMap, transformWalkthroughMap],

--- a/src/utils/migrationHelpers.test.ts
+++ b/src/utils/migrationHelpers.test.ts
@@ -310,6 +310,36 @@ describe('reduxMigrations', () => {
     });
   });
 
+  describe('v17: appRating backfill', () => {
+    it('adds a default appRating when an upgraded install lacks it', () => {
+      // Reproduces the startup crash: persisted `application` from a pre-rating
+      // build has no appRating, and recordAppSession derefs it on launch.
+      const state = { application: { imageServer: 'https://images.ecency.com' } } as any;
+      const result = reduxMigrations[17](state);
+      expect(result.application.appRating).toEqual({
+        firstUseTime: null,
+        sessionCount: 0,
+        hasRequestedReview: false,
+      });
+      // unrelated keys in the slice are preserved
+      expect(result.application.imageServer).toBe('https://images.ecency.com');
+    });
+
+    it('leaves an existing appRating untouched', () => {
+      const existing = { firstUseTime: 123, sessionCount: 7, hasRequestedReview: true };
+      const state = { application: { appRating: existing } } as any;
+      const result = reduxMigrations[17](state);
+      expect(result.application.appRating).toBe(existing);
+    });
+
+    it('no-ops when the application slice is absent', () => {
+      const state = { account: { keep: 'me' } } as any;
+      const result = reduxMigrations[17](state);
+      expect(result.account.keep).toBe('me');
+      expect(result.application).toBeUndefined();
+    });
+  });
+
   describe('failure isolation', () => {
     it('rolls back a throwing migration and preserves the rest of the state', () => {
       // v1 writes state.application.notificationDetails.favoriteNotification; with

--- a/src/utils/migrationHelpers.ts
+++ b/src/utils/migrationHelpers.ts
@@ -498,6 +498,22 @@ const reduxMigrations = {
     }
     return state;
   },
+  17: (state) => {
+    // Backfill appRating for users upgrading from a build before the in-app
+    // review prompt. autoMergeLevel1 replaces the whole persisted `application`
+    // slice on rehydration, so a missing appRating key is NOT defaulted from
+    // initialState — and recordAppSession dereferences it on launch, crashing
+    // every existing install. (A primitive like imageServer survived this only
+    // because its reads are falsy-guarded; an object that's dereferenced is not.)
+    if (state.application && !state.application.appRating) {
+      state.application.appRating = {
+        firstUseTime: null,
+        sessionCount: 0,
+        hasRequestedReview: false,
+      };
+    }
+    return state;
+  },
 };
 
 // Wrap every migration so a throw degrades to "skip this migration" and keep the


### PR DESCRIPTION
## Problem

The app crashes on launch for **existing users upgrading** to the build that added the in-app review prompt. Sentry:

```
TypeError: Cannot read property 'firstUseTime' of undefined
    at Application (...)
```

Installs that persisted the `application` redux slice before `appRating` existed have no such key. redux-persist uses the default **`autoMergeLevel1`** reconciler, which replaces the whole `application` slice on rehydration instead of merging nested keys from `initialState`. So `state.application.appRating` is `undefined`, and `recordAppSession()` — dispatched on mount in `useInitApplication` — dereferences it and throws, crashing at startup. Fresh installs get `initialState` and were unaffected, so it passed review/CI.

## Fix

- **Guard the reads** in `recordAppSession` / `maybeRequestReview` (`appRating?.…`, `appRating ?? {}`). This also recovers users already in a crash-loop after updating, independent of their persisted state.
- **Add migration v17** to backfill `appRating` into the persisted slice (persist `version` 16 → 17), mirroring the existing v16 `globalProps` backfill. The `safeReduxMigrations` wrapper rolls back on any throw, so no data-loss risk.
- **Unit tests** for migration v17 (backfills when missing, leaves existing untouched, no-ops without the slice).

Pure-JS change — no native rebuild required; an OTA/JS bundle update delivers it and existing crashing users recover on next launch.

## Verification

- `yarn lint` — 0 errors on changed files
- `migrationHelpers` suite — 30/30 pass (3 new)

## Note for reviewers

Any **new nested key** added to a persisted redux slice needs a backfill migration (or defensive reads). `autoMergeLevel1` does not merge below the top level — a primitive read behind an `if` survives, an object that gets dereferenced does not.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved in-app review prompt reliability with enhanced error handling and defensive state access to prevent crashes during app upgrades when review data is unavailable.

* **Tests**
  * Added test coverage for app rating data migration and backfill logic to ensure stable transitions between app versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->