### PR TITLE
chore(waves): bump @ecency/sdk to 2.3.19, drop redundant client-side created mapping

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@babel/preset-typescript": "^7.26.0",
     "@babel/runtime": "^7.26.7",
     "@ecency/render-helper": "^2.5.11",
-    "@ecency/sdk": "^2.3.18",
+    "@ecency/sdk": "^2.3.19",
     "@esteemapp/react-native-autocomplete-input": "^4.2.1",
     "@esteemapp/react-native-multi-slider": "^1.1.0",
     "@native-html/iframe-plugin": "^2.6.1",

--- a/src/providers/queries/postQueries/wavesQueries.ts
+++ b/src/providers/queries/postQueries/wavesQueries.ts
@@ -149,17 +149,11 @@ export const useWavesQuery = (
     };
 
     const parsed = flatData
-      // Map esync's `timestamp` onto `created` so following / tag feeds show the
-      // relative publish time like the for-you feed. Organic waves are never
-      // promoted (isPromoted=false). Shallow-copy before parsing: parsePost mutates
-      // its argument, and `flatData` holds the SDK query cache objects.
-      .map((item) =>
-        parsePost(
-          { ...item, created: item.created || (item as any).timestamp },
-          currentAccount?.name,
-          false,
-        ),
-      )
+      // Shallow-copy before parsing: parsePost mutates its argument, and `flatData`
+      // holds the SDK query cache objects (mutating re-renders the body each refetch).
+      // The SDK (>= 2.3.19) normalizes `created` on the custom feeds, so no client-side
+      // timestamp mapping is needed here. Organic waves are never promoted (isPromoted=false).
+      .map((item) => parsePost({ ...item }, currentAccount?.name, false))
       .filter(isVisibleWave);
 
     if (!injectPromoted || !Array.isArray(promotedQuery.data) || !promotedQuery.data.length) {
@@ -171,13 +165,7 @@ export const useWavesQuery = (
     // (keep the promoted version), then splice promoted cards in at the web
     // cadence until the queue drains.
     const promotedWaves = promotedQuery.data
-      .map((item) =>
-        parsePost(
-          { ...item, created: item.created || (item as any).timestamp },
-          currentAccount?.name,
-          true,
-        ),
-      )
+      .map((item) => parsePost({ ...item }, currentAccount?.name, true))
       .filter(isVisibleWave);
     if (!promotedWaves.length) {
       return parsed;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1211,10 +1211,10 @@
     url "^0.11.0"
     xss "^1.0.9"
 
-"@ecency/sdk@^2.3.18":
-  version "2.3.18"
-  resolved "https://registry.yarnpkg.com/@ecency/sdk/-/sdk-2.3.18.tgz#e9d06574edd76153674143331da01833e8735f50"
-  integrity sha512-u7/W3Zh96l+0sGLCfM6QxzZSf5tUCu81kqPaZ1dV3Q/UVbu1Q2HLtVO41r0PpGE2FfKi3Ye8vD3OUjJ/OpoOAQ==
+"@ecency/sdk@^2.3.19":
+  version "2.3.19"
+  resolved "https://registry.yarnpkg.com/@ecency/sdk/-/sdk-2.3.19.tgz#0495a4216fb902c82786c33bf7faacdbabf2fdbb"
+  integrity sha512-ehTY7WTiWbdsUOZWEzls0HHarskV5syGglMR/oqyhCG6ymc398b1eCaPo1dtYhYpafTLQDIh3xnrLwS+jgG4ww==
   dependencies:
     "@noble/ciphers" "^2.1.1"
     "@noble/curves" "^2.0.1"


### PR DESCRIPTION
## Summary

Adopts the canonical SDK fix for waves publish-time and removes the mobile-side workaround, so web and mobile share one code path.

- Bumps `@ecency/sdk` `^2.3.18 → ^2.3.19`. 2.3.19 maps the custom waves feeds' `timestamp` onto `created` inside `normalizeWaveEntryFromApi` (the same fix that landed for web).
- Removes the client-side `created: item.created || item.timestamp` map in `useWavesQuery` (both the organic and promoted `parsePost` calls), now redundant.

## Why this is safe
All three mobile wave sources supply `created` on 2.3.19:
- **Following / tag feeds** → SDK `normalizeWaveEntryFromApi` maps `timestamp → created`
- **For You** → built from Hive RPC, always has `created`
- **Promoted waves** → the promoted-entries endpoint already returns `created` (verified: items carry `created`, none carry `timestamp`)

No behaviour change versus the current `development` build (the workaround did the same mapping); this just makes the SDK the single source of truth.

## Verification
- Lockfile entry verified against the real npm tarball: computed sha512 and sha1 both match the `@ecency/sdk@2.3.19` lockfile entry; dependencies are identical to 2.3.18, so the swap is isolated to the one block.
- Prettier (2.8.8) clean.
- CI runs `yarn --frozen-lockfile` + lint + tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated SDK dependency.

* **Refactor**
  * Streamlined wave post processing logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->