### PR TITLE
fix(waves): correct vote count on custom waves feeds

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@babel/preset-typescript": "^7.26.0",
     "@babel/runtime": "^7.26.7",
     "@ecency/render-helper": "^2.5.11",
-    "@ecency/sdk": "^2.3.15",
+    "@ecency/sdk": "^2.3.18",
     "@esteemapp/react-native-autocomplete-input": "^4.2.1",
     "@esteemapp/react-native-multi-slider": "^1.1.0",
     "@native-html/iframe-plugin": "^2.6.1",

--- a/src/components/comment/view/commentView.tsx
+++ b/src/components/comment/view/commentView.tsx
@@ -65,11 +65,18 @@ const CommentView = ({
   );
 
   const activeVotes = comment?.active_votes || [];
-  // Fall back to the actual voter list / total_votes when hivemind stats.total_votes is
-  // missing, so the heart matches the voters list shown on press. NOTE: this does not fix
-  // a stale persisted/un-refetched snapshot (where stats is a truthy-but-old value) — that
-  // is a data-freshness issue tracked separately.
-  const _totalVotes = comment.stats?.total_votes || activeVotes.length || comment.total_votes || 0;
+  // Fall back to the actual voter list / net_votes / total_votes when hivemind
+  // stats.total_votes is missing, so the heart matches the voters list shown on press.
+  // net_votes covers the custom waves feeds (following/tags/user) whose esync payload
+  // carries net_votes but no active_votes. NOTE: this does not fix a stale
+  // persisted/un-refetched snapshot (where stats is a truthy-but-old value) — that is a
+  // data-freshness issue tracked separately.
+  const _totalVotes =
+    comment.stats?.total_votes ||
+    activeVotes.length ||
+    comment.net_votes ||
+    comment.total_votes ||
+    0;
 
   const [isOpeningReplies, setIsOpeningReplies] = useState(false);
 

--- a/src/components/comment/view/commentView.tsx
+++ b/src/components/comment/view/commentView.tsx
@@ -65,16 +65,16 @@ const CommentView = ({
   );
 
   const activeVotes = comment?.active_votes || [];
-  // Fall back to the actual voter list / net_votes / total_votes when hivemind
-  // stats.total_votes is missing, so the heart matches the voters list shown on press.
-  // net_votes covers the custom waves feeds (following/tags/user) whose esync payload
-  // carries net_votes but no active_votes. NOTE: this does not fix a stale
-  // persisted/un-refetched snapshot (where stats is a truthy-but-old value) — that is a
-  // data-freshness issue tracked separately.
+  // hivemind stats.total_votes is the freshest authoritative count when present
+  // (it tracks optimistic up/unvotes), so it stays first. Otherwise take the
+  // larger of the live voter list and net_votes: the custom waves feeds
+  // (following/tags/user) carry net_votes but no active_votes, and an optimistic
+  // vote there creates a length-1 active_votes array — Math.max keeps the real
+  // count (e.g. 29) instead of collapsing to 1 until the next refetch. NOTE: this
+  // does not fix a stale persisted/un-refetched snapshot — tracked separately.
   const _totalVotes =
     comment.stats?.total_votes ||
-    activeVotes.length ||
-    comment.net_votes ||
+    Math.max(activeVotes.length, comment.net_votes || 0) ||
     comment.total_votes ||
     0;
 

--- a/src/components/comment/view/commentView.tsx
+++ b/src/components/comment/view/commentView.tsx
@@ -66,17 +66,15 @@ const CommentView = ({
 
   const activeVotes = comment?.active_votes || [];
   // hivemind stats.total_votes is the freshest authoritative count when present
-  // (it tracks optimistic up/unvotes), so it stays first. Otherwise take the
-  // larger of the live voter list and net_votes: the custom waves feeds
-  // (following/tags/user) carry net_votes but no active_votes, and an optimistic
-  // vote there creates a length-1 active_votes array — Math.max keeps the real
-  // count (e.g. 29) instead of collapsing to 1 until the next refetch. NOTE: this
-  // does not fix a stale persisted/un-refetched snapshot — tracked separately.
+  // (it tracks optimistic up/unvotes), so it wins via ?? — a legit 0 (viewer
+  // removed the last vote) must NOT fall through to a stale net_votes. When stats
+  // is absent (custom waves feeds carry net_votes but no active_votes), take the
+  // larger of the live voter list and net_votes so an optimistic length-1
+  // active_votes array can't collapse the count (e.g. 29) to 1 until refetch.
+  // NOTE: this does not fix a stale persisted/un-refetched snapshot — tracked separately.
   const _totalVotes =
-    comment.stats?.total_votes ||
-    Math.max(activeVotes.length, comment.net_votes || 0) ||
-    comment.total_votes ||
-    0;
+    comment.stats?.total_votes ??
+    (Math.max(activeVotes.length, comment.net_votes || 0) || comment.total_votes || 0);
 
   const [isOpeningReplies, setIsOpeningReplies] = useState(false);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1211,10 +1211,10 @@
     url "^0.11.0"
     xss "^1.0.9"
 
-"@ecency/sdk@^2.3.15":
-  version "2.3.15"
-  resolved "https://registry.yarnpkg.com/@ecency/sdk/-/sdk-2.3.15.tgz#9de2163cf9c9bdffb3b00b8b0441cd7b392d87b7"
-  integrity sha512-RDmX+E9W2dcE3AU4hE8GDRB3h8BBB4lPe0uu15k2mA+0mph3YRJBZuHGC+70TGMbsYfmmZag++AM0uUpMgW8cA==
+"@ecency/sdk@^2.3.18":
+  version "2.3.18"
+  resolved "https://registry.yarnpkg.com/@ecency/sdk/-/sdk-2.3.18.tgz#e9d06574edd76153674143331da01833e8735f50"
+  integrity sha512-u7/W3Zh96l+0sGLCfM6QxzZSf5tUCu81kqPaZ1dV3Q/UVbu1Q2HLtVO41r0PpGE2FfKi3Ye8vD3OUjJ/OpoOAQ==
   dependencies:
     "@noble/ciphers" "^2.1.1"
     "@noble/curves" "^2.0.1"


### PR DESCRIPTION
Fixes the vote count on the custom waves feeds (following / tags / user-own), which displayed **0 / wrong** (the @mdakash62 report). Those feeds come from the esync private-api, whose payload carries `net_votes` but no `active_votes`/`stats`, so `CommentView` fell through to 0.

## Changes
- **Vote count:** thread `net_votes` into the `_totalVotes` fallback, keeping `stats.total_votes` first (freshest authoritative; tracks optimistic up/unvotes) then `Math.max(activeVotes.length, net_votes)`:
  `comment.stats?.total_votes || Math.max(activeVotes.length, comment.net_votes || 0) || comment.total_votes || 0`.
  Shows the right count on custom feeds, never collapses 29->1 on an optimistic vote, and does not regress the for-you feed or the optimistic unvote case.
- **SDK bump `@ecency/sdk` ^2.3.15 -> ^2.3.18:** ships the merged waves support (vision-next#971). Version alignment; the vote-count fix works at runtime regardless (parsePost reads `net_votes` untyped). SDK deps unchanged 2.3.15<->2.3.18, so the lockfile change is just the `@ecency/sdk` entry.

Payout on these feeds is fixed by esync + the existing `parsePost` payout sum. Tapping the count opens the voters screen, which fetches voters from chain via `get_active_votes` independent of the feed payload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved comment vote count display accuracy by enhancing fallback logic to handle cases where vote data is incomplete or inconsistent, ensuring reliable vote tallies are shown to users.

* **Chores**
  * Updated dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->