### PR TITLE
fix(native): mitigate Fabric/Reanimated crash and reduce ANR write payload (Wave 1)

### DIFF
--- a/src/components/atoms/scrollTopPopup/scrollTopPopup.tsx
+++ b/src/components/atoms/scrollTopPopup/scrollTopPopup.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { View, TouchableOpacity } from 'react-native';
+import { View, TouchableOpacity, Platform } from 'react-native';
 import Animated, { SlideInLeft, SlideOutLeft } from 'react-native-reanimated';
 import { IconButton } from '../..';
 import styles from './scrollTopPopup.styles';
@@ -15,7 +15,11 @@ export const ScrollTopPopup = ({ onPress, enable }: ScrollTopPopupProps) => {
   }
 
   return (
-    <Animated.View style={styles.popupContainer} entering={SlideInLeft} exiting={SlideOutLeft}>
+    <Animated.View
+      style={styles.popupContainer}
+      entering={Platform.OS === 'ios' ? SlideInLeft : undefined}
+      exiting={Platform.OS === 'ios' ? SlideOutLeft : undefined}
+    >
       <View style={styles.popupContentContainer}>
         <TouchableOpacity onPress={onPress}>
           <View style={styles.popupContentContainer}>

--- a/src/components/post-translation-modal/postTranslationModal.tsx
+++ b/src/components/post-translation-modal/postTranslationModal.tsx
@@ -166,7 +166,9 @@ const PostTranslationModal = ({ payload }: SheetProps<'post_translation'>) => {
       <>
         <Animated.View
           style={{ overflow: 'hidden' }}
-          layout={LinearTransition.easing(Easing.ease).duration(300)}
+          layout={
+            Platform.OS === 'ios' ? LinearTransition.easing(Easing.ease).duration(300) : undefined
+          }
         >
           {!isLoadingTranslation && (
             <Text style={styles.translatedText}>

--- a/src/components/toastNotification/view/toastNotificaitonView.tsx
+++ b/src/components/toastNotification/view/toastNotificaitonView.tsx
@@ -67,8 +67,8 @@ const ToastNotification = ({
           ...style,
           ...(keyboardHeight > 0 && { bottom: keyboardHeight + 10 }),
         }}
-        entering={SlideInDown.duration(750)}
-        exiting={SlideOutDown.duration(500)}
+        entering={Platform.OS === 'ios' ? SlideInDown.duration(750) : undefined}
+        exiting={Platform.OS === 'ios' ? SlideOutDown.duration(500) : undefined}
       >
         <Text style={[styles.text, textStyle]} numberOfLines={2}>
           {text}

--- a/src/components/uploadsGalleryModal/children/mediaPreviewItem.tsx
+++ b/src/components/uploadsGalleryModal/children/mediaPreviewItem.tsx
@@ -54,7 +54,10 @@ export const MediaPreviewItem = ({
 
   const _renderMinus = () =>
     isDeleteMode && (
-      <AnimatedView.View entering={ZoomIn} style={styles.minusContainer}>
+      <AnimatedView.View
+        entering={Platform.OS === 'ios' ? ZoomIn : undefined}
+        style={styles.minusContainer}
+      >
         <Icon
           color={EStyleSheet.value('$pureWhite')}
           iconType="MaterialCommunityIcons"
@@ -67,7 +70,10 @@ export const MediaPreviewItem = ({
   const _renderCounter = () =>
     isInsertedTimes > 0 &&
     !isDeleteMode && (
-      <AnimatedView.View entering={ZoomIn} style={styles.counterContainer}>
+      <AnimatedView.View
+        entering={Platform.OS === 'ios' ? ZoomIn : undefined}
+        style={styles.counterContainer}
+      >
         <Text style={styles.counterText}>{isInsertedTimes}</Text>
       </AnimatedView.View>
     );

--- a/src/components/uploadsGalleryModal/children/uploadsGalleryContent.tsx
+++ b/src/components/uploadsGalleryModal/children/uploadsGalleryContent.tsx
@@ -6,6 +6,7 @@ import {
   Keyboard,
   NativeScrollEvent,
   NativeSyntheticEvent,
+  Platform,
   Text,
   TouchableOpacity,
   View,
@@ -295,8 +296,14 @@ const UploadsGalleryContent = ({
         justifyContent: isExpandedMode ? 'flex-end' : 'center',
       } as ViewStyle;
 
+      // Declarative enter/exit on this toggled button races Fabric view recycling on
+      // Android (RetryableMountingLayerException "Unable to find viewState"). iOS only.
       return (
-        <AnimatedView.View entering={SlideInRight} exiting={SlideOutRight} style={_delStyle}>
+        <AnimatedView.View
+          entering={Platform.OS === 'ios' ? SlideInRight : undefined}
+          exiting={Platform.OS === 'ios' ? SlideOutRight : undefined}
+          style={_delStyle}
+        >
           <IconButton
             style={styles.deleteButton}
             color={EStyleSheet.value('$pureWhite')}

--- a/src/providers/queries/index.ts
+++ b/src/providers/queries/index.ts
@@ -9,6 +9,10 @@ import { initSdkConfig } from './sdk-config';
 export const initQueryClient = () => {
   const asyncStoragePersister = createAsyncStoragePersister({
     storage: AsyncStorage,
+    // Batch cache writes (default is 1000ms). A longer window reduces how often the large
+    // dehydrated-cache blob is rewritten, lessening the synchronous SharedPreferences flush
+    // on backgrounding that contributes to Android Background ANRs.
+    throttleTime: 2000,
   });
 
   const client = new QueryClient({

--- a/src/redux/store/store.ts
+++ b/src/redux/store/store.ts
@@ -7,11 +7,22 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import reducers from '../reducers';
 import MigrationHelpers from '../../utils/migrationHelpers';
 
+// Cap the unbounded optimistic-vote and point-activity caches before they are serialized
+// to AsyncStorage. The full collections stay in memory for the session; only the persisted
+// (most-recent) slice is bounded, which shrinks the synchronous background SharedPreferences
+// flush that drives Android Background ANRs. Insertion order keeps the newest entries.
+const CACHE_PERSIST_LIMIT = 200;
+const capObject = (obj: Record<string, any> = {}, limit = CACHE_PERSIST_LIMIT) => {
+  const entries = Object.entries(obj || {});
+  return entries.length <= limit ? obj : Object.fromEntries(entries.slice(-limit));
+};
+
 const transformCacheVoteMap = createTransform(
   (inboundState: any) => ({
     ...inboundState,
+    votesCollection: capObject(inboundState.votesCollection),
     subscribedCommunities: Array.from(inboundState.subscribedCommunities),
-    pointActivities: Array.from(inboundState.pointActivities),
+    pointActivities: Array.from(inboundState.pointActivities).slice(-CACHE_PERSIST_LIMIT),
   }),
   (outboundState) => ({
     ...outboundState,

--- a/src/redux/store/store.ts
+++ b/src/redux/store/store.ts
@@ -13,8 +13,9 @@ import MigrationHelpers from '../../utils/migrationHelpers';
 // flush that drives Android Background ANRs. Insertion order keeps the newest entries.
 const CACHE_PERSIST_LIMIT = 200;
 const capObject = (obj: Record<string, any> = {}, limit = CACHE_PERSIST_LIMIT) => {
-  const entries = Object.entries(obj || {});
-  return entries.length <= limit ? obj : Object.fromEntries(entries.slice(-limit));
+  const safe = obj || {};
+  const entries = Object.entries(safe);
+  return entries.length <= limit ? safe : Object.fromEntries(entries.slice(-limit));
 };
 
 const transformCacheVoteMap = createTransform(


### PR DESCRIPTION
JS-only mitigations for the two native crash families confirmed **live on the 3.5.7 alpha track**. No dependency bumps here — the native version bumps (reanimated/screens/FCM) are a separate PR for on-device QA, and the AsyncStorage→MMKV migration is deferred to 3.5.8.

## Fabric + Reanimated `Unable to find viewState for tag` (ECENCY-MOBILE-7 / 78 / 7F)

Declarative `entering`/`exiting`/`layout` animations on conditionally-mounted or list-recycled views collide with Fabric's transaction merging on Android (DELETE+CREATE for the same tag merge → the view is gone at mount-commit). Tracked in reanimated#6908 and RN core #38743/#49077 (fixed in RN core ~0.81, **no backport to 0.79**). Gate the flagged sites to **iOS-only**:

| File | Animation |
|---|---|
| `mediaPreviewItem` | `ZoomIn` (recycled grid cell — highest risk) |
| `uploadsGalleryContent` | `SlideInRight`/`SlideOutRight` (toggled delete button) |
| `toastNotification` | `SlideInDown`/`SlideOutDown` |
| `scrollTopPopup` | `SlideInLeft`/`SlideOutLeft` |
| `postTranslationModal` | `LinearTransition` |

Android loses these entrance/exit animations (cosmetic); iOS unchanged. This **reduces** the crash rate; the durable fix is the reanimated bump (separate PR) + RN core.

## Background ANRs (ECENCY-MOBILE-9 + siblings — `QueuedWork`/SharedPreferences flush)

The dominant lever is **persisted payload size**, not write frequency (the persister already defaults to 1000ms). 
- Cap the two unbounded cache collections — `votesCollection` (optimistic votes) and `pointActivities` — to the most-recent 200 entries **on serialize only**. The full collections stay in memory for the session; on rehydrate only the recent slice is restored (chain/server data corrects the rest). Drafts/claims untouched (no data loss).
- Set an explicit `throttleTime: 2000` on the TanStack persister.

Honest scope note: this is a **partial** ANR reduction. The root-cause fix (AsyncStorage → `react-native-mmkv`, which bypasses SharedPreferences/QueuedWork) is intentionally deferred to a 3.5.8 effort.

## Testing (native — needs a device)

New-Arch (Hermes) **Android** build: open the uploads gallery and toggle delete mode / scroll the recycled grid rapidly; trigger toasts; the scroll-to-top popup; open the translation modal — confirm no crash and that the (now-instant on Android) UI behaves. **iOS** build: confirm all five animations still play. Optionally log the persisted redux/RQ blob size before/after to confirm the cap shrinks it. `yarn lint` + `yarn test:ci`.