### PR TITLE
fix(crashes): guard 4 Sentry crashes and filter expected-error noise

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -56,6 +56,23 @@ const redactBreadcrumb = (breadcrumb: any) => {
   return breadcrumb;
 };
 
+// Benign/expected errors that carry no diagnostic value and should not be reported to
+// Sentry: normal user actions (wrong password, wrong PIN, cancelled HiveSigner signing)
+// and TanStack Query's internal cancellation signal.
+const IGNORED_ERROR_VALUES = ['auth.invalid_credentials', 'auth.invalid_username'];
+const IGNORED_ERROR_PATTERNS = [/check your PIN/i, /HiveSigner signing cancelled/i, /CancelledError/];
+const IGNORED_ERROR_TYPES = ['CancelledError', 'SigningCancelledError'];
+
+const isIgnoredError = (event: any): boolean =>
+  !!event?.exception?.values?.some((v: any) => {
+    const value = v?.value || '';
+    return (
+      IGNORED_ERROR_TYPES.includes(v?.type) ||
+      IGNORED_ERROR_VALUES.includes(value) ||
+      IGNORED_ERROR_PATTERNS.some((re) => re.test(value))
+    );
+  });
+
 Sentry.init({
   dsn: 'https://a7b0c5a49bdeae965767e2967411b7b0@o4507985141956608.ingest.de.sentry.io/4509786252116048',
 
@@ -68,12 +85,17 @@ Sentry.init({
   replaysSessionSampleRate: enableSessionReplay ? 0.1 : 0,
   replaysOnErrorSampleRate: enableSessionReplay ? 1 : 0,
   integrations,
+  ignoreErrors: [/CancelledError/],
 
   beforeBreadcrumb(breadcrumb) {
     return redactBreadcrumb(breadcrumb);
   },
 
   beforeSend(event) {
+    // Drop benign/expected errors (see IGNORED_ERROR_* above) before anything else.
+    if (isIgnoredError(event)) {
+      return null;
+    }
     if (typeof event.message === 'string') {
       event.message = redactSecrets(event.message);
     }

--- a/App.tsx
+++ b/App.tsx
@@ -60,7 +60,8 @@ const redactBreadcrumb = (breadcrumb: any) => {
 // Sentry: normal user actions (wrong password, wrong PIN, cancelled HiveSigner signing)
 // and TanStack Query's internal cancellation signal.
 const IGNORED_ERROR_VALUES = ['auth.invalid_credentials', 'auth.invalid_username'];
-const IGNORED_ERROR_PATTERNS = [/check your PIN/i, /HiveSigner signing cancelled/i, /CancelledError/];
+// CancelledError is covered by ignoreErrors + IGNORED_ERROR_TYPES, so it is not repeated here.
+const IGNORED_ERROR_PATTERNS = [/check your PIN/i, /HiveSigner signing cancelled/i];
 const IGNORED_ERROR_TYPES = ['CancelledError', 'SigningCancelledError'];
 
 const isIgnoredError = (event: any): boolean =>

--- a/src/components/basicUIElements/view/tag/tagContainer.tsx
+++ b/src/components/basicUIElements/view/tag/tagContainer.tsx
@@ -72,7 +72,10 @@ const TagContainer = ({
     return () => {
       isCancelled = true;
     };
-  });
+    // Only re-run when the inputs change. Without a dependency array this effect ran on
+    // every render and its unconditional setLabel/setIsCommunity calls fed back into it,
+    // looping until React threw "Maximum update depth exceeded".
+  }, [value, communityTitle, isFilter, queryClient]);
 
   // Component Functions
   const _handleOnTagPress = () => {

--- a/src/components/uploadsGalleryModal/container/uploadsGalleryModal.tsx
+++ b/src/components/uploadsGalleryModal/container/uploadsGalleryModal.tsx
@@ -9,7 +9,7 @@ import { SheetManager } from 'react-native-actions-sheet';
 import * as Sentry from '@sentry/react-native';
 import UploadsGalleryContent from '../children/uploadsGalleryContent';
 
-import { useAppDispatch, useAppSelector } from '../../../hooks';
+import { useAppSelector } from '../../../hooks';
 import { delay, extractFilenameFromPath, extractImageUrls } from '../../../utils/editor';
 import { isMediaPickerCancellation, reportMediaPickerError } from '../../../utils/mediaPickerError';
 import { readImageFromClipboard } from '../../../utils/clipboard';
@@ -75,7 +75,6 @@ export const UploadsGalleryModal = forwardRef(
     ref,
   ) => {
     const intl = useIntl();
-    const dispatch = useAppDispatch();
 
     const imageUploadsQuery = editorQueries.useMediaQuery();
 
@@ -163,7 +162,9 @@ export const UploadsGalleryModal = forwardRef(
             return null;
           });
 
-          _handleMediaOnSelected(_mediaItems, true);
+          // Drop entries the map returned as null (shared files missing path/name) so the
+          // size filter in _handleMediaOnSelected never dereferences a null item.
+          _handleMediaOnSelected(_mediaItems.filter(Boolean), true);
         });
       }
     }, [paramFiles]);
