### PR TITLE
fix(i18n): preserve hierarchy so Crowdin sync targets the existing source file

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,3 +1,8 @@
+# Keep the repo path under the Crowdin branch (development/src/config/locales/en-US.json).
+# Without this the CLI flattens the path to <branch>/en-US.json and forks a second,
+# untranslated copy of every string instead of updating the existing file.
+preserve_hierarchy: true
+
 files:
   - source: /src/config/locales/en-US.json
     translation: /src/config/locales/%locale%.json


### PR DESCRIPTION
## Problem

The Crowdin upload/download workflows run the CLI without `preserve_hierarchy`, so the source path `src/config/locales/en-US.json` gets **flattened** to `<branch>/en-US.json`. Because the project's real, fully-translated source file lives at `development/src/config/locales/en-US.json`, the flattened upload didn't update it — it **forked a second, empty copy** of every string.

Crowdin then counted both copies, so the project reported roughly **half** its true translation progress, and a download in that state could have pulled the empty copy over the translated locale files.

## Fix

Set `preserve_hierarchy: true` in `crowdin.yml` so both upload and download keep the repo path under the branch and resolve the existing source file. One line; no workflow changes needed (the action reads this config).

The Crowdin side has been reconciled separately (duplicate file removed, source re-synced); after this merges, a normal `sync-translations` run will batch the up-to-date translations back into the repo.