### PR TITLE
fix: account_update2 profile robustness + hive-uri links in chat

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@babel/preset-typescript": "^7.26.0",
     "@babel/runtime": "^7.26.7",
     "@ecency/render-helper": "^2.5.11",
-    "@ecency/sdk": "^2.3.19",
+    "@ecency/sdk": "^2.3.20",
     "@esteemapp/react-native-autocomplete-input": "^4.2.1",
     "@esteemapp/react-native-multi-slider": "^1.1.0",
     "@native-html/iframe-plugin": "^2.6.1",

--- a/src/components/postOptionsModal/container/postOptionsModal.tsx
+++ b/src/components/postOptionsModal/container/postOptionsModal.tsx
@@ -9,7 +9,12 @@ import { useNavigation } from '@react-navigation/native';
 import { FlatList } from 'react-native-gesture-handler';
 import ActionSheet, { SheetManager } from 'react-native-actions-sheet';
 import { useQueryClient } from '@tanstack/react-query';
-import { getPostQueryOptions, getAccountFullQueryOptions, useDeleteComment } from '@ecency/sdk';
+import {
+  getPostQueryOptions,
+  getAccountFullQueryOptions,
+  parseProfileMetadata,
+  useDeleteComment,
+} from '@ecency/sdk';
 import { useAuthContext } from '../../../providers/sdk';
 import {
   useReblogMutation,
@@ -502,12 +507,22 @@ const PostOptionsModal = ({ pageType, isWave, isVisibleTranslateModal, onDelete 
   const _updatePinnedPost = async (
     { unpinPost }: { unpinPost: boolean } = { unpinPost: false },
   ) => {
-    const profileParams = {
-      ...(currentAccount.profile || {}),
-      pinned: unpinPost ? null : content.permlink,
-    };
-
     try {
+      // Merge onto the CURRENT on-chain profile, not a possibly stale/empty
+      // Redux copy. Force a fresh fetch first so changing only `pinned` can
+      // never overwrite name/avatar/cover/etc with stale or empty values.
+      const freshAccount = await queryClient.fetchQuery({
+        ...getAccountFullQueryOptions(currentAccount.name),
+        staleTime: 0,
+      });
+      const baseProfile =
+        parseProfileMetadata(freshAccount?.posting_json_metadata) || currentAccount.profile || {};
+
+      const profileParams = {
+        ...baseProfile,
+        pinned: unpinPost ? null : content.permlink,
+      };
+
       await accountUpdateMutation.mutateAsync({ profile: profileParams });
 
       const nextAccount = {

--- a/src/config/locales/en-US.json
+++ b/src/config/locales/en-US.json
@@ -951,7 +951,8 @@
     "invalid_amount_desc": "Enter valid amount in proper format",
     "open": "Open URL",
     "invalid_key_desc": "kindly login with {key} key or master key to perform this transaction",
-    "auth_transfer_confirm": "Confirm transfer to {username}?"
+    "auth_transfer_confirm": "Confirm transfer to {username}?",
+    "sign_warning": "Only approve if you trust the source of this link. Approving broadcasts the operation below from your account using your {authority} key."
   },
   "voters_dropdown": {
     "rewards": "REWARDS",

--- a/src/hooks/useLinkProcessor.tsx
+++ b/src/hooks/useLinkProcessor.tsx
@@ -13,6 +13,7 @@ import {
   getDigitPinCode,
 } from '../providers/hive/hive';
 import { getFormattedTx, isHiveUri, normalizeHiveUri } from '../utils/hive-uri';
+import { resolveTxRequiredAuthority } from '../utils/hiveOperationAuthority';
 import { deepLinkParser } from '../utils/deepLinkParser';
 import showLoginAlert from '../utils/showLoginAlert';
 import RootNavigation from '../navigation/rootNavigation';
@@ -648,10 +649,11 @@ export const useLinkProcessor = (onClose?: () => void) => {
         }
         const ops = get(tx, 'operations', []);
         const op = ops[0];
+        const requiredAuthority = resolveTxRequiredAuthority(ops);
         SheetManager.show(SheetNames.ACTION_MODAL, {
           payload: {
             title: intl.formatMessage({ id: 'qr.confirmTransaction' }),
-            bodyContent: _renderActionModalBody(op, formattedTx.opName),
+            bodyContent: _renderActionModalBody(op, formattedTx.opName, requiredAuthority),
             buttons: [
               {
                 text: intl.formatMessage({ id: 'qr.cancel' }),
@@ -756,8 +758,17 @@ export const useLinkProcessor = (onClose?: () => void) => {
     </View>
   );
 
-  const _renderActionModalBody = (operations: any[], opName: string) => (
+  const _renderActionModalBody = (
+    operations: any[],
+    opName: string,
+    authority: 'posting' | 'active',
+  ) => (
     <View style={styles.transactionBodyContainer}>
+      <View style={styles.signWarningContainer}>
+        <Text style={styles.signWarningText}>
+          {intl.formatMessage({ id: 'qr.sign_warning' }, { authority })}
+        </Text>
+      </View>
       <View style={styles.transactionHeadingContainer}>
         <Text style={styles.transactionHeading}> {opName} </Text>
       </View>
@@ -803,6 +814,17 @@ const styles = EStyleSheet.create({
     marginVertical: 10,
     width: SCREEN_WIDTH - 64,
   } as ViewStyle,
+  signWarningContainer: {
+    borderBottomWidth: 1,
+    borderColor: '$borderColor',
+    paddingHorizontal: 8,
+    paddingVertical: 8,
+  } as ViewStyle,
+  signWarningText: {
+    color: '$primaryRed',
+    fontSize: 12,
+    fontWeight: '600',
+  } as TextStyle,
   transactionRow: {
     flexDirection: 'row',
     alignItems: 'center',

--- a/src/providers/hive/hive.ts
+++ b/src/providers/hive/hive.ts
@@ -29,6 +29,7 @@ import { getServer, getCache, setCache } from '../../realm/realm';
 // Utils
 import { decryptKey } from '../../utils/crypto';
 import { getName, getAvatar, parseReputation } from '../../utils/user';
+import { resolveTxRequiredAuthority } from '../../utils/hiveOperationAuthority';
 
 // Constant
 import AUTH_TYPE from '../../constants/authType';
@@ -646,41 +647,6 @@ const handleChainError = (strErr: string) => {
     return 'chain-error.insufficient_fund';
   }
   return null;
-};
-
-const POSTING_AUTH_OPERATION_NAMES = new Set([
-  'vote',
-  'comment',
-  'comment_options',
-  'custom_json',
-  'delete_comment',
-  'claim_reward_balance',
-]);
-
-const resolveOperationAuthority = (operation: Operation): 'posting' | 'active' => {
-  const [operationName, payload] = operation;
-
-  if (operationName === 'custom_json') {
-    const hasActiveAuth = Array.isArray(payload?.required_auths)
-      ? payload.required_auths.length > 0
-      : false;
-    if (hasActiveAuth) {
-      return 'active';
-    }
-    return 'posting';
-  }
-
-  return POSTING_AUTH_OPERATION_NAMES.has(operationName) ? 'posting' : 'active';
-};
-
-const resolveTxRequiredAuthority = (operations: Operation[]): 'posting' | 'active' => {
-  if (!operations || operations.length === 0) {
-    return 'posting';
-  }
-
-  return operations.some((operation) => resolveOperationAuthority(operation) === 'active')
-    ? 'active'
-    : 'posting';
 };
 
 export const handleHiveUriOperation = async (

--- a/src/screens/chats/container/chatThreadContainer.tsx
+++ b/src/screens/chats/container/chatThreadContainer.tsx
@@ -22,6 +22,7 @@ import { catchPostImage, postBodySummary } from '@ecency/render-helper';
 
 import { getCommunityQueryOptions, getPostQueryOptions } from '@ecency/sdk';
 import { useQueryClient } from '@tanstack/react-query';
+import { addHiveScheme } from '../utils/chatLinkify';
 import ROUTES from '../../../constants/routeNames';
 import { useAppSelector, useLinkProcessor } from '../../../hooks';
 import { selectCurrentAccount, selectPin } from '../../../redux/selectors';
@@ -227,6 +228,7 @@ export const ChatThreadContainer: React.FC<ChatThreadContainerProps> = ({
   const linkifyInstance = useMemo(() => {
     const linkify = new LinkifyIt();
     linkify.set({ fuzzyLink: false });
+    addHiveScheme(linkify);
     return linkify;
   }, []);
 

--- a/src/screens/chats/utils/chatLinkify.test.ts
+++ b/src/screens/chats/utils/chatLinkify.test.ts
@@ -1,0 +1,32 @@
+import LinkifyIt from 'linkify-it';
+import { addHiveScheme } from './chatLinkify';
+
+const makeLinkify = () => {
+  const linkify = new LinkifyIt();
+  linkify.set({ fuzzyLink: false });
+  return addHiveScheme(linkify);
+};
+
+// A real hive-uri payload ends in `..` (the `=` padding under hive-uri's
+// custom base64), so verify those trailing dots are kept in the match.
+const HIVE_URI = 'hive://sign/op/WyJhY2NvdW50X3VwZGF0ZTIiLHt9XQ..';
+
+describe('addHiveScheme (chat linkify)', () => {
+  it('detects a hive:// signing link', () => {
+    const matches = makeLinkify().match(`please open ${HIVE_URI} to restore`);
+    expect(matches).toBeTruthy();
+    const hit = matches?.find((m) => m.schema === 'hive:');
+    expect(hit).toBeTruthy();
+    expect(hit?.url).toBe(HIVE_URI); // full link incl. trailing ".." padding
+  });
+
+  it('still detects https links', () => {
+    const matches = makeLinkify().match('see https://hivesigner.com/sign/op/abc');
+    expect(matches).toBeTruthy();
+    expect(matches?.[0].url).toContain('https://hivesigner.com/sign/op/abc');
+  });
+
+  it('does not match plain text', () => {
+    expect(makeLinkify().match('just a normal message')).toBeNull();
+  });
+});

--- a/src/screens/chats/utils/chatLinkify.ts
+++ b/src/screens/chats/utils/chatLinkify.ts
@@ -1,0 +1,22 @@
+import type LinkifyIt from 'linkify-it';
+
+// hive-uri links look like `hive://sign/op/<payload>` (also tx/ops/msg). The
+// payload is a custom base64 that can end in `.` (its `=` padding), so the tail
+// is matched as everything up to whitespace rather than trimming punctuation.
+const HIVE_URI_TAIL = /^\/\/[^\s<>"]+/;
+
+/**
+ * Register the `hive:` scheme on a linkify-it instance so hive-uri signing
+ * links (hive://sign/op/...) are detected and become tappable in chat
+ * messages, the same as http/https links. Returns the same instance.
+ */
+export const addHiveScheme = (linkify: LinkifyIt.LinkifyIt) => {
+  linkify.add('hive:', {
+    validate: (text: string, pos: number) => {
+      const tail = text.slice(pos);
+      const match = tail.match(HIVE_URI_TAIL);
+      return match ? match[0].length : 0;
+    },
+  });
+  return linkify;
+};

--- a/src/utils/hiveOperationAuthority.test.ts
+++ b/src/utils/hiveOperationAuthority.test.ts
@@ -1,0 +1,103 @@
+import { resolveOperationAuthority, resolveTxRequiredAuthority } from './hiveOperationAuthority';
+
+describe('resolveOperationAuthority', () => {
+  it('account_update2 changing only posting_json_metadata -> posting', () => {
+    expect(
+      resolveOperationAuthority([
+        'account_update2',
+        {
+          account: 'alice',
+          json_metadata: '',
+          posting_json_metadata: '{"profile":{"pinned":"x"}}',
+          extensions: [],
+        },
+      ] as any),
+    ).toBe('posting');
+  });
+
+  it('account_update2 changing posting authority -> active', () => {
+    expect(
+      resolveOperationAuthority([
+        'account_update2',
+        {
+          account: 'alice',
+          posting: { weight_threshold: 1, account_auths: [], key_auths: [] },
+          json_metadata: '',
+          posting_json_metadata: '',
+          extensions: [],
+        },
+      ] as any),
+    ).toBe('active');
+  });
+
+  it('account_update2 also changing json_metadata -> active', () => {
+    expect(
+      resolveOperationAuthority([
+        'account_update2',
+        { account: 'alice', json_metadata: '{"x":1}', posting_json_metadata: '' },
+      ] as any),
+    ).toBe('active');
+  });
+
+  it('account_update2 changing memo_key -> active', () => {
+    expect(
+      resolveOperationAuthority([
+        'account_update2',
+        { account: 'alice', memo_key: 'STM8x', json_metadata: '', posting_json_metadata: '' },
+      ] as any),
+    ).toBe('active');
+  });
+
+  it('account_update (v1) -> active', () => {
+    expect(
+      resolveOperationAuthority(['account_update', { account: 'alice', json_metadata: '' }] as any),
+    ).toBe('active');
+  });
+
+  it('vote -> posting', () => {
+    expect(resolveOperationAuthority(['vote', {}] as any)).toBe('posting');
+  });
+
+  it('custom_json without required_auths -> posting', () => {
+    expect(
+      resolveOperationAuthority([
+        'custom_json',
+        { required_auths: [], required_posting_auths: ['alice'] },
+      ] as any),
+    ).toBe('posting');
+  });
+
+  it('custom_json with required_auths -> active', () => {
+    expect(resolveOperationAuthority(['custom_json', { required_auths: ['alice'] }] as any)).toBe(
+      'active',
+    );
+  });
+
+  it('transfer -> active', () => {
+    expect(resolveOperationAuthority(['transfer', {}] as any)).toBe('active');
+  });
+});
+
+describe('resolveTxRequiredAuthority', () => {
+  it('empty tx -> posting', () => {
+    expect(resolveTxRequiredAuthority([])).toBe('posting');
+  });
+
+  it('all-posting tx -> posting', () => {
+    expect(
+      resolveTxRequiredAuthority([
+        ['vote', {}],
+        ['account_update2', { posting_json_metadata: '{}', json_metadata: '' }],
+      ] as any),
+    ).toBe('posting');
+  });
+
+  it('any active op -> active', () => {
+    expect(
+      resolveTxRequiredAuthority([
+        ['vote', {}],
+        ['transfer', {}],
+      ] as any),
+    ).toBe('active');
+  });
+});

--- a/src/utils/hiveOperationAuthority.test.ts
+++ b/src/utils/hiveOperationAuthority.test.ts
@@ -100,4 +100,10 @@ describe('resolveTxRequiredAuthority', () => {
       ] as any),
     ).toBe('active');
   });
+
+  it('non-array / malformed payload -> posting (no throw)', () => {
+    expect(resolveTxRequiredAuthority(undefined as any)).toBe('posting');
+    expect(resolveTxRequiredAuthority({} as any)).toBe('posting');
+    expect(resolveTxRequiredAuthority('nope' as any)).toBe('posting');
+  });
 });

--- a/src/utils/hiveOperationAuthority.ts
+++ b/src/utils/hiveOperationAuthority.ts
@@ -1,0 +1,62 @@
+import type { Operation } from '@ecency/sdk';
+
+/**
+ * Operations that, under current Hive consensus, can be signed with the
+ * posting authority. Everything not listed (and not special-cased below)
+ * defaults to active.
+ */
+export const POSTING_AUTH_OPERATION_NAMES = new Set([
+  'vote',
+  'comment',
+  'comment_options',
+  'custom_json',
+  'delete_comment',
+  'claim_reward_balance',
+]);
+
+/**
+ * Resolve the authority required to sign a single operation.
+ *
+ * Special cases mirror Hive consensus so valid hive-uri hot links are signed
+ * with the correct key instead of falling back to active:
+ * - `custom_json`: posting unless it declares `required_auths` (then active).
+ * - `account_update2`: posting when it only changes `posting_json_metadata`
+ *   (the common profile/pin update); active if it also changes `json_metadata`
+ *   or any key/authority (`owner`, `active`, `posting`, `memo_key`).
+ * - `account_update` (v1) is not listed, so it correctly resolves to active.
+ */
+export const resolveOperationAuthority = (operation: Operation): 'posting' | 'active' => {
+  const [operationName, payload] = operation as [string, any];
+
+  if (operationName === 'custom_json') {
+    return Array.isArray(payload?.required_auths) && payload.required_auths.length > 0
+      ? 'active'
+      : 'posting';
+  }
+
+  if (operationName === 'account_update2') {
+    const changesAuthorityOrKeys =
+      payload?.owner != null ||
+      payload?.active != null ||
+      payload?.posting != null ||
+      payload?.memo_key != null ||
+      (typeof payload?.json_metadata === 'string' && payload.json_metadata.length > 0);
+    return changesAuthorityOrKeys ? 'active' : 'posting';
+  }
+
+  return POSTING_AUTH_OPERATION_NAMES.has(operationName) ? 'posting' : 'active';
+};
+
+/**
+ * Resolve the single authority required to sign a whole transaction. If any
+ * operation needs active, the transaction needs active.
+ */
+export const resolveTxRequiredAuthority = (operations: Operation[]): 'posting' | 'active' => {
+  if (!operations || operations.length === 0) {
+    return 'posting';
+  }
+
+  return operations.some((operation) => resolveOperationAuthority(operation) === 'active')
+    ? 'active'
+    : 'posting';
+};

--- a/src/utils/hiveOperationAuthority.ts
+++ b/src/utils/hiveOperationAuthority.ts
@@ -52,7 +52,9 @@ export const resolveOperationAuthority = (operation: Operation): 'posting' | 'ac
  * operation needs active, the transaction needs active.
  */
 export const resolveTxRequiredAuthority = (operations: Operation[]): 'posting' | 'active' => {
-  if (!operations || operations.length === 0) {
+  // operations comes from deeplink-derived `tx` typed as `any`, so guard against
+  // a non-array payload before calling .some().
+  if (!Array.isArray(operations) || operations.length === 0) {
     return 'posting';
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1211,10 +1211,10 @@
     url "^0.11.0"
     xss "^1.0.9"
 
-"@ecency/sdk@^2.3.19":
-  version "2.3.19"
-  resolved "https://registry.yarnpkg.com/@ecency/sdk/-/sdk-2.3.19.tgz#0495a4216fb902c82786c33bf7faacdbabf2fdbb"
-  integrity sha512-ehTY7WTiWbdsUOZWEzls0HHarskV5syGglMR/oqyhCG6ymc398b1eCaPo1dtYhYpafTLQDIh3xnrLwS+jgG4ww==
+"@ecency/sdk@^2.3.20":
+  version "2.3.20"
+  resolved "https://registry.yarnpkg.com/@ecency/sdk/-/sdk-2.3.20.tgz#549639796760edffd7700b14caa23c6abad8f615"
+  integrity sha512-CVBe7F7wYb+ihpBAdM76bBjwVKVhZ6DYuz1K3aIjc57A0MbOy3JfIowHoyLVmKwBz3ACAB2S6jB/8+px3N91ng==
   dependencies:
     "@noble/ciphers" "^2.1.1"
     "@noble/curves" "^2.0.1"


### PR DESCRIPTION
Profile `posting_json_metadata` robustness plus making hive-uri signing links work and be safe in chat.

## 1. Pin merges onto a fresh on-chain profile
`_updatePinnedPost` built the `account_update2` profile by spreading the Redux `currentAccount.profile`. A stale/unloaded snapshot could let a pin overwrite name/avatar/cover/etc, worst case collapsing to `{ pinned, version }`. It now force-fetches the account and uses its parsed profile as the merge base.

## 2. Bump `@ecency/sdk` to 2.3.20
Picks up the merged server-side fixes (ecency/vision-next#976): full `posting_json_metadata` read-modify-write that preserves non-`profile` top-level keys, and a fresh-fetch-before-merge guard in `useAccountUpdate`.

## 3. Sign `account_update2` hive-uri links with the correct authority
The deeplink key-selection (`resolveOperationAuthority`) treated every `account_update2` as **active**, contradicting the app's own pre-check (`operations.json` marks it **posting**) and Hive consensus, so a posting-only user would approve then fail with `missing-authority`. Now `account_update2` resolves to **posting** when it only changes `posting_json_metadata`, and **active** when it also changes `json_metadata` or any key/authority. Extracted to a pure, testable util.

## 4. Guard `resolveTxRequiredAuthority` against non-array input
`operations` comes from deeplink-derived `tx` typed `any`; added `Array.isArray` before `.some()` so a malformed payload returns posting instead of throwing.

## 5. Recognize `hive://` links in chat messages
Registered the `hive:` scheme on the chat `linkify-it` instance so hive-uri signing links (`hive://sign/op/...`) are detected and tappable in DMs/channels (previously plain text). Tapping routes through the existing `handleLink` -> confirm sheet -> sign. The custom base64 payload's trailing `.` padding is preserved.

## 6. Warn and surface authority on the sign confirmation
Since a chat message can now carry any operation (e.g. a transfer), the confirm sheet (which already lists the operation name and every field) now also shows a warning to only approve if the source is trusted and which key (posting/active) will sign. A transfer or other active-key op from an untrusted link is clearly flagged before signing.

## Tests
- `src/utils/hiveOperationAuthority.test.ts` (13 cases incl. non-array guard)
- `src/screens/chats/utils/chatLinkify.test.ts` (3 cases incl. trailing-dot padding)
- `yarn lint` clean on changed files (pre-existing warnings in the large chat container untouched)

## Manual test plan
- Pin right after cold start (profile stays intact).
- Open `hive://sign/op/<account_update2>` as a posting-key user: signs and broadcasts (no missing-authority).
- Send a `hive://sign/...` link in a DM: it is tappable, opens the confirm sheet, shows the operation fields + the warning + the key it will use.