@@ -259,9 +260,11 @@ export const UploadsGalleryModal = forwardRef(
         }
 
         // filter out oversized images (server limit is 30MB)
-        const oversized = media.filter((item) => item.size && item.size > MAX_IMAGE_UPLOAD_SIZE);
+        const oversized = media.filter(
+          (item) => item && item.size && item.size > MAX_IMAGE_UPLOAD_SIZE,
+        );
         if (oversized.length > 0) {
-          media = media.filter((item) => !item.size || item.size <= MAX_IMAGE_UPLOAD_SIZE);
+          media = media.filter((item) => item && (!item.size || item.size <= MAX_IMAGE_UPLOAD_SIZE));
           Alert.alert(
             intl.formatMessage({ id: 'alert.fail' }),
             intl.formatMessage({ id: 'alert.payloadTooLarge' }),
@@ -510,15 +513,15 @@ export const UploadsGalleryModal = forwardRef(
           break;
       }
 
-      dispatch(
-        SheetManager.show(SheetNames.ACTION_MODAL, {
-          payload: {
-            title,
-            body,
-            buttons: [dialogAction],
-          },
-        }),
-      );
+      // SheetManager.show is self-executing and returns a Promise, not a Redux action;
+      // dispatching it threw Redux error #7 ("Actions may not have an undefined type").
+      SheetManager.show(SheetNames.ACTION_MODAL, {
+        payload: {
+          title,
+          body,
+          buttons: [dialogAction],
+        },
+      });
     };
 
     const _handleOpenSpeakUploader = () => {

--- a/src/components/uploadsGalleryModal/container/uploadsGalleryModal.tsx
+++ b/src/components/uploadsGalleryModal/container/uploadsGalleryModal.tsx
@@ -163,8 +163,13 @@ export const UploadsGalleryModal = forwardRef(
           });
 
           // Drop entries the map returned as null (shared files missing path/name) so the
-          // size filter in _handleMediaOnSelected never dereferences a null item.
-          _handleMediaOnSelected(_mediaItems.filter(Boolean), true);
+          // size filter in _handleMediaOnSelected never dereferences a null item. A text-only
+          // share filters to [], which would otherwise hit the "no media" error path, so only
+          // invoke upload handling when something remains.
+          const _validMediaItems = _mediaItems.filter(Boolean);
+          if (_validMediaItems.length) {
+            _handleMediaOnSelected(_validMediaItems, true);
+          }
         });
       }
     }, [paramFiles]);
