### PR TITLE
feat(redeem): funnel low-Points users from RC top-up to in-app Points purchase

### DIFF
--- a/src/config/locales/en-US.json
+++ b/src/config/locales/en-US.json
@@ -1315,7 +1315,9 @@
   "rc_topup": {
     "title": "Top up RC",
     "desc": "A short-term RC boost so you can keep posting.",
-    "confirm": "Spend Points to top up your Resource Credits?"
+    "confirm": "Spend Points to top up your Resource Credits?",
+    "insufficient": "You do not have enough Points.",
+    "buy_points": "Buy Points"
   },
   "ai_image_generator": {
     "title": "AI Image Generator",

--- a/src/screens/redeem/children/rcTopUp.tsx
+++ b/src/screens/redeem/children/rcTopUp.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useState, useEffect, useRef, useMemo } from 'react';
+import React, { Fragment, useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import { injectIntl } from 'react-intl';
 import { Text, View, ScrollView, TouchableOpacity } from 'react-native';
 import { WebView } from 'react-native-webview';
@@ -8,6 +8,7 @@ import { ScaleSlider } from '../../../components';
 import { hsOptions } from '../../../constants/hsOptions';
 import RootNavigation from '../../../navigation/rootNavigation';
 import ROUTES from '../../../constants/routeNames';
+import { useFocusEffect } from '@react-navigation/native';
 
 // Components
 import { BasicHeader } from '../../../components/basicHeader';
@@ -93,6 +94,16 @@ const RcTopUp = ({
     const balanceValue = Math.round(points * 1000) / 1000;
     setBalance(Number.isNaN(balanceValue) ? _balance : balanceValue);
   }, [pointsQuery.data, _balance]);
+
+  // Points are credited server-side by the IAP. Refetch the balance whenever the
+  // screen regains focus (e.g. returning from the Points purchase) so a freshly
+  // bought balance shows up and the user can finish the top-up. React Native
+  // refetch-on-focus is AppState-based, not navigation-based, so do it explicitly.
+  useFocusEffect(
+    useCallback(() => {
+      pointsQuery.refetch();
+    }, [pointsQuery.refetch]),
+  );
 
   const _renderDropdown = (accountName) => <Text style={styles.dropdownText}>{accountName}</Text>;
 

--- a/src/screens/redeem/children/rcTopUp.tsx
+++ b/src/screens/redeem/children/rcTopUp.tsx
@@ -4,11 +4,11 @@ import { Text, View, ScrollView, TouchableOpacity } from 'react-native';
 import { WebView } from 'react-native-webview';
 import { useQuery } from '@tanstack/react-query';
 import { getRcDelegationPricesQueryOptions, getPointsQueryOptions } from '@ecency/sdk';
+import { useFocusEffect } from '@react-navigation/native';
 import { ScaleSlider } from '../../../components';
 import { hsOptions } from '../../../constants/hsOptions';
 import RootNavigation from '../../../navigation/rootNavigation';
 import ROUTES from '../../../constants/routeNames';
-import { useFocusEffect } from '@react-navigation/native';
 
 // Components
 import { BasicHeader } from '../../../components/basicHeader';

--- a/src/screens/redeem/children/rcTopUp.tsx
+++ b/src/screens/redeem/children/rcTopUp.tsx
@@ -1,11 +1,13 @@
 import React, { Fragment, useState, useEffect, useRef, useMemo } from 'react';
 import { injectIntl } from 'react-intl';
-import { Text, View, ScrollView } from 'react-native';
+import { Text, View, ScrollView, TouchableOpacity } from 'react-native';
 import { WebView } from 'react-native-webview';
 import { useQuery } from '@tanstack/react-query';
 import { getRcDelegationPricesQueryOptions, getPointsQueryOptions } from '@ecency/sdk';
 import { ScaleSlider } from '../../../components';
 import { hsOptions } from '../../../constants/hsOptions';
+import RootNavigation from '../../../navigation/rootNavigation';
+import ROUTES from '../../../constants/routeNames';
 
 // Components
 import { BasicHeader } from '../../../components/basicHeader';
@@ -98,6 +100,17 @@ const RcTopUp = ({
     handleOnSubmit(redeemType, day, currentAccountName, currentAccountName);
   };
 
+  // low on Points: funnel to the in-app Points purchase (native Apple/Google
+  // billing) so the user can buy Points and come back to finish the top-up.
+  const insufficient = price != null && price > balance;
+
+  const _onBuyPoints = () => {
+    RootNavigation.navigate({
+      name: ROUTES.SCREENS.BOOST,
+      params: { username: currentAccountName },
+    });
+  };
+
   return (
     <Fragment>
       <BasicHeader title={intl.formatMessage({ id: 'rc_topup.title' })} />
@@ -109,6 +122,17 @@ const RcTopUp = ({
               rightComponent={() => _renderDropdown(currentAccountName)}
             />
             <Text style={styles.balanceText}>{`${balance} Points`}</Text>
+
+            {insufficient && (
+              <Text style={styles.insufficientText}>
+                {intl.formatMessage({ id: 'rc_topup.insufficient' })}
+              </Text>
+            )}
+            <TouchableOpacity style={styles.buyPointsButton} onPress={_onBuyPoints}>
+              <Text style={styles.buyPointsText}>
+                {intl.formatMessage({ id: 'rc_topup.buy_points' })}
+              </Text>
+            </TouchableOpacity>
 
             <View style={styles.total}>
               <Text style={styles.day}>

--- a/src/screens/redeem/styles/boostPlus.styles.ts
+++ b/src/screens/redeem/styles/boostPlus.styles.ts
@@ -13,6 +13,22 @@ export default EStyleSheet.create({
     marginLeft: 20,
     marginBottom: 10,
   },
+  insufficientText: {
+    fontSize: 13,
+    color: '$primaryRed',
+    alignSelf: 'center',
+    marginBottom: 6,
+  },
+  buyPointsButton: {
+    alignSelf: 'center',
+    marginBottom: 12,
+    paddingVertical: 4,
+  },
+  buyPointsText: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '$primaryBlue',
+  },
   descText: {
     fontSize: 14,
     color: '$primaryDarkGray',

--- a/src/screens/redeem/styles/boostPlus.styles.ts
+++ b/src/screens/redeem/styles/boostPlus.styles.ts
@@ -23,6 +23,7 @@ export default EStyleSheet.create({
     alignSelf: 'center',
     marginBottom: 12,
     paddingVertical: 4,
+    paddingHorizontal: 16,
   },
   buyPointsText: {
     fontSize: 14,


### PR DESCRIPTION
Mobile counterpart to the web buy-Points funnel. The RC top-up redeem screen used to just disable **Next** when the user lacked enough Points, with no message and no path forward.

## Changes (`src/screens/redeem/children/rcTopUp.tsx`)
- Shows an **insufficient Points** message when the selected duration's price exceeds the balance.
- Adds an always-visible **Buy Points** action that opens the in-app Points purchase (native Apple/Google billing via the existing Boost/IAP screen, SKUs `099points`...`9999points`). After the purchase credits Points, the user returns and the balance query refetches so they can finish the top-up.
- Shown regardless of balance, so users can also stock up for later.

Mobile is the easiest conversion path here since the purchase is the OS payment sheet (no crypto, no QR). No SDK bump (uses existing navigation + the existing IAP screen), so it ships on the next app build. Strings added to `en-US.json` only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Points balance automatically refreshes when you return to the RC top-up screen, ensuring you always see your most current available balance after making any in-app purchases
  * Added insufficient points notification with a convenient button to directly purchase additional points when your selected RC option exceeds your available balance, simplifying the top-up experience

<!-- end of auto-generated comment: release notes by coderabbit.ai -->