### PR TITLE
fix(android): gate residual reanimated animations on the Waves comment path

### DIFF
--- a/src/components/buttons/views/fabButton.tsx
+++ b/src/components/buttons/views/fabButton.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { TouchableOpacity, View } from 'react-native';
+import { TouchableOpacity, View, Platform } from 'react-native';
 import Animated, { BounceIn, FadeOut } from 'react-native-reanimated';
 import Icon from '../../icon';
 import styles from './fabButton.styles';
@@ -13,7 +13,13 @@ interface FabButtonProps {
 const FabButton = ({ bottomOffset, onPress, iconName = 'pencil' }: FabButtonProps) => {
   return (
     <View pointerEvents="box-none" style={[styles.fabWrapper, { bottom: bottomOffset }]}>
-      <Animated.View entering={BounceIn.delay(1000)} exiting={FadeOut}>
+      {/* Declarative enter/exit gated to iOS: on Android Fabric these worklet-driven
+          mount/unmount commits race the live-recycling Waves feed and throw the
+          "Unable to find viewState for tag" crash (ECENCY-MOBILE-7). */}
+      <Animated.View
+        entering={Platform.OS === 'ios' ? BounceIn.delay(1000) : undefined}
+        exiting={Platform.OS === 'ios' ? FadeOut : undefined}
+      >
         <TouchableOpacity activeOpacity={0.7} style={styles.fabButton} onPress={onPress}>
           <Icon iconType="MaterialCommunityIcons" name={iconName} color="#fff" size={24} />
         </TouchableOpacity>

--- a/src/components/pollsWizardModal/children/pollConfig.tsx
+++ b/src/components/pollsWizardModal/children/pollConfig.tsx
@@ -1,5 +1,5 @@
 import React, { useRef } from 'react';
-import { Text } from 'react-native';
+import { Text, Platform } from 'react-native';
 import { useIntl } from 'react-intl';
 import Animated, { SlideInDown, SlideOutDown } from 'react-native-reanimated';
 import styles from '../styles/pollsWizardContent.styles';
@@ -90,7 +90,10 @@ export const PollConfig = ({ pollDraft, setPollDraft }: Props) => {
   };
 
   return (
-    <Animated.View entering={SlideInDown} exiting={SlideOutDown}>
+    <Animated.View
+      entering={Platform.OS === 'ios' ? SlideInDown : undefined}
+      exiting={Platform.OS === 'ios' ? SlideOutDown : undefined}
+    >
       <Text style={styles.label}>{intl.formatMessage({ id: 'post_poll.config_age' })}</Text>
       <FormInput
         ref={ageInputRef}

--- a/src/components/pollsWizardModal/children/pollsWizardContent.tsx
+++ b/src/components/pollsWizardModal/children/pollsWizardContent.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useMemo, useCallback, memo, useRef } from 'react';
-import { View, Text, TouchableOpacity, ScrollView } from 'react-native';
+import { View, Text, TouchableOpacity, ScrollView, Platform } from 'react-native';
 import { useIntl } from 'react-intl';
 import DatePicker from 'react-native-date-picker';
 import { useDispatch } from 'react-redux';
@@ -252,7 +252,7 @@ export const PollsWizardContent = ({
     return (
       <>
         {!showConfig && (
-          <Animated.View exiting={SlideOutRight}>
+          <Animated.View exiting={Platform.OS === 'ios' ? SlideOutRight : undefined}>
             <View style={styles.separator} />
             <TouchableOpacity
               onPress={() => {


### PR DESCRIPTION
## Report
Production (3.5.6): commenting on Waves crashes the app after ~2-3 comments (usually the 3rd/submit), on a **Poco M7 Plus 5G and other devices**, for 7-10 days.

## Root cause (confirmed from live Sentry, 0.86)
**ECENCY-MOBILE-7** (group 56070987, 367 users) — the Fabric/Worklets mounting race: `com.swmansion.worklets.AndroidUIScheduler.triggerUI` flushes a Fabric mount instruction against a shadow-node tag whose `ViewState` was already deleted → fatal `CppException RetryableMountingLayerException "Unable to find viewState for tag"` at `SurfaceMountingManager.getViewState` (sibling **78** on the plain Fabric `doFrame` path). Breadcrumbs across multiple recent events match the comment-submit flow (TextInput compose → submit → `api.deathwing.me` broadcast + `/reputation-api` burst → crash) on Poco/Xiaomi/vivo/moto.

Per comment: a **declarative reanimated `entering`/`exiting`** view mounts/unmounts on Android and collides with the Fabric commit from the FlashList **optimistic-prepend re-render**. The "~3rd comment" is **cumulative race probability, not a leak** (verified: actions-sheet 0.9.7 uses RN-core Animated, not reanimated; no listener/timer/bitmap accumulation; the optimistic entry lands in the thread cache, not an unbounded feed).

## Why this PR (in addition to the pending 3.5.7)
The **primary** per-comment trigger (the `alert.success` **toast**) is already iOS-gated in **#3260**, and **#3261** bumps reanimated 3.17.4→3.19.5 (Fabric mounting-race fixes) — both merged but **not yet in production**. This PR closes the residuals #3260 missed that sit on the **same Waves-comment path**:
- **`FabButton`** (mounted on the Waves screen) — `BounceIn`/`FadeOut` → iOS only.
- **`pollsWizard`** (`pollConfig`, `pollsWizardContent`, reachable from the quick-post comment sheet) — `SlideInDown/Out` + `SlideOutRight` → iOS only.

Android loses these decorative animations (behavior-preserving); iOS unchanged. Same gating pattern as #3260. The ~30 other still-un-gated declarative sites are on **unrelated screens** and are covered by the #3261 runtime fix (or a separate app-wide decision) — deliberately **not** bundled here.

## Testing (on device)
- [ ] On a MediaTek Android 15/16 device (Poco/Xiaomi/vivo), reply to Waves **5-10+ times in one session** → no crash (reproduces the ~3rd-comment pattern).
- [ ] Confirm FAB + poll wizard still appear/work on Android (just without the entrance/exit animation); iOS animations unchanged.
- [ ] **Field-validate the full fix on a 3.5.7 build whose epoch postdates the reanimated 3.19.5 commit (2026-06-18)** — earlier 3.5.7 internal builds predate it and don't count.
- [ ] Monitor Sentry **ECENCY-MOBILE-7 / 78** on that build → trend toward zero; no new `worklets.triggerUI` events on the Waves flow.
- [ ] `yarn lint` + `yarn test:ci`.

## If `triggerUI` persists post-bump (next lever, not in this PR)
Pause the two `wavesQueries` `refetchInterval(60000)` feeds while the `QUICK_POST` sheet is open, to cut concurrent Fabric churn during the compose/submit window.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized animations on modal and button components to render only on iOS, improving performance on other platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->