### PR TITLE
fix(editor): stop post body jumping up and down while typing

### DIFF
--- a/src/components/markdownEditor/styles/markdownEditorStyles.ts
+++ b/src/components/markdownEditor/styles/markdownEditorStyles.ts
@@ -16,8 +16,11 @@ export default EStyleSheet.create({
     color: '$primaryBlack',
     backgroundColor: '$primaryBackgroundColor',
     textAlignVertical: 'top',
-    minHeight: isAndroidOreo() ? undefined : '$deviceHeight/2',
-    maxHeight: isAndroidOreo() ? '$deviceHeight' : undefined,
+    // flex:1 fills the editor's flex parent; maxHeight clamps the self-scrolling input so
+    // it scrolls its own content instead of growing off-screen. No deviceHeight/2 minHeight:
+    // that floor forced the field taller than the keyboard-shrunk viewport, which was the
+    // overflow the (now removed) outer ScrollView snapped around while typing.
+    maxHeight: '$deviceHeight',
   },
   previewContainer: {
     flex: 1,

--- a/src/components/markdownEditor/view/markdownEditorView.tsx
+++ b/src/components/markdownEditor/view/markdownEditorView.tsx
@@ -28,7 +28,6 @@ import {
 import { useAppSelector } from '../../../hooks';
 import { selectIsDarkTheme } from '../../../redux/selectors';
 import { walkthrough } from '../../../redux/constants/walkthroughConstants';
-import isAndroidOreo from '../../../utils/isAndroidOreo';
 import { OptionsModal } from '../../atoms';
 import { MainButton } from '../../mainButton';
 import { MediaInsertData } from '../../uploadsGalleryModal/container/uploadsGalleryModal';
@@ -417,15 +416,17 @@ const MarkdownEditorView = ({
     </>
   );
 
-  const _editorWithScroll = (
-    <ScrollView style={styles.container}>{_renderEditor(false)}</ScrollView>
-  );
-  const _editorWithoutScroll = <View style={styles.container}>{_renderEditor(true)}</View>;
+  // The multiline TextInput owns its own scrolling (scrollEnabled=true) inside a plain
+  // flex View. Wrapping it in an outer ScrollView (with the input's scrollEnabled=false)
+  // created two competing scroll containers that both tracked the caret, which jumped the
+  // body up and down while typing. This self-scrolling layout is what Android 8.0/8.1
+  // already shipped without that issue; it now runs on every platform.
+  const _editor = <View style={styles.container}>{_renderEditor(true)}</View>;
 
   const _renderContent = () => {
     const _editorContent = (
       <>
-        {isAndroidOreo() ? _editorWithoutScroll : _editorWithScroll}
+        {_editor}
 
         {/* {isDraftUpdated && (
           <UsernameAutofillBar

--- a/src/components/markdownEditor/view/markdownEditorView.tsx
+++ b/src/components/markdownEditor/view/markdownEditorView.tsx
@@ -357,7 +357,7 @@ const MarkdownEditorView = ({
       _setTextAndSelection({ text: '', selection: { start: 0, end: 0 } });
     }
   };
-  const _renderEditor = (editorScrollEnabled: boolean) => (
+  const _renderEditor = () => (
     <>
       {isReply && !isEdit && <SummaryArea summary={headerText} />}
       {!isReply && (
@@ -410,7 +410,7 @@ const MarkdownEditorView = ({
         innerRef={inputRef}
         editable={editable}
         contextMenuHidden={false}
-        scrollEnabled={editorScrollEnabled}
+        scrollEnabled={true}
         defaultValue={bodyTextRef.current || draftBody || ''}
       />
     </>
@@ -421,7 +421,7 @@ const MarkdownEditorView = ({
   // created two competing scroll containers that both tracked the caret, which jumped the
   // body up and down while typing. This self-scrolling layout is what Android 8.0/8.1
   // already shipped without that issue; it now runs on every platform.
-  const _editor = <View style={styles.container}>{_renderEditor(true)}</View>;
+  const _editor = <View style={styles.container}>{_renderEditor()}</View>;
 
   const _renderContent = () => {
     const _editorContent = (


### PR DESCRIPTION
## Problem

Users report that while writing a post, the **body editor scrolls/jumps up and down on nearly every keystroke**, making it hard to write.

## Root cause

The body `TextInput` is `multiline` with `scrollEnabled={false}`, `flex:1`, and `minHeight: deviceHeight/2`, and it was **nested inside an outer `ScrollView`**:

```jsx
const _editorWithScroll = <ScrollView>{_renderEditor(false)}</ScrollView>; // scrollEnabled=false
...
{isAndroidOreo() ? _editorWithoutScroll : _editorWithScroll}
```

That creates **two competing scroll containers**. As the caret advances or a line wraps, the OS keeps the caret visible by auto-scrolling the *outer* `ScrollView` (iOS `scrollResponderScrollNativeHandleToKeyboard`, Android `bringPointIntoView`), and the keyboard inset (`windowSoftInputMode="adjustResize"`, no `KeyboardAvoidingView`) is reconciled on top. The two fight, and the body bounces.

The `isAndroidOreo()` branch meant this broken path ran on **iOS and all Android 9+**. Only Android 8.0/8.1 got the correct self-scrolling path, where the `TextInput` owns its own scroll. The team already uses that correct pattern in `quickPostModal`.

## Fix

Route every platform through the self-scrolling editor:

- The multiline `TextInput` owns its own scroll inside a plain flex `View`; no outer `ScrollView` wrapping the body.
- Drop the `deviceHeight/2` minHeight (which forced the field taller than the keyboard-shrunk viewport, the overflow the ScrollView snapped around) and clamp the input to `maxHeight: deviceHeight` so it scrolls its own content.

This is byte-for-byte the layout Android 8.0/8.1 already shipped without the jump. Two files, +12/-8.

**Untouched:** the uncontrolled-typing model, the 500ms autosave debounce, refs, `defaultValue`, and all `setNativeProps` insert / draft-restore / AI-replace paths.

## Behavior note

With the wrapper `ScrollView` gone, the **title + tags now stay pinned at the top** while only the body scrolls internally (previously they co-scrolled away with the body). This is the standard editor feel and what Android 8.x users already had.

## Testing needed (native layout change)

- [ ] iOS: focus body, type several paragraphs with the keyboard open and caret near the bottom; confirm no vertical jump.
- [ ] Android 9-14: same.
- [ ] Android 8.0/8.1 smoke test: behavior unchanged (it already used this path).
- [ ] Programmatic inserts position correctly: snippet, media/image, link, AI full-body replace.
- [ ] Draft restore loads body and lands caret at end; preview toggle re-applies text/selection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed caret and body jump issues during typing in the markdown editor by removing competing scroll container layers
  * Simplified editor layout by eliminating platform-specific version checks and conditional scroll view wrapping
  * Updated text wrapper sizing to use consistent device height scaling across platforms

<!-- end of auto-generated comment: release notes by coderabbit.ai -->