### PR TITLE
fix(waves): hide bare $ on zero-payout cards + vote-count read fallback

### DIFF
--- a/src/components/comment/view/commentView.tsx
+++ b/src/components/comment/view/commentView.tsx
@@ -65,7 +65,11 @@ const CommentView = ({
   );
 
   const activeVotes = comment?.active_votes || [];
-  const _totalVotes = comment.stats?.total_votes || 0;
+  // Fall back to the actual voter list / total_votes when hivemind stats.total_votes is
+  // missing, so the heart matches the voters list shown on press. NOTE: this does not fix
+  // a stale persisted/un-refetched snapshot (where stats is a truthy-but-old value) — that
+  // is a data-freshness issue tracked separately.
+  const _totalVotes = comment.stats?.total_votes || activeVotes.length || comment.total_votes || 0;
 
   const [isOpeningReplies, setIsOpeningReplies] = useState(false);
 

--- a/src/components/postCard/children/upvoteButton.tsx
+++ b/src/components/postCard/children/upvoteButton.tsx
@@ -66,6 +66,11 @@ export const UpvoteButton = ({
 
   const payoutLimitHit = totalPayout >= maxPayout;
   const _shownPayout = payoutLimitHit && maxPayout > 0 ? maxPayout : totalPayout;
+  // Only render the payout chip when there is something to show. Waves typically have a
+  // 0 payout, where the old `_shownPayout || '0.000'` rendered a bare "$" with a tiny
+  // 0.000 the user reads as "$ and nothing else". Real payouts and declined-payout
+  // (strikethrough) still render.
+  const _hasPayoutToShow = Number(_shownPayout) > 0 || isDeclinedPayout;
 
   let iconName = 'upcircleo';
   const iconType = 'AntDesign';
@@ -92,7 +97,7 @@ export const UpvoteButton = ({
         </View>
       </TouchableOpacity>
       <View style={styles.payoutTextButton}>
-        {isShowPayoutValue && (
+        {isShowPayoutValue && _hasPayoutToShow && (
           <TouchableOpacity ref={detailsRef} onPress={_onDetailsPress}>
             <Text
               style={[
@@ -101,7 +106,7 @@ export const UpvoteButton = ({
                 boldPayout && styles.boldText,
               ]}
             >
-              <FormattedCurrency value={_shownPayout || '0.000'} />
+              <FormattedCurrency value={_shownPayout} />
             </Text>
           </TouchableOpacity>
         )}

--- a/src/components/postCard/children/upvoteButton.tsx
+++ b/src/components/postCard/children/upvoteButton.tsx
@@ -66,11 +66,14 @@ export const UpvoteButton = ({
 
   const payoutLimitHit = totalPayout >= maxPayout;
   const _shownPayout = payoutLimitHit && maxPayout > 0 ? maxPayout : totalPayout;
-  // Only render the payout chip when there is something to show. Waves typically have a
-  // 0 payout, where the old `_shownPayout || '0.000'` rendered a bare "$" with a tiny
-  // 0.000 the user reads as "$ and nothing else". Real payouts and declined-payout
-  // (strikethrough) still render.
-  const _hasPayoutToShow = Number(_shownPayout) > 0 || isDeclinedPayout;
+  // Coerce an absent/NaN payout to 0 so FormattedCurrency never receives undefined
+  // (which would render "$ NaN", e.g. a declined-payout card whose feed omits payout
+  // fields). Only render the payout chip when there is something to show — waves
+  // typically have a 0 payout, where the old `_shownPayout || '0.000'` rendered a bare
+  // "$" with a tiny 0.000 the user reads as "$ and nothing else". Real payouts and
+  // declined-payout (strikethrough $0.000) still render.
+  const _payoutValue = Number(_shownPayout) || 0;
+  const _hasPayoutToShow = _payoutValue > 0 || isDeclinedPayout;
 
   let iconName = 'upcircleo';
   const iconType = 'AntDesign';
@@ -106,7 +109,7 @@ export const UpvoteButton = ({
                 boldPayout && styles.boldText,
               ]}
             >
-              <FormattedCurrency value={_shownPayout} />
+              <FormattedCurrency value={_payoutValue} />
             </Text>
           </TouchableOpacity>
         )}


### PR DESCRIPTION
From a production bug report (@mdakash62, Android, prod 3.5.6) — four issues; this PR fixes the **two Waves-card display bugs** (verified still present on `development`, byte-identical to 3.5.6). The two editor issues are addressed separately (below).

## D) Payout shows a bare `$` with no amount ✅ complete fix
`upvoteButton` rendered `<FormattedCurrency value={_shownPayout || '0.000'} />`, so a **0-payout wave** showed a `$` with a tiny `0.000` the user reads as "$ and nothing else." Now the payout chip renders **only when there's a value** (`payout > 0 || isDeclinedPayout`) and passes the real value. Real payouts and declined-payout (strikethrough) are unchanged. Shared with regular post cards — those normally have non-zero payout, so the only visible change is hiding the dangling `$0.000` on zero-payout items.

## C) Vote count wrong (card `3` vs real `29`) ⚠️ partial — freshness is the real fix
`commentView` read **only** `comment.stats?.total_votes`. Now falls back to `active_votes.length || total_votes` when `stats` is missing (matches web + the voters list shown on press).

**Honest caveat:** this does **not** fix the user's specific `3 vs 29`. Fresh waves data has `stats.total_votes === active_votes.length` (both correct), so the stale `3` is a **data-freshness artifact** — a persisted/old waves snapshot whose count isn't reconciling (the read-fallback can't override a truthy-but-stale `stats`). The real fix is a query-freshness change (staleTime / refetch / invalidate on the waves query that backs the screen the user views — likely the profile waves tab), which needs an **on-device repro** to pin the exact screen/query. Tracked as a follow-up.

## A) Editor preview (eye) toggle jumps position — editor-only, not here
Partially mitigated by #3257 (single self-scrolling input), **not** fully fixed: the preview swap still **remounts** the body `TextInput`, destroying the scroll offset (only the caret is restored). **Device-validate on 3.5.7**; if it still jumps, the robust fix is keeping the editor mounted (visibility toggle) / preserving scroll offset rather than the ternary swap.

## B) Title disappears after writing — editor-only, likely fixed by #3257
Dominant cause on 3.5.6: the title scrolled off-screen (one outer ScrollView). #3257 **pins** title/tags, so it can no longer scroll away. **Verify on 3.5.7.** (A separate latent title/body `setState` race exists but is low-confidence; fix only if reproduced.)

## Testing
JS-only. `yarn lint` + `yarn test:ci`. On device: a 0-payout wave shows no `$` chip (real payouts unchanged); a wave with votes shows the count matching the voters list. For C's freshness + A/B, see the device-validation notes above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed vote count display to accurately reflect the voters list shown when viewing a comment.
  * Removed payout indicators from appearing for zero-payout content, providing a cleaner interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->