### PR TITLE
feat(waves): promoted waves, relative time on custom feeds, expander reply text

### DIFF
--- a/src/components/comment/view/commentStyles.ts
+++ b/src/components/comment/view/commentStyles.ts
@@ -19,6 +19,8 @@ export default EStyleSheet.create({
     flexDirection: 'row-reverse',
     borderRadius: 20,
     minWidth: 40,
+    justifyContent: 'center',
+    alignItems: 'center',
   },
   moreButton: {
     backgroundColor: '$iconColor',
@@ -38,6 +40,13 @@ export default EStyleSheet.create({
     color: '$white',
     marginRight: 12,
     marginTop: 1,
+  },
+  // Lone chevron on the reply-expander pill: no side margin so the icon centers
+  // (the pill is row-reverse with justifyContent/alignItems center and minWidth 40,
+  // and the expander passes no textStyle, so the empty label adds no offset).
+  chevronIcon: {
+    color: '$white',
+    marginRight: 0,
   },
   footerWrapper: {
     flex: 1,

--- a/src/components/comment/view/commentView.tsx
+++ b/src/components/comment/view/commentView.tsx
@@ -282,10 +282,9 @@ const CommentView = ({
               <TextWithIcon
                 wrapperStyle={styles.rightButton}
                 iconName={repliesToggle ? 'keyboard-arrow-up' : 'keyboard-arrow-down'}
-                textStyle={styles.moreText}
                 iconType="MaterialIcons"
                 isClickable
-                iconStyle={styles.iconStyle}
+                iconStyle={styles.chevronIcon}
                 iconSize={16}
                 onPress={() => _showSubCommentsToggle()}
                 text=""
@@ -319,6 +318,7 @@ const CommentView = ({
           currentAccountUsername={_currentUsername}
           isShowOwnerIndicator={mainAuthor === comment.author}
           isShowPinnedIndicator={isPinned}
+          isShowPromotedIndicator={comment.is_promoted}
           isHideImage={isHideImage}
           inlineTime={true}
           customStyle={{ alignItems: 'flex-start', paddingLeft: 12 }}

--- a/src/components/organisms/postStatsModal/children/postStatsContent.tsx
+++ b/src/components/organisms/postStatsModal/children/postStatsContent.tsx
@@ -29,7 +29,7 @@ export const PostStatsContent = ({
   const _durationValue = Math.floor((statsQuery.data?.visit_duration || 0) / 1000);
   const statsData1 = [
     { label: intl.formatMessage({ id: 'stats.viewers' }), value: statsQuery.data?.visitors },
-    { label: intl.formatMessage({ id: 'stats.pageviews' }), value: statsQuery.data?.pageviews },
+    { label: intl.formatMessage({ id: 'stats.pageviews' }), value: statsQuery.data?.visits },
     { label: intl.formatMessage({ id: 'stats.duration' }), value: _durationValue },
   ] as StatsItem[];
 

--- a/src/components/postElements/headerDescription/view/postHeaderDescription.tsx
+++ b/src/components/postElements/headerDescription/view/postHeaderDescription.tsx
@@ -120,6 +120,7 @@ class PostHeaderDescription extends PureComponent {
       tagOnPress,
       isShowOwnerIndicator,
       isShowPinnedIndicator,
+      isShowPromotedIndicator,
       isPromoted,
       intl,
       inlineTime,
@@ -164,6 +165,12 @@ class PostHeaderDescription extends PureComponent {
 
               {isShowPinnedIndicator && (
                 <Icon style={styles.pushPinIcon} name="pin" iconType="MaterialCommunityIcons" />
+              )}
+
+              {isShowPromotedIndicator && (
+                <Text style={styles.promotedIndicator}>
+                  {intl.formatMessage({ id: 'post.promoted' })}
+                </Text>
               )}
 
               {showDotMenuButton && (

--- a/src/components/postElements/headerDescription/view/postHeaderDescriptionStyles.ts
+++ b/src/components/postElements/headerDescription/view/postHeaderDescriptionStyles.ts
@@ -95,6 +95,18 @@ export default EStyleSheet.create({
     alignSelf: 'center',
     marginLeft: 8,
   },
+  promotedIndicator: {
+    alignSelf: 'center',
+    marginLeft: 8,
+    color: '$white',
+    backgroundColor: '$primaryBlue',
+    fontSize: 9,
+    fontWeight: '600',
+    paddingHorizontal: 6,
+    paddingVertical: 1,
+    borderRadius: 6,
+    overflow: 'hidden',
+  },
   rightIcon: {
     color: '$iconColor',
   },

--- a/src/components/postView/view/postDisplayView.tsx
+++ b/src/components/postView/view/postDisplayView.tsx
@@ -391,7 +391,7 @@ const PostDisplayView = ({
                     iconType="MaterialCommunityIcons"
                     isClickable
                     onPress={_showStatsModal}
-                    text={getAbbreviatedNumber(postStatsQuery.data?.pageviews || 0)}
+                    text={getAbbreviatedNumber(postStatsQuery.data?.visits || 0)}
                     textMarginLeft={4}
                     isLoading={postStatsQuery.isLoading}
                   />
@@ -448,7 +448,7 @@ const PostDisplayView = ({
       formatedTime,
       tags,
       postBodyLoading,
-      postStatsQuery.data?.pageviews,
+      postStatsQuery.data?.visits,
       postStatsQuery.isLoading,
       _showQuickProfileModal,
       _openProfilePage,

--- a/src/providers/plausible/converters.ts
+++ b/src/providers/plausible/converters.ts
@@ -33,8 +33,14 @@ export const convertStatsData = (rawData: any) => {
 // NOTE: update default stats here along with accompanying interface
 // this will also update thre returned response object
 export function getDefaultPostStats(): PostStats {
+  // `visits` (sessions) is the displayed "Views" number, matching the web app:
+  // it is reload-proof (a single user refreshing inflates pageviews but not
+  // visits), so app and web report the same count. `pageviews` is still fetched
+  // for the per-device breakdown. parsePostStatsResponse maps by metric NAME,
+  // so adding a key here just requests + parses that extra metric.
   return {
     visitors: 0,
+    visits: 0,
     pageviews: 0,
     visit_duration: 0,
   } as PostStats;

--- a/src/providers/plausible/plausible.types.ts
+++ b/src/providers/plausible/plausible.types.ts
@@ -16,6 +16,7 @@ export interface StatsResponse {
 // NOTE: this interface is also used to update
 export interface PostStats {
   visitors: number;
+  visits: number;
   pageviews: number;
   visit_duration: number;
 }

--- a/src/providers/queries/postQueries/wavesQueries.ts
+++ b/src/providers/queries/postQueries/wavesQueries.ts
@@ -260,6 +260,12 @@ export const useWavesQuery = (
       if (fallbackQuery.data) {
         await fallbackQuery.refetch();
       }
+      // Keep interleaved promoted waves fresh on pull-to-refresh too; skip when
+      // promoted injection is off (tag feeds / profile tab) so we don't fire a
+      // disabled query.
+      if (injectPromoted) {
+        await promotedQuery.refetch();
+      }
     } finally {
       setIsRefreshing(false);
     }

--- a/src/providers/queries/postQueries/wavesQueries.ts
+++ b/src/providers/queries/postQueries/wavesQueries.ts
@@ -4,6 +4,7 @@ import {
   UseMutationOptions,
   useInfiniteQuery,
   useMutation,
+  useQuery,
   useQueryClient,
 } from '@tanstack/react-query';
 import { useCallback, useMemo, useState } from 'react';
@@ -13,6 +14,7 @@ import { useDispatch } from 'react-redux';
 import { useIntl } from 'react-intl';
 import {
   getAccountPosts,
+  getPromotedPostsQuery,
   getWavesByHostQueryOptions,
   getWavesFollowingQueryOptions,
   getWavesByTagQueryOptions,
@@ -52,6 +54,9 @@ export const useWavesQuery = (
     primary: WAVES_PRIMARY_HOST,
     fallback: WAVES_FALLBACK_HOST,
   },
+  // When true (for-you / following feeds, not tag feeds), promoted waves are
+  // fetched and interleaved into the list like the web waves feed.
+  injectPromoted = false,
 ) => {
   const queryClient = useQueryClient();
   const dispatch = useDispatch();
@@ -102,6 +107,14 @@ export const useWavesQuery = (
     refetchInterval: 60000,
   });
 
+  // Promoted waves (only for for-you / following feeds, never tag feeds). The
+  // SDK keys this separately from the home-feed promoted query, so the two
+  // never collide. Interleaved into the list below, like the web waves feed.
+  const promotedQuery = useQuery({
+    ...getPromotedPostsQuery<WaveEntry>('waves'),
+    enabled: injectPromoted,
+  });
+
   const data = useMemo(() => {
     const primaryItems: WaveEntry[] = primaryQuery.data?.pages?.flat() ?? [];
     // Surface fallback items only while the primary is exhausted, so a primary
@@ -113,32 +126,70 @@ export const useWavesQuery = (
     const flatData: WaveEntry[] = [...primaryItems, ...fallbackItems];
     const botAuthors = botAuthorsQuery.data ?? [];
 
-    return (
-      flatData
-        // Waves are never promoted; pass the explicit `isPromoted=false` so this
-        // stays on the shared parsePost(post, currentUserName, isPromoted) contract.
-        // Shallow-copy before parsing: parsePost mutates its argument, and `flatData`
-        // holds the SDK query cache objects (mutating re-renders the body each refetch).
-        .map((item) => parsePost({ ...item }, currentAccount?.name, false))
-        .filter((post) => {
-          if (!post) {
-            return false;
+    const parsed = flatData
+      // Map esync's `timestamp` onto `created` so following / tag feeds show the
+      // relative publish time like the for-you feed. Organic waves are never
+      // promoted (isPromoted=false). Shallow-copy before parsing: parsePost mutates
+      // its argument, and `flatData` holds the SDK query cache objects.
+      .map((item) =>
+        parsePost(
+          { ...item, created: item.created || (item as any).timestamp },
+          currentAccount?.name,
+          false,
+        ),
+      )
+      .filter((post) => {
+        if (!post) {
+          return false;
+        }
+        // discard wave if author is muted
+        if (isArray(mutes) && mutes.indexOf(post.author) >= 0) {
+          return false;
+        }
+        // discard if wave is downvoted or marked gray
+        if (post.isMuted) {
+          return false;
+        }
+        // discard bot authors
+        if (botAuthors.includes(post.author)) {
+          return false;
+        }
+        return true;
+      });
+
+    if (!injectPromoted || !Array.isArray(promotedQuery.data) || !promotedQuery.data.length) {
+      return parsed;
+    }
+
+    // Interleave promoted waves like the web feed (waves-list-view): parse them
+    // as promoted, drop organic duplicates, then splice one in after every 4th
+    // item until the promoted queue drains.
+    const promotedWaves = promotedQuery.data
+      .map((item) =>
+        parsePost(
+          { ...item, created: item.created || (item as any).timestamp },
+          currentAccount?.name,
+          true,
+        ),
+      )
+      .filter(Boolean);
+    if (!promotedWaves.length) {
+      return parsed;
+    }
+    const promotedKeys = new Set(promotedWaves.map((wave) => `${wave.author}/${wave.permlink}`));
+    const queue = [...promotedWaves];
+    return parsed
+      .filter((post) => !promotedKeys.has(`${post.author}/${post.permlink}`))
+      .reduce((acc, post, index) => {
+        acc.push(post);
+        if (index % 4 === 1 && queue.length) {
+          const promoted = queue.shift();
+          if (promoted) {
+            acc.push(promoted);
           }
-          // discard wave if author is muted
-          if (isArray(mutes) && mutes.indexOf(post.author) >= 0) {
-            return false;
-          }
-          // discard if wave is downvoted or marked gray
-          if (post.isMuted) {
-            return false;
-          }
-          // discard bot authors
-          if (botAuthors.includes(post.author)) {
-            return false;
-          }
-          return true;
-        })
-    );
+        }
+        return acc;
+      }, [] as typeof parsed);
   }, [
     primaryQuery.data,
     fallbackQuery.data,
@@ -146,6 +197,8 @@ export const useWavesQuery = (
     mutes,
     botAuthorsQuery.data,
     currentAccount?.name,
+    promotedQuery.data,
+    injectPromoted,
   ]);
 
   const primaryItemCount = primaryQuery.data?.pages?.flat()?.length ?? 0;

--- a/src/providers/queries/postQueries/wavesQueries.ts
+++ b/src/providers/queries/postQueries/wavesQueries.ts
@@ -126,6 +126,28 @@ export const useWavesQuery = (
     const flatData: WaveEntry[] = [...primaryItems, ...fallbackItems];
     const botAuthors = botAuthorsQuery.data ?? [];
 
+    // Shared visibility filter: drop empty parses, muted authors, downvoted /
+    // gray waves, and bot authors. Applied to BOTH organic and promoted waves
+    // so the user's own mutes (and bot/gray hiding) hold even for promoted cards.
+    const isVisibleWave = (post: any) => {
+      if (!post) {
+        return false;
+      }
+      // discard wave if author is muted
+      if (isArray(mutes) && mutes.indexOf(post.author) >= 0) {
+        return false;
+      }
+      // discard if wave is downvoted or marked gray
+      if (post.isMuted) {
+        return false;
+      }
+      // discard bot authors
+      if (botAuthors.includes(post.author)) {
+        return false;
+      }
+      return true;
+    };
+
     const parsed = flatData
       // Map esync's `timestamp` onto `created` so following / tag feeds show the
       // relative publish time like the for-you feed. Organic waves are never
@@ -138,32 +160,16 @@ export const useWavesQuery = (
           false,
         ),
       )
-      .filter((post) => {
-        if (!post) {
-          return false;
-        }
-        // discard wave if author is muted
-        if (isArray(mutes) && mutes.indexOf(post.author) >= 0) {
-          return false;
-        }
-        // discard if wave is downvoted or marked gray
-        if (post.isMuted) {
-          return false;
-        }
-        // discard bot authors
-        if (botAuthors.includes(post.author)) {
-          return false;
-        }
-        return true;
-      });
+      .filter(isVisibleWave);
 
     if (!injectPromoted || !Array.isArray(promotedQuery.data) || !promotedQuery.data.length) {
       return parsed;
     }
 
-    // Interleave promoted waves like the web feed (waves-list-view): parse them
-    // as promoted, drop organic duplicates, then splice one in after every 4th
-    // item until the promoted queue drains.
+    // Interleave promoted waves exactly like the web feed (waves-list-view):
+    // parse as promoted, apply the same visibility filter, drop organic copies
+    // (keep the promoted version), then splice promoted cards in at the web
+    // cadence until the queue drains.
     const promotedWaves = promotedQuery.data
       .map((item) =>
         parsePost(
@@ -172,7 +178,7 @@ export const useWavesQuery = (
           true,
         ),
       )
-      .filter(Boolean);
+      .filter(isVisibleWave);
     if (!promotedWaves.length) {
       return parsed;
     }
@@ -182,6 +188,8 @@ export const useWavesQuery = (
       .filter((post) => !promotedKeys.has(`${post.author}/${post.permlink}`))
       .reduce((acc, post, index) => {
         acc.push(post);
+        // Matches the web feed's cadence (`index % 4 === 1`): the first promoted
+        // card appears after the 2nd organic wave, then after every 4th.
         if (index % 4 === 1 && queue.length) {
           const promoted = queue.shift();
           if (promoted) {

--- a/src/screens/waves/screen/wavesScreen.tsx
+++ b/src/screens/waves/screen/wavesScreen.tsx
@@ -86,7 +86,9 @@ const WavesFeed = ({
   registerDeleter: (key: string, deleter: DeleteWaveFn | null) => void;
   isDarkTheme: boolean;
 }) => {
-  const wavesQuery = wavesQueries.useWavesQuery(buildQueryOptions);
+  // Interleave promoted waves on the for-you / following feeds, but never on a
+  // tag feed (matches the web waves feed's `enabled: !tag`).
+  const wavesQuery = wavesQueries.useWavesQuery(buildQueryOptions, undefined, feedKey !== 'tag');
   const blockPopupRef = useRef(false);
   const scrollOffsetRef = useRef(0);
 


### PR DESCRIPTION
## Summary

Waves-feed polish plus a view-count fix, matching the web app:

- **Promoted waves** are interleaved into the For You and Following feeds (deduped against organic results) with a "Promoted" badge, mirroring the web waves feed. Tag feeds and the profile waves tab are excluded. They also respect the user's own mutes / gray / bot hiding, and refresh on pull-to-refresh.
- **Relative publish time** now shows on the Following and tag waves feeds. Those feeds return the publish time under a different field than For You, so it was previously blank; we map it onto `created`.
- The **reply expander chevron is centered** in its pill (it had been off-center). No reply-count text is added; the existing reply-count chip already shows the count.
- **View count fix**: the eye count on the post/wave detail screen (and the stats modal "Views" row) used Plausible `pageviews` (every page load), while the web app uses `visits` (sessions, reload-proof). `pageviews >= visits`, so the app showed a much higher number than the website for the same post. Now both show `visits`. `pageviews` is still fetched for the per-device breakdown.

## Notes

- **Promoted cadence (`index % 4 === 1`) is intentional**: it is identical to the web waves feed (`waves-list-view.tsx`), so app and web interleave promoted waves at the same positions (first promoted card after the 2nd wave, then every 4th). Kept deliberately for parity rather than changed to "every 4th."
- Promoted waves use the shared SDK `getPromotedPostsQuery("waves")`, keyed separately from the home-feed promoted query so the two never collide. Dedupe drops the organic copy and keeps the promoted version, matching web.
- The "Promoted" badge is a new inline indicator on the post header, gated by a dedicated prop so regular post cards are unaffected.
- The relative-time mapping lives in the shared waves data hook, so the profile waves tab benefits too (it just does not interleave promoted waves).
- The view-count change adds `visits` to the parsed post stats (the parser maps by metric name, so no index shifts); no SDK change is needed.
