### PR TITLE
Fix register username validation to match chain account-name rules

### DIFF
--- a/src/config/locales/en-US.json
+++ b/src/config/locales/en-US.json
@@ -997,7 +997,7 @@
       "username_exists": "Username already exists, try a different one",
       "username_length_error": "Length should be between 3 to 16 symbols",
       "username_contains_symbols_error": "Should contain letters, numbers, hyphen only",
-      "username_no_ascii_first_letter_error": "First letter should be in ASCII",
+      "username_no_ascii_first_letter_error": "Should start with a letter",
       "username_contains_double_hyphens": "Should not contain double hyphens",
       "username_contains_underscore": "Should not contain underscore"
     },

--- a/src/screens/register/children/turnstileWebView.tsx
+++ b/src/screens/register/children/turnstileWebView.tsx
@@ -76,6 +76,9 @@ const TurnstileWebView = ({ onVerify, onExpire, onError, height = 76 }: Props) =
         onMessage={_onMessage}
         onError={() => setLoadFailed(true)}
         onHttpError={() => setLoadFailed(true)}
+        // iOS kills the web content process under memory pressure, leaving a
+        // permanently blank widget — surface the retry UI instead.
+        onContentProcessDidTerminate={() => setLoadFailed(true)}
       />
     </View>
   );

--- a/src/screens/register/registerScreen.tsx
+++ b/src/screens/register/registerScreen.tsx
@@ -75,7 +75,10 @@ const RegisterScreen = ({ navigation, route }) => {
     if (referredUser) {
       _handleRefUsernameChange({ value: referredUser });
     }
-    if (purchaseOnly && email && username) {
+    // deep-link / purchase-recovery entry: apply the same synchronous rule
+    // check as the Continue button so a chain-invalid username can't reach
+    // the purchase modal through route params either
+    if (purchaseOnly && email && username && !getUsernameError(username.toLowerCase())) {
       registerAccountModalRef.current?.showModal({ purchaseOnly });
     }
   }, []);

--- a/src/screens/register/registerScreen.tsx
+++ b/src/screens/register/registerScreen.tsx
@@ -113,6 +113,7 @@ const RegisterScreen = ({ navigation, route }) => {
       setUsernameError(intl.formatMessage({ id: USERNAME_ERROR_MESSAGE_IDS[errorCode] }));
       return false;
     }
+    setUsernameError('');
     return true;
   };
 

--- a/src/screens/register/registerScreen.tsx
+++ b/src/screens/register/registerScreen.tsx
@@ -24,6 +24,9 @@ const USERNAME_ERROR_MESSAGE_IDS: Record<UsernameValidationError, string> = {
   start_letter: 'register.validation.username_no_ascii_first_letter_error',
   symbols: 'register.validation.username_contains_symbols_error',
   double_hyphens: 'register.validation.username_contains_double_hyphens',
+  // reuses the symbols message: a dedicated string would be missing from the
+  // 38 non-en locale files until the next translation sync
+  trailing_hyphen: 'register.validation.username_contains_symbols_error',
   underscore: 'register.validation.username_contains_underscore',
 };
 
@@ -154,6 +157,13 @@ const RegisterScreen = ({ navigation, route }) => {
   };
 
   const _onContinuePress = () => {
+    // the button's disabled state lags behind the debounced validation, so a
+    // just-typed invalid name could otherwise still reach the signup/purchase
+    // modal — re-run the synchronous rule check before opening it
+    if (!_isValidUsername(username)) {
+      setIsUsernameValid(false);
+      return;
+    }
     Keyboard.dismiss();
     registerAccountModalRef.current?.showModal();
   };

--- a/src/screens/register/registerScreen.tsx
+++ b/src/screens/register/registerScreen.tsx
@@ -17,6 +17,15 @@ import { RegisterAccountModal } from './children/registerAccountModal';
 import { ECENCY_TERMS_URL } from '../../config/ecencyApi';
 import { useAppSelector } from '../../hooks';
 import { selectIsConnected } from '../../redux/selectors';
