### PR TITLE
fix(profile): stop the profile header scroll oscillation

### DIFF
--- a/src/components/profile/profileView.tsx
+++ b/src/components/profile/profileView.tsx
@@ -42,6 +42,10 @@ const SUMMARY_TOGGLE_COOLDOWN_MS = 550;
 class ProfileView extends PureComponent {
   _lastSummaryToggleAt = 0;
 
+  _lastOffsetY = 0;
+
+  _summaryRecheckTimer = null;
+
   constructor(props) {
     super(props);
     this.state = {
@@ -52,28 +56,49 @@ class ProfileView extends PureComponent {
     };
   }
 
-  _handleOnScroll = (event) => {
+  componentWillUnmount() {
+    if (this._summaryRecheckTimer) {
+      clearTimeout(this._summaryRecheckTimer);
+    }
+  }
+
+  // Decide collapse/expand from the latest scroll offset, honoring the dead zone and the
+  // post-toggle cooldown. If a wanted toggle lands inside the cooldown, re-evaluate once it
+  // clears using the most recent offset — so returning to the top still settles (re-expands)
+  // even when no further scroll event arrives (otherwise that lone toggle event is dropped).
+  _evaluateSummary = () => {
     const { isSummaryOpen } = this.state;
+    const offsetY = this._lastOffsetY;
+    const wantCollapse = isSummaryOpen && offsetY > SUMMARY_COLLAPSE_THRESHOLD;
+    const wantExpand = !isSummaryOpen && offsetY <= SUMMARY_EXPAND_THRESHOLD;
+    if (!wantCollapse && !wantExpand) {
+      return;
+    }
+
+    const now = Date.now();
+    const elapsed = now - this._lastSummaryToggleAt;
+    if (elapsed < SUMMARY_TOGGLE_COOLDOWN_MS) {
+      if (this._summaryRecheckTimer) {
+        clearTimeout(this._summaryRecheckTimer);
+      }
+      this._summaryRecheckTimer = setTimeout(() => {
+        this._summaryRecheckTimer = null;
+        this._evaluateSummary();
+      }, SUMMARY_TOGGLE_COOLDOWN_MS - elapsed + 20);
+      return;
+    }
+
+    this._lastSummaryToggleAt = now;
+    this.setState({ isSummaryOpen: wantExpand });
+  };
+
+  _handleOnScroll = (event) => {
     const offsetY = event?.nativeEvent?.contentOffset?.y;
     if (offsetY === undefined) {
       return;
     }
-
-    // Debounce direction flips while the header height animation settles.
-    const now = Date.now();
-    if (now - this._lastSummaryToggleAt < SUMMARY_TOGGLE_COOLDOWN_MS) {
-      return;
-    }
-
-    // Collapse only well past the top; re-expand only near the very top. The gap between
-    // the two thresholds is a dead zone so jitter / overscroll around 0 can't flip state.
-    if (isSummaryOpen && offsetY > SUMMARY_COLLAPSE_THRESHOLD) {
-      this._lastSummaryToggleAt = now;
-      this.setState({ isSummaryOpen: false });
-    } else if (!isSummaryOpen && offsetY <= SUMMARY_EXPAND_THRESHOLD) {
-      this._lastSummaryToggleAt = now;
-      this.setState({ isSummaryOpen: true });
-    }
+    this._lastOffsetY = offsetY;
+    this._evaluateSummary();
   };
 
   _loadMoreComments = () => {
@@ -309,10 +334,9 @@ class ProfileView extends PureComponent {
           selectedOptionIndex={selectedIndex}
           pageType={pageType}
           feedUsername={username}
-          // Do not toggle on touch-start: a stationary touch / tiny drag must not collapse
-          // the header. onScrollEndDrag + per-tab onScroll already drive collapse on real
-          // movement, so begin-drag toggling only fed the oscillation.
-          handleOnScrollBeginDrag={null}
+          // Begin-drag intentionally not wired (prop omitted): toggling on touch-start (a
+          // stationary touch or tiny drag) only fed the oscillation. onScrollEndDrag drives
+          // collapse instead.
           handleOnScroll={this._handleOnScroll}
           forceLoadPost={forceLoadPost}
           changeForceLoadPostState={changeForceLoadPostState}

--- a/src/components/profile/profileView.tsx
+++ b/src/components/profile/profileView.tsx
@@ -30,7 +30,18 @@ import CommentsTabContent from './children/commentsTabContent';
 import WavesTabContent from './children/wavesTabContent';
 import { Icon } from '..';
 
+// Profile summary collapse/expand is driven by feed scroll. A dead zone + cooldown keep
+// the header from oscillating: collapse only once scrolled well past the top, re-expand
+// only within a few px of the top, and ignore further flips for COOLDOWN ms (>= the 500ms
+// CollapsibleCard height animation) so the reflow that animation causes — which momentarily
+// reports offsetY≈0 on FlashList — can't re-trigger the opposite toggle.
+const SUMMARY_COLLAPSE_THRESHOLD = 80;
+const SUMMARY_EXPAND_THRESHOLD = 8;
+const SUMMARY_TOGGLE_COOLDOWN_MS = 550;
+
 class ProfileView extends PureComponent {
+  _lastSummaryToggleAt = 0;
+
   constructor(props) {
     super(props);
     this.state = {
@@ -44,16 +55,24 @@ class ProfileView extends PureComponent {
   _handleOnScroll = (event) => {
     const { isSummaryOpen } = this.state;
     const offsetY = event?.nativeEvent?.contentOffset?.y;
-
-    // Scrolled to top → re-expand profile
-    if (offsetY !== undefined && offsetY <= 0 && !isSummaryOpen) {
-      this.setState({ isSummaryOpen: true });
+    if (offsetY === undefined) {
       return;
     }
 
-    // Scrolling down → collapse profile
-    if (isSummaryOpen) {
+    // Debounce direction flips while the header height animation settles.
+    const now = Date.now();
+    if (now - this._lastSummaryToggleAt < SUMMARY_TOGGLE_COOLDOWN_MS) {
+      return;
+    }
+
+    // Collapse only well past the top; re-expand only near the very top. The gap between
+    // the two thresholds is a dead zone so jitter / overscroll around 0 can't flip state.
+    if (isSummaryOpen && offsetY > SUMMARY_COLLAPSE_THRESHOLD) {
+      this._lastSummaryToggleAt = now;
       this.setState({ isSummaryOpen: false });
+    } else if (!isSummaryOpen && offsetY <= SUMMARY_EXPAND_THRESHOLD) {
+      this._lastSummaryToggleAt = now;
+      this.setState({ isSummaryOpen: true });
     }
   };
 
@@ -248,7 +267,6 @@ class ProfileView extends PureComponent {
       deepLinkFilter,
     } = this.props;
 
-    const { isSummaryOpen } = this.state;
     const pageType = isOwnProfile ? 'ownProfile' : 'profile';
     const tabs = (isOwnProfile ? ownProfileTabs : profileTabs) || getDefaultFilters(pageType);
 
@@ -291,7 +309,10 @@ class ProfileView extends PureComponent {
           selectedOptionIndex={selectedIndex}
           pageType={pageType}
           feedUsername={username}
-          handleOnScrollBeginDrag={isSummaryOpen ? this._handleOnScroll : null}
+          // Do not toggle on touch-start: a stationary touch / tiny drag must not collapse
+          // the header. onScrollEndDrag + per-tab onScroll already drive collapse on real
+          // movement, so begin-drag toggling only fed the oscillation.
+          handleOnScrollBeginDrag={null}
           handleOnScroll={this._handleOnScroll}
           forceLoadPost={forceLoadPost}
           changeForceLoadPostState={changeForceLoadPostState}

--- a/src/components/profile/profileView.tsx
+++ b/src/components/profile/profileView.tsx
@@ -116,6 +116,10 @@ class ProfileView extends PureComponent {
     const { isSummaryOpen } = this.state;
 
     if (!isSummaryOpen) {
+      // Stamp the cooldown clock like the scroll-driven path, otherwise a tap-expand while
+      // scrolled past the threshold leaves the timestamp stale and the next scroll event
+      // immediately re-collapses the header.
+      this._lastSummaryToggleAt = Date.now();
       this.setState({ isSummaryOpen: true });
     }
   };


### PR DESCRIPTION
## Problem
On a profile page, scrolling the feed makes the page **repeatedly snap back to the fully-expanded top** (avatar/bio/follower-count reappear) ~once a second — the scroll position is unstable ("flakiness"). Reproduced from a user screen-recording; affects **all tabs** (posts/waves/replies/wallet).

## Root cause
`ProfileView._handleOnScroll` flips `isSummaryOpen` via `setState` on every feed scroll event with **no dead zone** (collapse on any `offsetY>0`, expand on `offsetY<=0`). That one flag (a) toggles the top `<Header>` and (b) animates `CollapsibleCard`'s height over 500ms — both **above the `FlashList` in a flex column**. Each toggle reflows the list; FlashList v2 on Fabric momentarily reports `offsetY≈0` during the resize, which **re-fires the opposite toggle** → a self-sustaining ~1s oscillation. `onScrollBeginDrag` also toggled, so even a stationary touch kicked it off.

## Fix (this PR — pure scroll-handler logic, zero layout/structure change)
- **Hysteresis / dead zone:** collapse only when `offsetY > 80`, re-expand only when `offsetY <= 8`. Jitter/overscroll around 0 can no longer flip state.
- **Cooldown:** ignore further flips for 550ms after a toggle (≥ the 500ms `CollapsibleCard` animation), so the reflow that animation causes can't sneak a flip in mid-animation.
- **No begin-drag toggle:** `handleOnScrollBeginDrag={null}` — a touch-start / tiny drag no longer collapses; real movement (`onScrollEndDrag` + per-tab `onScroll`) still does.

This breaks the feedback loop that produced the oscillation, with no render-structure change (trivially revertible).

## Known follow-up (separate PR, needs device QA)
The top `<Header>` is still conditionally **mounted/unmounted** on collapse — a one-frame column-height step that can still cause a *single* jump on a legitimate collapse (not the oscillation). The robust end state is an **always-mounted overlay header driven by a Reanimated shared `scrollY` with a fixed list `paddingTop`**, so the list box never reflows. Scoped and ready to do next.

## Testing (on device — FlashList v2/Fabric scroll behavior is device-sensitive)
- [ ] Profile page: slow-drag the feed past ~80px → header collapses **once** and stays; keep scrolling → no snap-back to the expanded summary.
- [ ] Scroll fully to top → header re-expands **once**; tiny rubber-band at top does **not** cause flicker.
- [ ] Fast flick down/up repeatedly → no ~1s oscillation.
- [ ] Repeat on **every** tab: POSTS, WAVES, REPLIES, and (own profile) WALLET.
- [ ] Switch tabs while scrolled; pinned-post profile; pull-to-refresh on waves/comments — header state stays consistent.
- [ ] `yarn lint` + `yarn test:ci`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved profile header scroll behavior to eliminate rapid expand/collapse flickering during header animations. Added explicit scroll thresholds and a cooldown window to stabilize expand/collapse decisions, including consistent behavior after manual summary expansion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->