### PR TITLE
feat(perks): Points-funded RC top-up redeem

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@babel/preset-typescript": "^7.26.0",
     "@babel/runtime": "^7.26.7",
     "@ecency/render-helper": "^2.5.11",
-    "@ecency/sdk": "^2.3.20",
+    "@ecency/sdk": "^2.3.21",
     "@esteemapp/react-native-autocomplete-input": "^4.2.1",
     "@esteemapp/react-native-multi-slider": "^1.1.0",
     "@native-html/iframe-plugin": "^2.6.1",

--- a/src/config/locales/en-US.json
+++ b/src/config/locales/en-US.json
@@ -27,7 +27,9 @@
     "promote": "Promote a post",
     "promote_desc": "Get more eyes on your post",
     "account_boost": "Account boost",
-    "account_boost_desc": "Boost any account"
+    "account_boost_desc": "Boost any account",
+    "rc_topup": "Top up RC",
+    "rc_topup_desc": "Keep posting when low on Resource Credits"
   },
   "waves": {
     "for_you": "For you",
@@ -1309,6 +1311,11 @@
     "already_boosted": "Account already boosted till {date}",
     "confirm_boost_plus": "Are you sure to Boost with In-App Purchase?",
     "title": "Boost+"
+  },
+  "rc_topup": {
+    "title": "Top up RC",
+    "desc": "A short-term RC boost so you can keep posting.",
+    "confirm": "Spend Points to top up your Resource Credits?"
   },
   "ai_image_generator": {
     "title": "AI Image Generator",

--- a/src/config/locales/en-US.json
+++ b/src/config/locales/en-US.json
@@ -243,7 +243,7 @@
     "hot": "Hot",
     "popular": "Popular",
     "new": "New",
-    "friends": "Friends",
+    "friends": "Following",
     "my_blog": "My Blog"
   },
   "bookmarks": {

--- a/src/containers/redeemContainer.tsx
+++ b/src/containers/redeemContainer.tsx
@@ -15,7 +15,11 @@ import {
 } from '../redux/selectors';
 import { getQueryClient } from '../providers/queries';
 import { toastNotification } from '../redux/actions/uiAction';
-import { usePromoteMutation, useBoostPlusMutation } from '../providers/sdk/mutations';
+import {
+  usePromoteMutation,
+  useBoostPlusMutation,
+  useRcDelegationMutation,
+} from '../providers/sdk/mutations';
 import { useAuthContext } from '../providers/sdk';
 
 /*
@@ -40,7 +44,7 @@ class RedeemContainer extends Component {
 
   _redeemAction = async (user, redeemType = 'promote', actionSpecificParam, author, permlink) => {
     const { dispatch, intl, navigation } = this.props;
-    const { promoteMutation, boostPlusMutation, boostMutation } = this.props;
+    const { promoteMutation, boostPlusMutation, boostMutation, rcDelegationMutation } = this.props;
 
     this.setState({ isLoading: true });
 
@@ -57,6 +61,12 @@ class RedeemContainer extends Component {
         case 'boost_plus':
           await boostPlusMutation.mutateAsync({
             account: author,
+            duration: actionSpecificParam,
+          });
+          break;
+
+        case 'rc_topup':
+          await rcDelegationMutation.mutateAsync({
             duration: actionSpecificParam,
           });
           break;
@@ -95,7 +105,7 @@ class RedeemContainer extends Component {
     let _author;
     let _permlink;
 
-    if (redeemType !== 'boost_plus') {
+    if (redeemType !== 'boost_plus' && redeemType !== 'rc_topup') {
       const separatedPermlink = fullPermlinkOrUsername.split('/');
       _author = get(separatedPermlink, '[0]');
       _permlink = get(separatedPermlink, '[1]');
@@ -164,6 +174,7 @@ const mapHooksToProps = (props) => {
   const { currentAccount } = props;
   const promoteMutation = usePromoteMutation();
   const boostPlusMutation = useBoostPlusMutation();
+  const rcDelegationMutation = useRcDelegationMutation();
   const boostMutation = useBroadcastMutation(
     ['ecency', 'boost'],
     currentAccount?.name,
@@ -181,6 +192,7 @@ const mapHooksToProps = (props) => {
       navigation={navigation}
       promoteMutation={promoteMutation}
       boostPlusMutation={boostPlusMutation}
+      rcDelegationMutation={rcDelegationMutation}
       boostMutation={boostMutation}
     />
   );

--- a/src/providers/sdk/mutations/index.ts
+++ b/src/providers/sdk/mutations/index.ts
@@ -22,6 +22,7 @@ export { usePinPostMutation } from './usePinPostMutation';
 export { useMutePostMutation } from './useMutePostMutation';
 export { usePromoteMutation } from './usePromoteMutation';
 export { useBoostPlusMutation } from './useBoostPlusMutation';
+export { useRcDelegationMutation } from './useRcDelegationMutation';
 
 // AI
 export { useGenerateImageMutation } from './useGenerateImageMutation';

--- a/src/providers/sdk/mutations/useRcDelegationMutation.ts
+++ b/src/providers/sdk/mutations/useRcDelegationMutation.ts
@@ -1,0 +1,7 @@
+import { useRcDelegation } from '@ecency/sdk';
+import { useMutationAuth } from './common';
+
+export function useRcDelegationMutation() {
+  const { username, authContext } = useMutationAuth();
+  return useRcDelegation(username, authContext, 'async');
+}

--- a/src/screens/perks/children/spendOptions.tsx
+++ b/src/screens/perks/children/spendOptions.tsx
@@ -17,6 +17,12 @@ const OPTIONS: { id: string; icon: string; route: string; params?: any }[] = [
     params: { redeemType: 'boost_plus' },
   },
   {
+    id: 'rc_topup',
+    icon: 'lightning-bolt',
+    route: ROUTES.SCREENS.REDEEM,
+    params: { redeemType: 'rc_topup' },
+  },
+  {
     id: 'promote',
     icon: 'bullhorn-outline',
     route: ROUTES.SCREENS.REDEEM,

--- a/src/screens/redeem/children/rcTopUp.tsx
+++ b/src/screens/redeem/children/rcTopUp.tsx
@@ -1,0 +1,175 @@
+import React, { Fragment, useState, useEffect, useRef, useMemo } from 'react';
+import { injectIntl } from 'react-intl';
+import { Text, View, ScrollView } from 'react-native';
+import { WebView } from 'react-native-webview';
+import { useQuery } from '@tanstack/react-query';
+import { getRcDelegationPricesQueryOptions, getPointsQueryOptions } from '@ecency/sdk';
+import { ScaleSlider } from '../../../components';
+import { hsOptions } from '../../../constants/hsOptions';
+
+// Components
+import { BasicHeader } from '../../../components/basicHeader';
+import { TransferFormItem } from '../../../components/transferFormItem';
+import { MainButton } from '../../../components/mainButton';
+import { Modal } from '../../../components/modal';
+
+// Styles (reuses the generic redeem-form styles)
+import styles from '../styles/boostPlus.styles';
+import { OptionsModal } from '../../../components/atoms';
+import { useAuth } from '../../../hooks';
+
+const RcTopUp = ({
+  intl,
+  handleOnSubmit,
+  redeemType,
+  isLoading,
+  currentAccountName,
+  balance: _balance,
+  SCPath,
+  isSCModalOpen,
+  handleOnSCModalClose,
+}) => {
+  const [balance, setBalance] = useState(_balance);
+  const [day, setDay] = useState(1);
+  const [price, setPrice] = useState<number | null>(null);
+  const [isValid, setIsValid] = useState(false);
+
+  const startActionSheet = useRef(null);
+
+  const { code } = useAuth();
+
+  const pricesQuery = useQuery({
+    ...getRcDelegationPricesQueryOptions(code),
+    enabled: !!code,
+  });
+
+  const { rcDays: _rcDays, rcPrices: _rcPrices } = useMemo(() => {
+    if (!pricesQuery.data || !Array.isArray(pricesQuery.data)) {
+      return { rcDays: [], rcPrices: [] };
+    }
+
+    const normalized = pricesQuery.data
+      .map((item) => {
+        const duration = Number(item.duration);
+        const price = Number(item.price);
+        return { duration, price };
+      })
+      .filter((item) => Number.isFinite(item.duration) && Number.isFinite(item.price));
+
+    return {
+      rcDays: normalized.map((item) => item.duration),
+      rcPrices: normalized.map((item) => item.price),
+    };
+  }, [pricesQuery.data]);
+
+  useEffect(() => {
+    setBalance(_balance);
+  }, [_balance]);
+
+  useEffect(() => {
+    if (_rcDays.length > 0 && !_rcDays.includes(day)) {
+      setDay(_rcDays[0]);
+    }
+
+    const index = _rcDays.indexOf(day);
+    const pr = index >= 0 ? _rcPrices[index] : undefined;
+
+    setIsValid(pr != null && pr <= balance);
+    setPrice(pr ?? null);
+  }, [day, balance, pricesQuery.data]);
+
+  const pointsQuery = useQuery({
+    ...getPointsQueryOptions(currentAccountName, 0),
+    enabled: !!currentAccountName,
+  });
+
+  useEffect(() => {
+    if (!pointsQuery.data || pointsQuery.data.points === undefined) {
+      return;
+    }
+    const points = Number(String(pointsQuery.data?.points ?? '').replace(/,/g, ''));
+    const balanceValue = Math.round(points * 1000) / 1000;
+    setBalance(Number.isNaN(balanceValue) ? _balance : balanceValue);
+  }, [pointsQuery.data, _balance]);
+
+  const _renderDropdown = (accountName) => <Text style={styles.dropdownText}>{accountName}</Text>;
+
+  const _handleOnSubmit = async () => {
+    handleOnSubmit(redeemType, day, currentAccountName, currentAccountName);
+  };
+
+  return (
+    <Fragment>
+      <BasicHeader title={intl.formatMessage({ id: 'rc_topup.title' })} />
+      <View style={styles.container}>
+        <ScrollView>
+          <View style={styles.middleContent}>
+            <TransferFormItem
+              label={intl.formatMessage({ id: 'promote.user' })}
+              rightComponent={() => _renderDropdown(currentAccountName)}
+            />
+            <Text style={styles.balanceText}>{`${balance} Points`}</Text>
+
+            <View style={styles.total}>
+              <Text style={styles.day}>
+                {`${_rcDays.length > 0 ? day : '--'} ${intl.formatMessage({
+                  id: 'promote.days',
+                })} `}
+              </Text>
+              <Text style={styles.price}>{`${price ?? '--'} Points  `}</Text>
+            </View>
+
+            {_rcDays.length > 0 && (
+              <ScaleSlider
+                values={_rcDays}
+                LRpadding={50}
+                activeValue={day}
+                handleOnValueChange={(_day) => setDay(_day)}
+                single
+              />
+            )}
+          </View>
+
+          <View style={styles.bottomContent}>
+            <MainButton
+              style={styles.button}
+              isDisable={isLoading || !isValid}
+              onPress={() => startActionSheet.current.show()}
+              isLoading={isLoading}
+            >
+              <Text style={styles.buttonText}>{intl.formatMessage({ id: 'transfer.next' })}</Text>
+            </MainButton>
+            <View style={styles.separator} />
+            <Text style={styles.descText}>{intl.formatMessage({ id: 'rc_topup.desc' })}</Text>
+          </View>
+        </ScrollView>
+      </View>
+      <OptionsModal
+        ref={startActionSheet}
+        options={[
+          intl.formatMessage({ id: 'alert.confirm' }),
+          intl.formatMessage({ id: 'alert.cancel' }),
+        ]}
+        title={intl.formatMessage({ id: 'rc_topup.confirm' })}
+        cancelButtonIndex={1}
+        destructiveButtonIndex={0}
+        onPress={(index) => {
+          if (index === 0) {
+            _handleOnSubmit();
+          }
+        }}
+      />
+      <Modal
+        isOpen={isSCModalOpen}
+        isFullScreen
+        isCloseButton
+        handleOnModalClose={handleOnSCModalClose}
+        title={intl.formatMessage({ id: 'transfer.steemconnect_title' })}
+      >
+        <WebView source={{ uri: `${hsOptions.base_url}${SCPath}` }} />
+      </Modal>
+    </Fragment>
+  );
+};
+
+export default injectIntl(RcTopUp);

--- a/src/screens/redeem/screen/redeemScreen.tsx
+++ b/src/screens/redeem/screen/redeemScreen.tsx
@@ -7,6 +7,7 @@ import { RedeemContainer, PointsContainer } from '../../../containers';
 
 import { Promote, PostBoost } from '../../../components';
 import BoostPlus from '../children/boostPlus';
+import RcTopUp from '../children/rcTopUp';
 import styles from '../styles/redeemScreen.styles';
 import globalStyles from '../../../globalStyles';
 
@@ -75,6 +76,22 @@ class RedeemScreen extends PureComponent {
                   case 'boost_plus':
                     _retView = (
                       <BoostPlus
+                        isLoading={isLoading}
+                        currentAccountName={currentAccountName}
+                        balance={balance}
+                        navigationParams={navigationParams}
+                        handleOnSubmit={handleOnSubmit}
+                        redeemType={redeemType}
+                        isSCModalOpen={isSCModalOpen}
+                        handleOnSCModalClose={handleOnSCModalClose}
+                        SCPath={SCPath}
+                        getESTMPrice={getESTMPrice}
+                      />
+                    );
+                    break;
+                  case 'rc_topup':
+                    _retView = (
+                      <RcTopUp
                         isLoading={isLoading}
                         currentAccountName={currentAccountName}
                         balance={balance}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1211,10 +1211,10 @@
     url "^0.11.0"
     xss "^1.0.9"
 
-"@ecency/sdk@^2.3.20":
-  version "2.3.20"
-  resolved "https://registry.yarnpkg.com/@ecency/sdk/-/sdk-2.3.20.tgz#549639796760edffd7700b14caa23c6abad8f615"
-  integrity sha512-CVBe7F7wYb+ihpBAdM76bBjwVKVhZ6DYuz1K3aIjc57A0MbOy3JfIowHoyLVmKwBz3ACAB2S6jB/8+px3N91ng==
+"@ecency/sdk@^2.3.21":
+  version "2.3.21"
+  resolved "https://registry.yarnpkg.com/@ecency/sdk/-/sdk-2.3.21.tgz#69179f5e3948369a07938b19a26f2c5959d4c09e"
+  integrity sha512-FIPbUIhwnfm6xy5OVk7A24Y5PnzG4y+ePvk4t9Z6b5jZ2A9APk3hywWUj363mJwzY9SkNSgBSWSKybdDwTxawA==
   dependencies:
     "@noble/ciphers" "^2.1.1"
     "@noble/curves" "^2.0.1"


### PR DESCRIPTION
Adds an RC top-up option to the Points spend menu: spend Points for a short-term Resource Credits boost so you can keep posting when low on RC. Mirrors the existing Boost+ Points-spend redeem (self-only, single-account, Points-funded) and reuses the shared redeem container, screen routing, and form styles.

Funded entirely by Points — no new in-app-purchase SKU and it does not touch the IAP path.

## Changes
- `useRcDelegationMutation` (new) over the SDK `useRcDelegation` hook via `useMutationAuth`; re-exported from the mutations barrel.
- `rcTopUp.tsx` (new) redeem child: durations + Points prices via `getRcDelegationPricesQueryOptions`, balance via `getPointsQueryOptions`, duration slider, confirm sheet. Reuses the boostPlus redeem styles.
- `redeemContainer` routes `rc_topup` to the mutation (self-only, like `boost_plus`); `redeemScreen` renders the child; `spendOptions` adds the entry; i18n strings added.
- Bumps `@ecency/sdk` to `^2.3.21` (published; ships the RC delegation mutation + pricing query). Backend (esync/ePoints/api-proxy/vapi) is already deployed.

Follow-up (separate): a duplicate-purchase UI guard mirroring web, using `getRcDelegationActiveQueryOptions` (the backend already blocks duplicates and charges no Points).