+import { getUsernameError, UsernameValidationError } from '../../utils/usernameValidation';
+
+const USERNAME_ERROR_MESSAGE_IDS: Record<UsernameValidationError, string> = {
+  length: 'register.validation.username_length_error',
+  start_letter: 'register.validation.username_no_ascii_first_letter_error',
+  symbols: 'register.validation.username_contains_symbols_error',
+  double_hyphens: 'register.validation.username_contains_double_hyphens',
+  underscore: 'register.validation.username_contains_underscore',
+};
 
 const RegisterScreen = ({ navigation, route }) => {
   const intl = useIntl();
@@ -93,39 +102,12 @@ const RegisterScreen = ({ navigation, route }) => {
   };
 
   const _isValidUsername = (value) => {
-    if (!value || value.length <= 2 || value.length >= 16) {
-      setUsernameError(intl.formatMessage({ id: 'register.validation.username_length_error' }));
+    const errorCode = getUsernameError(value);
+    if (errorCode) {
+      setUsernameError(intl.formatMessage({ id: USERNAME_ERROR_MESSAGE_IDS[errorCode] }));
       return false;
-    } else {
-      return value.split('.').some((item) => {
-        if (item.length < 3) {
-          setUsernameError(intl.formatMessage({ id: 'register.validation.username_length_error' }));
-          return false;
-        } else if (!/^[\x00-\x7F]*$/.test(item[0])) {
-          setUsernameError(
-            intl.formatMessage({ id: 'register.validation.username_no_ascii_first_letter_error' }),
-          );
-          return false;
-        } else if (!/^([a-zA-Z0-9]|-|\.)+$/.test(item)) {
-          setUsernameError(
-            intl.formatMessage({ id: 'register.validation.username_contains_symbols_error' }),
-          );
-          return false;
-        } else if (item.includes('--')) {
-          setUsernameError(
-            intl.formatMessage({ id: 'register.validation.username_contains_double_hyphens' }),
-          );
-          return false;
-        } else if (item.includes('_')) {
-          setUsernameError(
-            intl.formatMessage({ id: 'register.validation.username_contains_underscore' }),
-          );
-          return false;
-        } else {
-          return true;
-        }
-      });
     }
+    return true;
   };
 
   const _validateUsername = (value) => {

--- a/src/utils/usernameValidation.test.ts
+++ b/src/utils/usernameValidation.test.ts
@@ -1,0 +1,47 @@
+import { getUsernameError } from './usernameValidation';
+
+describe('getUsernameError', () => {
+  it('accepts valid usernames', () => {
+    expect(getUsernameError('ecency')).toBeNull();
+    expect(getUsernameError('abc')).toBeNull();
+    expect(getUsernameError('good-karma')).toBeNull();
+    expect(getUsernameError('user123')).toBeNull();
+    expect(getUsernameError('abc1')).toBeNull();
+    expect(getUsernameError('foo.barbaz')).toBeNull();
+    expect(getUsernameError('a23456789012345b')).toBeNull(); // 16 chars
+  });
+
+  it('rejects usernames not starting with a letter', () => {
+    expect(getUsernameError('31454476')).toBe('start_letter');
+    expect(getUsernameError('1abc')).toBe('start_letter');
+    expect(getUsernameError('-abc')).toBe('start_letter');
+    expect(getUsernameError('abc.123abc')).toBe('start_letter');
+  });
+
+  it('rejects every segment, not just one valid segment', () => {
+    // an invalid segment must fail the whole name even when a later
+    // segment is valid on its own
+    expect(getUsernameError('123.validname')).toBe('start_letter');
+    expect(getUsernameError('validname.123')).toBe('start_letter');
+  });
+
+  it('rejects bad lengths', () => {
+    expect(getUsernameError('')).toBe('length');
+    expect(getUsernameError('ab')).toBe('length');
+    expect(getUsernameError('a2345678901234567')).toBe('length'); // 17 chars
+    expect(getUsernameError('ab.cde')).toBe('length'); // short segment
+    expect(getUsernameError('abc.')).toBe('length'); // empty segment
+  });
+
+  it('rejects invalid symbols', () => {
+    expect(getUsernameError('ab@c')).toBe('symbols');
+    expect(getUsernameError('abc!')).toBe('symbols');
+    expect(getUsernameError('abc def')).toBe('symbols');
+    expect(getUsernameError('abc-')).toBe('symbols'); // trailing hyphen
+  });
+
+  it('rejects double hyphens and underscores', () => {
+    expect(getUsernameError('ab--cd')).toBe('double_hyphens');
+    expect(getUsernameError('ab_cd')).toBe('underscore');
+  });
+});

--- a/src/utils/usernameValidation.test.ts
+++ b/src/utils/usernameValidation.test.ts
@@ -8,6 +8,7 @@ describe('getUsernameError', () => {
     expect(getUsernameError('user123')).toBeNull();
     expect(getUsernameError('abc1')).toBeNull();
     expect(getUsernameError('foo.barbaz')).toBeNull();
+    expect(getUsernameError('abc.def.ghi')).toBeNull(); // multi-dot segments
     expect(getUsernameError('a23456789012345b')).toBeNull(); // 16 chars
   });
 
@@ -37,7 +38,11 @@ describe('getUsernameError', () => {
     expect(getUsernameError('ab@c')).toBe('symbols');
     expect(getUsernameError('abc!')).toBe('symbols');
     expect(getUsernameError('abc def')).toBe('symbols');
-    expect(getUsernameError('abc-')).toBe('symbols'); // trailing hyphen
+  });
+
+  it('rejects trailing hyphens', () => {
+    expect(getUsernameError('abc-')).toBe('trailing_hyphen');
+    expect(getUsernameError('abc-.defg')).toBe('trailing_hyphen');
   });
 
   it('rejects double hyphens and underscores', () => {

--- a/src/utils/usernameValidation.ts
+++ b/src/utils/usernameValidation.ts
@@ -10,32 +10,37 @@ export type UsernameValidationError =
   | 'trailing_hyphen'
   | 'underscore';
 
+const getSegmentError = (segment: string): UsernameValidationError | null => {
+  if (segment.length < 3) {
+    return 'length';
+  }
+  if (segment.includes('_')) {
+    return 'underscore';
+  }
+  if (!/^[a-z]/.test(segment)) {
+    return 'start_letter';
+  }
+  if (segment.includes('--')) {
+    return 'double_hyphens';
+  }
+  if (segment.endsWith('-')) {
+    return 'trailing_hyphen';
+  }
+  if (!/^[a-z][a-z0-9-]*[a-z0-9]$/.test(segment)) {
+    return 'symbols';
+  }
+  return null;
+};
+
 export const getUsernameError = (value: string): UsernameValidationError | null => {
   if (!value || value.length < 3 || value.length > 16) {
     return 'length';
   }
 
-  const segments = value.split('.');
-  for (const segment of segments) {
-    if (segment.length < 3) {
-      return 'length';
-    }
-    if (segment.includes('_')) {
-      return 'underscore';
-    }
-    if (!/^[a-z]/.test(segment)) {
-      return 'start_letter';
-    }
-    if (segment.includes('--')) {
-      return 'double_hyphens';
-    }
-    if (segment.endsWith('-')) {
-      return 'trailing_hyphen';
-    }
-    if (!/^[a-z][a-z0-9-]*[a-z0-9]$/.test(segment)) {
-      return 'symbols';
-    }
-  }
-
-  return null;
+  return (
+    value
+      .split('.')
+      .map(getSegmentError)
+      .find((error) => error !== null) ?? null
+  );
 };

--- a/src/utils/usernameValidation.ts
+++ b/src/utils/usernameValidation.ts
@@ -7,6 +7,7 @@ export type UsernameValidationError =
   | 'start_letter'
   | 'symbols'
   | 'double_hyphens'
+  | 'trailing_hyphen'
   | 'underscore';
 
 export const getUsernameError = (value: string): UsernameValidationError | null => {
@@ -27,6 +28,9 @@ export const getUsernameError = (value: string): UsernameValidationError | null 
     }
     if (segment.includes('--')) {
       return 'double_hyphens';
+    }
+    if (segment.endsWith('-')) {
+      return 'trailing_hyphen';
     }
     if (!/^[a-z][a-z0-9-]*[a-z0-9]$/.test(segment)) {
       return 'symbols';

--- a/src/utils/usernameValidation.ts
+++ b/src/utils/usernameValidation.ts
@@ -1,0 +1,37 @@
+// Mirrors the blockchain's account-name rules (is_valid_account_name): 3-16
+// chars total, dot-separated segments of 3+ chars, each starting with a letter,
+// containing only lowercase letters, digits and single hyphens, and ending with
+// a letter or digit. Expects already-lowercased input.
+export type UsernameValidationError =
+  | 'length'
+  | 'start_letter'
+  | 'symbols'
+  | 'double_hyphens'
+  | 'underscore';
+
+export const getUsernameError = (value: string): UsernameValidationError | null => {
+  if (!value || value.length < 3 || value.length > 16) {
+    return 'length';
+  }
+
+  const segments = value.split('.');
+  for (const segment of segments) {
+    if (segment.length < 3) {
+      return 'length';
+    }
+    if (segment.includes('_')) {
+      return 'underscore';
+    }
+    if (!/^[a-z]/.test(segment)) {
+      return 'start_letter';
+    }
+    if (segment.includes('--')) {
+      return 'double_hyphens';
+    }
+    if (!/^[a-z][a-z0-9-]*[a-z0-9]$/.test(segment)) {
+      return 'symbols';
+    }
+  }
+
+  return null;
+};


### PR DESCRIPTION
## What

Fixes username validation on the register screen, which let invalid Hive account names through to the paid-signup flow.

### Bugs fixed
1. The "first letter" check only tested that the first character was **ASCII**, so all-digit usernames passed validation. Hive requires each name segment to start with a letter — such names fail on-chain creation after the user has already paid.
2. The segment check used `Array.some()`, so a name with one valid dot-segment passed even when other segments were invalid (e.g. `123.validname`).
3. Trailing hyphens (`abc-`) passed but are rejected on-chain.
4. Length check rejected valid 16-char names (`>= 16` instead of `> 16`).

### Changes
- New `src/utils/usernameValidation.ts` mirroring the blockchain's `is_valid_account_name` rules (3–16 chars, dot-separated segments of 3+ chars, each starting with a letter, lowercase letters/digits/single hyphens, ending with letter or digit), returning an error code that maps to the existing i18n validation messages — no new locale keys.
- `registerScreen.tsx` delegates to the utility; the `.some()` logic is gone.
- Unit tests for the utility (picked up by CI).
- en-US: "First letter should be in ASCII" → "Should start with a letter" (same key).
- `turnstileWebView.tsx`: handle `onContentProcessDidTerminate` (iOS) so a killed WebView content process shows the retry UI instead of a permanently blank widget.

## Why

A real paid signup purchased an account for an all-digit username; the chain rejected creation with `Account name is not valid (RFC 1035)` after payment. Client-side validation should have blocked this before the purchase button was ever enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed registration flow on iOS where WebView content process termination resulted in a blank screen; now displays the retry interface to allow recovery.

* **Documentation**
  * Updated username validation error message to clarify that usernames must start with a letter.

* **Improvements**
  * Enhanced username validation logic for more consistent validation across the registration flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->