@@ -264,7 +269,9 @@ export const UploadsGalleryModal = forwardRef(
           (item) => item && item.size && item.size > MAX_IMAGE_UPLOAD_SIZE,
         );
         if (oversized.length > 0) {
-          media = media.filter((item) => item && (!item.size || item.size <= MAX_IMAGE_UPLOAD_SIZE));
+          media = media.filter(
+            (item) => item && (!item.size || item.size <= MAX_IMAGE_UPLOAD_SIZE),
+          );
           Alert.alert(
             intl.formatMessage({ id: 'alert.fail' }),
             intl.formatMessage({ id: 'alert.payloadTooLarge' }),

--- a/src/hooks/useLinkProcessor.tsx
+++ b/src/hooks/useLinkProcessor.tsx
@@ -713,9 +713,14 @@ export const useLinkProcessor = (onClose?: () => void) => {
         });
       })
       .catch((errObj: any) => {
+        // errObj only carries errorKey1/errorKey2 for structured hive-uri errors; plain
+        // errors (network, resolveTransaction, etc.) reach this catch too. Fall back to
+        // generic keys so intl.formatMessage is never called with an undefined id.
+        const titleId = errObj?.errorKey1 || 'qr.transaction_failed';
+        const bodyId = errObj?.errorKey2 || 'qr.invalid_op_desc';
         Alert.alert(
-          intl.formatMessage({ id: errObj.errorKey1 }, { key: errObj.authorityKeyType }),
-          intl.formatMessage({ id: errObj.errorKey2 }, { key: errObj.authorityKeyType }),
+          intl.formatMessage({ id: titleId }, { key: errObj?.authorityKeyType }),
+          intl.formatMessage({ id: bodyId }, { key: errObj?.authorityKeyType }),
         );
       });
   };


### PR DESCRIPTION
Addresses a batch of actionable mobile crashes surfaced in Sentry. All four crash guards were verified against current `development` (3.5.7) code, so they prevent recurrence on the next release; the noise filter cuts reporting volume.

## Crash guards

| Sentry | Bug | Fix |
|---|---|---|
| ECENCY-MOBILE-90 | `tagContainer` `useEffect` had no dependency array, so it re-ran every render and its unconditional `setLabel`/`setIsCommunity` calls looped until React threw **Maximum update depth exceeded** | add `[value, communityTitle, isFilter, queryClient]` |
| ECENCY-MOBILE-28Q / 1V8 | shared-files map returns `null` for entries missing path/name, then `.filter(item => item.size...)` read **`.size` of null** | `_mediaItems.filter(Boolean)` + null-tolerant size filters |
| ECENCY-MOBILE-260 | `dispatch(SheetManager.show(...))` on media-pick failure — `show()` returns a Promise, not a Redux action → **Redux #7** | call `SheetManager.show(...)` directly (drop the `dispatch` wrapper; removes the now-unused `useAppDispatch`) |
| ECENCY-MOBILE-2FA | deep-link catch called `intl.formatMessage({ id: undefined })` for non-structured errors → **[React Intl] An id must be provided** | fall back to existing `qr.transaction_failed` / `qr.invalid_op_desc` keys |

## Sentry noise filter (`App.tsx`)

Drops benign/expected events that carry no diagnostic value (user-facing messages unchanged):
- `auth.invalid_credentials` / `auth.invalid_username` — wrong password (ECENCY-MOBILE-1QE)
- wrong PIN — `…check your PIN.` (ECENCY-MOBILE-265)
- HiveSigner signing cancelled (ECENCY-MOBILE-1Y1 / 1ZG)
- TanStack Query `CancelledError` (ECENCY-MOBILE-26A / 1YT)

Implemented via `ignoreErrors` + a `beforeSend` guard, matched by error value/type.

## Testing

JS-only, no native changes. Worth a `yarn lint` + `yarn test:ci` in CI. Manual: confirm a deep link with a malformed/network-failing op shows a generic alert (no red box), sharing a file into the editor doesn't crash, and a media-permission denial shows the action modal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed a “maximum update depth exceeded” issue in tag selection by stabilizing data-loading behavior.
  * Improved null-safety in the uploads gallery to avoid crashes when media details are missing or incomplete.
  * Ensured transaction failure alerts show fallback text when specific error details aren’t available.

* **Improvements**
  * Reduced error-report noise by suppressing benign expected errors in monitoring (including cancelled operations).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->