### PR TITLE
fix(waves): transparent letterbox bars on portrait video thumbs

### DIFF
--- a/src/components/postHtmlRenderer/videoThumb.tsx
+++ b/src/components/postHtmlRenderer/videoThumb.tsx
@@ -24,7 +24,14 @@ const VideoThumb = ({
       <View pointerEvents="none">
         <ImageBackground
           source={{ uri }}
-          style={{ ...styles.videoThumb, width: contentWidth, height: contentWidth * heightRatio }}
+          style={{
+            ...styles.videoThumb,
+            width: contentWidth,
+            height: contentWidth * heightRatio,
+            // portrait (3Speak) thumbs use 'contain', so keep the letterbox bars
+            // transparent to blend with the card instead of showing the fill color
+            ...(resizeMode === 'contain' ? { backgroundColor: 'transparent' } : null),
+          }}
           resizeMode={resizeMode}
         >
           <IconButton


### PR DESCRIPTION
## Problem
Portrait video uploads (3Speak) in Waves correctly render in portrait ratio via `resizeMode: 'contain'`, but the resulting pillarbox/letterbox bars on the sides were filled with the `$darkIconColor` placeholder color, which looks off against the card.

## Fix
Make the `ImageBackground` background transparent **only in the `contain` case** (portrait 3Speak thumbs), so the bars blend with the card background.

- Cover thumbnails are unchanged: they keep the `$darkIconColor` load placeholder, which is never visible once the image fills the frame.
- No change to video-ratio / portrait detection or any other behavior. Pure style polish in `videoThumb.tsx`.

## Testing
- Prettier 2.8.8 `--check` passes.
- Visual: portrait 3Speak thumbs now show transparent side bars (card background) instead of the gray fill.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code improvements to video thumbnail styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->