### PR TITLE
fix(crashes): serialize vote errors, guard wallet refetch and account repair

### DIFF
--- a/src/components/upvotePopover/container/upvotePopover.tsx
+++ b/src/components/upvotePopover/container/upvotePopover.tsx
@@ -140,16 +140,13 @@ function logVoteError(
     error_description: error?.error_description,
   };
   console.warn(`[vote] ${kind} mutation rejected (networkLevel=${networkLevel})`, info);
-  Sentry.captureException(
-    error instanceof Error ? error : new Error(resolvedMessage),
-    {
-      level: networkLevel ? 'warning' : 'error',
-      tags: { feature: 'vote', voteKind: kind, voteNetworkLevel: String(networkLevel) },
-      // Group by real cause instead of collapsing every non-Error under "[object Object]".
-      fingerprint: ['vote', kind, String(error?.name || error?.code || 'unknown')],
-      extra: info,
-    } as any,
-  );
+  Sentry.captureException(error instanceof Error ? error : new Error(resolvedMessage), {
+    level: networkLevel ? 'warning' : 'error',
+    tags: { feature: 'vote', voteKind: kind, voteNetworkLevel: String(networkLevel) },
+    // Group by real cause instead of collapsing every non-Error under "[object Object]".
+    fingerprint: ['vote', kind, String(error?.name || error?.code || 'unknown')],
+    extra: info,
+  } as any);
 }
 
 interface PopoverOptions {

--- a/src/components/upvotePopover/container/upvotePopover.tsx
+++ b/src/components/upvotePopover/container/upvotePopover.tsx
@@ -90,6 +90,35 @@ function isNetworkLevelVoteError(error: any): boolean {
   return NETWORK_ERROR_PATTERN.test(haystack);
 }
 
+// Vote rejections from the SDK async-broadcast path are often non-Error objects
+// (dhive RPCError-like), so String(error) yields "[object Object]" and the real cause
+// is lost both in Sentry and in the user toast. Walk the common shapes first.
+function extractVoteErrorMessage(error: any): string {
+  if (!error) {
+    return 'Unknown vote error';
+  }
+  if (typeof error === 'string') {
+    return error;
+  }
+  const candidate =
+    error.jse_shortmsg ||
+    error.error_description ||
+    error.error?.message ||
+    error.data?.message ||
+    error.response?.data?.message ||
+    error.response?.jse_shortmsg ||
+    error.message ||
+    error.cause?.message;
+  if (candidate) {
+    return String(candidate);
+  }
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return String(error);
+  }
+}
+
 function logVoteError(
   kind: 'upvote' | 'downvote',
   error: any,
@@ -97,6 +126,7 @@ function logVoteError(
   author?: string,
   permlink?: string,
 ) {
+  const resolvedMessage = extractVoteErrorMessage(error);
   const info = {
     kind,
     networkLevel,
@@ -105,15 +135,18 @@ function logVoteError(
     name: error?.name,
     code: error?.code,
     message: error?.message,
+    resolvedMessage,
     jse_shortmsg: error?.jse_shortmsg,
     error_description: error?.error_description,
   };
   console.warn(`[vote] ${kind} mutation rejected (networkLevel=${networkLevel})`, info);
   Sentry.captureException(
-    error instanceof Error ? error : new Error(String(error?.message ?? error)),
+    error instanceof Error ? error : new Error(resolvedMessage),
     {
       level: networkLevel ? 'warning' : 'error',
       tags: { feature: 'vote', voteKind: kind, voteNetworkLevel: String(networkLevel) },
+      // Group by real cause instead of collapsing every non-Error under "[object Object]".
+      fingerprint: ['vote', kind, String(error?.name || error?.code || 'unknown')],
       extra: info,
     } as any,
   );
@@ -355,12 +388,10 @@ const UpvotePopover = forwardRef(({}, ref) => {
             dispatch(setRcOffer(true));
           } else {
             logVoteError('upvote', _error, false, _author, _permlink);
-            let errMsg = '';
-            if (_error?.message && _error.message.indexOf(':') > 0) {
-              [, errMsg] = _error.message.split(': ');
-            } else {
-              errMsg = _error?.jse_shortmsg || _error?.error_description || _error?.message;
-            }
+            const _fullMsg = extractVoteErrorMessage(_error);
+            // Strip a leading "Prefix: " (e.g. "RPCError: ...") to show the human part.
+            const errMsg =
+              _fullMsg.indexOf(': ') > 0 ? _fullMsg.split(': ').slice(1).join(': ') : _fullMsg;
             dispatch(
               toastNotification(
                 intl.formatMessage({ id: 'alert.something_wrong_msg' }, { message: errMsg }),
@@ -426,7 +457,10 @@ const UpvotePopover = forwardRef(({}, ref) => {
           logVoteError('downvote', _error, false, _author, _permlink);
           dispatch(
             toastNotification(
-              intl.formatMessage({ id: 'alert.something_wrong_msg' }, { message: _error?.message }),
+              intl.formatMessage(
+                { id: 'alert.something_wrong_msg' },
+                { message: extractVoteErrorMessage(_error) },
+              ),
             ),
           );
           _updateVoteCache(_author, _permlink, amount, true, 'FAILED');

--- a/src/components/upvotePopover/container/upvotePopover.tsx
+++ b/src/components/upvotePopover/container/upvotePopover.tsx
@@ -455,12 +455,13 @@ const UpvotePopover = forwardRef(({}, ref) => {
           setIsDownVoted(!!sliderValue);
         } else {
           logVoteError('downvote', _error, false, _author, _permlink);
+          const _dvFullMsg = extractVoteErrorMessage(_error);
+          // Strip a leading "Prefix: " (e.g. "RPCError: ...") to match the upvote toast.
+          const _dvErrMsg =
+            _dvFullMsg.indexOf(': ') > 0 ? _dvFullMsg.split(': ').slice(1).join(': ') : _dvFullMsg;
           dispatch(
             toastNotification(
-              intl.formatMessage(
-                { id: 'alert.something_wrong_msg' },
-                { message: extractVoteErrorMessage(_error) },
-              ),
+              intl.formatMessage({ id: 'alert.something_wrong_msg' }, { message: _dvErrMsg }),
             ),
           );
           _updateVoteCache(_author, _permlink, amount, true, 'FAILED');

--- a/src/screens/application/container/applicationContainer.tsx
+++ b/src/screens/application/container/applicationContainer.tsx
@@ -706,7 +706,14 @@ class ApplicationContainer extends Component {
 
     const _enabledNotificationForAccount = (account) => {
       const encAccessToken = account?.local?.accessToken;
-      this._enableNotification(account.name, isEnabled, settings, encAccessToken);
+      // otherAccounts entries are keyed by username; name can be undefined on some
+      // (e.g. HiveSigner) entries, so fall back to username.
+      this._enableNotification(
+        account.name || account.username,
+        isEnabled,
+        settings,
+        encAccessToken,
+      );
     };
 
     // updateing fcm token with settings;
@@ -714,20 +721,16 @@ class ApplicationContainer extends Component {
       // since there can be more than one accounts, process access tokens separate
       if (account?.local?.accessToken) {
         _enabledNotificationForAccount(account);
-      } else {
-        console.warn('access token not present, reporting to Sentry');
-        Sentry.captureException(
-          new Error(
-            `Reporting missing access token in other accounts section: account:${
-              account?.name ?? '<unknown>'
-            } with local keys: ${Object.keys(account?.local || {}).join(',')}`,
-          ),
-        );
+        return;
+      }
 
-        // fallback to current account access token to register atleast logged in account
-        if (currentAccount?.name && currentAccount.name === account?.name) {
-          _enabledNotificationForAccount(currentAccount);
-        }
+      // No stored access token on this other-account entry. This is common and benign
+      // (HiveSigner accounts, or entries keyed only by username), so do NOT report it to
+      // Sentry - it previously fired an error on every launch (ECENCY-MOBILE-1QY).
+      const acctName = account?.name || account?.username;
+      if (acctName && currentAccount?.name === acctName) {
+        // fallback to current account access token to register at least the logged-in account
+        _enabledNotificationForAccount(currentAccount);
       }
     });
   };

--- a/src/screens/wallet/screen/walletScreen.tsx
+++ b/src/screens/wallet/screen/walletScreen.tsx
@@ -167,6 +167,12 @@ const WalletScreen = ({ navigation }: { navigation: any }) => {
       dispatch(fetchCoinQuotes());
     }
 
+    // getPortfolio throws when called without a username, and refetch() bypasses the
+    // query's enabled:!!currentAccount?.name gate (e.g. the logout transition forces a
+    // refetch with an empty name). Skip the portfolio refetch when logged out.
+    if (!currentAccount?.name) {
+      return;
+    }
     walletQuery.refetch();
   };
 

--- a/src/utils/migrationHelpers.ts
+++ b/src/utils/migrationHelpers.ts
@@ -278,10 +278,16 @@ export const repairUserAccountData = async (username, dispatch, intl, accounts, 
 
 export const repairOtherAccountsData = (accounts, realmAuthData, dispatch) => {
   accounts.forEach((account) => {
-    const accRealmData = realmAuthData.find((data) => data.username === account.name);
+    // otherAccounts entries are keyed by username; account.name can be undefined on some
+    // (e.g. HiveSigner) entries, so match realm data on either field.
+    const accRealmData = realmAuthData.find(
+      (data) => data.username === (account.username || account.name),
+    );
     if (!account.local?.accessToken && accRealmData) {
       account.local = accRealmData;
-      // Note: account.name is the primary field, no need to set username separately
+      // Backfill name so consumers that read account.name (e.g. notification registration)
+      // have a value for entries that were keyed only by username.
+      account.name = account.name || accRealmData.username;
       dispatch(updateOtherAccount({ ...account }));
     }
   });


### PR DESCRIPTION
Second batch of Sentry fixes (follow-up to #3258). These touch a bit more logic than the quick-win guards, so they are split out for focused review.

## Fixes

**ECENCY-MOBILE-2E8 — vote error logged as `[object Object]`**
Vote rejections from the SDK async-broadcast path are frequently non-`Error` objects (dhive `RPCError`-like), so `String(error)` produced `[object Object]` as both the Sentry title and the toast message, losing the real cause. Adds `extractVoteErrorMessage()` (walks `jse_shortmsg` → `error_description` → nested `error/data/response` → `message` → `cause`, then `JSON.stringify`), used for the captured message, both toasts, and a stable `fingerprint: ['vote', kind, name|code]` so events group by real cause instead of collapsing.

**ECENCY-MOBILE-ST — `Username must be passed for fetching portfolio`**
The portfolio query is gated by `enabled: !!currentAccount?.name`, but an explicit `walletQuery.refetch()` bypasses that gate. The logout transition (and token-sync / pull-to-refresh) forces a refetch with an empty name → SDK `getPortfolio` throws. Guards the refetch on `currentAccount?.name` (coin-quote fetch, which is account-independent, still runs).

**ECENCY-MOBILE-1QY — "missing access token" Sentry error every launch**
`otherAccounts` entries are keyed by `username` (reducer dedups on it), but the notification registration read `account.name`, which is undefined for HiveSigner entries — so it both fired a `Sentry.captureException` on every launch and made `repairOtherAccountsData` fail to match (token never repaired). Now matches/repairs on `username || name`, backfills `name`, registers notifications with `name || username`, and stops reporting the benign tokenless other-account case.

## Testing

JS-only. Suggest `yarn lint` + `yarn test:ci` (there's a `migrationHelpers` test suite worth a look). Manual: cast a failing vote and confirm the toast shows a real message (not blank/`[object Object]`); log out from the wallet screen and confirm no error; with a HiveSigner second account, confirm no per-launch Sentry error and that notifications still register.