### PR TITLE
fix(payout): show payout on content pages, comments and waves (match web)

### DIFF
--- a/src/components/postCard/children/upvoteButton.tsx
+++ b/src/components/postCard/children/upvoteButton.tsx
@@ -66,14 +66,14 @@ export const UpvoteButton = ({
 
   const payoutLimitHit = totalPayout >= maxPayout;
   const _shownPayout = payoutLimitHit && maxPayout > 0 ? maxPayout : totalPayout;
-  // Coerce an absent/NaN payout to 0 so FormattedCurrency never receives undefined
-  // (which would render "$ NaN", e.g. a declined-payout card whose feed omits payout
-  // fields). Only render the payout chip when there is something to show — waves
-  // typically have a 0 payout, where the old `_shownPayout || '0.000'` rendered a bare
-  // "$" with a tiny 0.000 the user reads as "$ and nothing else". Real payouts and
-  // declined-payout (strikethrough $0.000) still render.
+  // Always render the payout value to match the web client (entry-payout always shows
+  // the amount, including $0.000, on posts, comments and waves alike). Coerce an
+  // absent/NaN payout to 0 so FormattedCurrency never receives undefined (which would
+  // render "$ NaN"). When an entry genuinely earns nothing the real value is 0.000, so
+  // we no longer hide the chip — that mirrors the website and avoids dropping real
+  // payouts on entries whose total only looks zero (see parsePost numeric-payout
+  // fallback for search/RPC-shaped entries).
   const _payoutValue = Number(_shownPayout) || 0;
-  const _hasPayoutToShow = _payoutValue > 0 || isDeclinedPayout;
 
   let iconName = 'upcircleo';
   const iconType = 'AntDesign';
@@ -100,7 +100,7 @@ export const UpvoteButton = ({
         </View>
       </TouchableOpacity>
       <View style={styles.payoutTextButton}>
-        {isShowPayoutValue && _hasPayoutToShow && (
+        {isShowPayoutValue && (
           <TouchableOpacity ref={detailsRef} onPress={_onDetailsPress}>
             <Text
               style={[

--- a/src/utils/postParser.test.ts
+++ b/src/utils/postParser.test.ts
@@ -157,7 +157,7 @@ describe('parsePost', () => {
   });
 
   it('falls back to numeric payout when asset-string fields are absent', () => {
-    // search-API / RPC shape: numeric `payout`, no asset-string fields or max_accepted_payout
+    // RPC shape: numeric `payout`, no asset-string fields or max_accepted_payout
     const post = makePost({
       payout: 3.21,
       pending_payout_value: undefined,
@@ -167,6 +167,39 @@ describe('parsePost', () => {
     });
     const result = parsePost(post, 'viewer', false);
     expect(result!.total_payout).toBe(3.21);
+  });
+
+  it('falls back to numeric total_payout for search-API shape', () => {
+    // SDK SearchResult exposes the amount as `total_payout` (no `payout`, no asset strings)
+    const post = makePost({
+      total_payout: 5.5,
+      payout: undefined,
+      pending_payout_value: undefined,
+      author_payout_value: undefined,
+      curator_payout_value: undefined,
+      max_accepted_payout: undefined,
+    });
+    const result = parsePost(post, 'viewer', false);
+    expect(result!.total_payout).toBe(5.5);
+  });
+
+  it('uses original_entry numeric payout for a cross-post', () => {
+    const post = makePost({
+      payout: undefined,
+      pending_payout_value: undefined,
+      author_payout_value: undefined,
+      curator_payout_value: undefined,
+      max_accepted_payout: undefined,
+      original_entry: {
+        author: 'original',
+        permlink: 'orig-post',
+        body: 'original body',
+        total_payout: 8.75,
+        max_accepted_payout: undefined,
+      },
+    });
+    const result = parsePost(post, 'viewer', false);
+    expect(result!.total_payout).toBe(8.75);
   });
 
   it('prefers asset-string fields over numeric payout when both are present', () => {
@@ -418,6 +451,40 @@ describe('parseComment', () => {
     });
     const result = parseComment(comment, 'viewer');
     expect(result.total_payout).toBe(0.42);
+  });
+
+  it('falls back to numeric total_payout for search-API shape', () => {
+    const comment = makeComment({
+      total_payout: 0.9,
+      payout: undefined,
+      pending_payout_value: undefined,
+      author_payout_value: undefined,
+      curator_payout_value: undefined,
+      max_accepted_payout: undefined,
+    });
+    const result = parseComment(comment, 'viewer');
+    expect(result.total_payout).toBe(0.9);
+  });
+
+  it('prefers asset-string fields over numeric payout when both are present', () => {
+    const comment = makeComment({
+      payout: 99,
+      pending_payout_value: '0.400 HBD',
+      author_payout_value: '0.000 HBD',
+      curator_payout_value: '0.000 HBD',
+    });
+    const result = parseComment(comment, 'viewer');
+    expect(result.total_payout).toBe(0.4);
+  });
+
+  it('keeps total_payout at 0 for a genuinely zero-payout comment', () => {
+    const comment = makeComment({
+      pending_payout_value: '0.000 HBD',
+      author_payout_value: '0.000 HBD',
+      curator_payout_value: '0.000 HBD',
+    });
+    const result = parseComment(comment, 'viewer');
+    expect(result.total_payout).toBe(0);
   });
 
   it('sets isDeletable when no votes, children, or rshares', () => {

--- a/src/utils/postParser.test.ts
+++ b/src/utils/postParser.test.ts
@@ -156,6 +156,40 @@ describe('parsePost', () => {
     expect(result!.total_payout).toBe(4);
   });
 
+  it('falls back to numeric payout when asset-string fields are absent', () => {
+    // search-API / RPC shape: numeric `payout`, no asset-string fields or max_accepted_payout
+    const post = makePost({
+      payout: 3.21,
+      pending_payout_value: undefined,
+      author_payout_value: undefined,
+      curator_payout_value: undefined,
+      max_accepted_payout: undefined,
+    });
+    const result = parsePost(post, 'viewer', false);
+    expect(result!.total_payout).toBe(3.21);
+  });
+
+  it('prefers asset-string fields over numeric payout when both are present', () => {
+    const post = makePost({
+      payout: 99,
+      pending_payout_value: '1.500 HBD',
+      author_payout_value: '0.000 HBD',
+      curator_payout_value: '0.000 HBD',
+    });
+    const result = parsePost(post, 'viewer', false);
+    expect(result!.total_payout).toBe(1.5);
+  });
+
+  it('keeps total_payout at 0 for a genuinely zero-payout entry', () => {
+    const post = makePost({
+      pending_payout_value: '0.000 HBD',
+      author_payout_value: '0.000 HBD',
+      curator_payout_value: '0.000 HBD',
+    });
+    const result = parsePost(post, 'viewer', false);
+    expect(result!.total_payout).toBe(0);
+  });
+
   it('detects declined payout', () => {
     const post = makePost({ max_accepted_payout: '0.000 HBD' });
     const result = parsePost(post, 'viewer', false);
@@ -372,6 +406,18 @@ describe('parseComment', () => {
     });
     const result = parseComment(comment, 'viewer');
     expect(result.total_payout).toBe(1);
+  });
+
+  it('falls back to numeric payout when asset-string fields are absent', () => {
+    const comment = makeComment({
+      payout: 0.42,
+      pending_payout_value: undefined,
+      author_payout_value: undefined,
+      curator_payout_value: undefined,
+      max_accepted_payout: undefined,
+    });
+    const result = parseComment(comment, 'viewer');
+    expect(result.total_payout).toBe(0.42);
   });
 
   it('sets isDeletable when no votes, children, or rshares', () => {

--- a/src/utils/postParser.tsx
+++ b/src/utils/postParser.tsx
@@ -103,10 +103,17 @@ export const parsePost = (
   post.max_payout = parseAsset(post.max_accepted_payout).amount || 0;
   post.is_declined_payout = !!post.max_accepted_payout && post.max_payout === 0;
 
-  const totalPayout =
-    parseAsset(post.pending_payout_value).amount +
-    parseAsset(post.author_payout_value).amount +
-    parseAsset(post.curator_payout_value).amount;
+  // Some entries (search-API / RPC shapes) expose a numeric `payout` and lack the
+  // asset-string payout fields, so parseAsset would yield 0 and hide a real payout.
+  // Mirror the web client's entry-payout: fall back to the numeric payout when the
+  // asset-string fields are absent (detected by the missing max_accepted_payout).
+  const _isNumericPayoutOnly = typeof post.payout === 'number' && !post.max_accepted_payout;
+
+  const totalPayout = _isNumericPayoutOnly
+    ? post.payout
+    : parseAsset(post.pending_payout_value).amount +
+      parseAsset(post.author_payout_value).amount +
+      parseAsset(post.curator_payout_value).amount;
 
   post.total_payout = totalPayout;
 
@@ -274,10 +281,15 @@ export const parseComment = (comment: any, currentUsername?: string, currentTime
   comment.is_declined_payout = !!comment.max_accepted_payout && comment.max_payout === 0;
 
   // calculate and set total_payout to show to user.
-  const totalPayout =
-    parseAsset(comment.pending_payout_value).amount +
-    parseAsset(comment.author_payout_value).amount +
-    parseAsset(comment.curator_payout_value).amount;
+  // Same numeric-payout fallback as parsePost: search-API / RPC-shaped entries expose a
+  // numeric `payout` without the asset-string fields, so use it when those are absent.
+  const _isNumericPayoutOnly = typeof comment.payout === 'number' && !comment.max_accepted_payout;
+
+  const totalPayout = _isNumericPayoutOnly
+    ? comment.payout
+    : parseAsset(comment.pending_payout_value).amount +
+      parseAsset(comment.author_payout_value).amount +
+      parseAsset(comment.curator_payout_value).amount;
 
   comment.total_payout = totalPayout;
 

--- a/src/utils/postParser.tsx
+++ b/src/utils/postParser.tsx
@@ -68,6 +68,10 @@ export const parsePost = (
     post.author_payout_value = orig.author_payout_value;
     post.curator_payout_value = orig.curator_payout_value;
     post.max_accepted_payout = orig.max_accepted_payout;
+    // also carry the numeric payout fields so the numeric-payout fallback below uses
+    // the original entry's value when it lacks the asset-string fields
+    post.payout = orig.payout;
+    post.total_payout = orig.total_payout;
     post.active_votes = orig.active_votes;
     post.children = orig.children;
     post.stats = orig.stats;
@@ -103,14 +107,22 @@ export const parsePost = (
   post.max_payout = parseAsset(post.max_accepted_payout).amount || 0;
   post.is_declined_payout = !!post.max_accepted_payout && post.max_payout === 0;
 
-  // Some entries (search-API / RPC shapes) expose a numeric `payout` and lack the
-  // asset-string payout fields, so parseAsset would yield 0 and hide a real payout.
-  // Mirror the web client's entry-payout: fall back to the numeric payout when the
-  // asset-string fields are absent (detected by the missing max_accepted_payout).
-  const _isNumericPayoutOnly = typeof post.payout === 'number' && !post.max_accepted_payout;
+  // Some entries expose the payout as a single numeric field and omit the asset-string
+  // fields, so the parseAsset sum would yield 0 and hide a real payout: search-API
+  // results carry `total_payout`, other RPC shapes carry `payout`. Mirror the web
+  // client's entry-payout and fall back to that numeric value when the asset-string
+  // fields are absent (Hive always sends max_accepted_payout for normal posts, so this
+  // only triggers for the numeric-only shapes).
+  const _numericPayout =
+    typeof post.payout === 'number'
+      ? post.payout
+      : typeof post.total_payout === 'number'
+      ? post.total_payout
+      : undefined;
+  const _isNumericPayoutOnly = _numericPayout !== undefined && !post.max_accepted_payout;
 
   const totalPayout = _isNumericPayoutOnly
-    ? post.payout
+    ? _numericPayout
     : parseAsset(post.pending_payout_value).amount +
       parseAsset(post.author_payout_value).amount +
       parseAsset(post.curator_payout_value).amount;
@@ -282,11 +294,18 @@ export const parseComment = (comment: any, currentUsername?: string, currentTime
 
   // calculate and set total_payout to show to user.
   // Same numeric-payout fallback as parsePost: search-API / RPC-shaped entries expose a
-  // numeric `payout` without the asset-string fields, so use it when those are absent.
-  const _isNumericPayoutOnly = typeof comment.payout === 'number' && !comment.max_accepted_payout;
+  // single numeric field (`total_payout` or `payout`) without the asset-string fields,
+  // so use it when those are absent.
+  const _numericPayout =
+    typeof comment.payout === 'number'
+      ? comment.payout
+      : typeof comment.total_payout === 'number'
+      ? comment.total_payout
+      : undefined;
+  const _isNumericPayoutOnly = _numericPayout !== undefined && !comment.max_accepted_payout;
 
   const totalPayout = _isNumericPayoutOnly
-    ? comment.payout
+    ? _numericPayout
     : parseAsset(comment.pending_payout_value).amount +
       parseAsset(comment.author_payout_value).amount +
       parseAsset(comment.curator_payout_value).amount;


### PR DESCRIPTION
## Problem

Pending/total payout was not showing on **post (content) detail pages** in the app. Reported via a device screenshot.

Root cause: the waves card fix in `763b73fc37` added a `_hasPayoutToShow` gate to the **shared** `UpvoteButton`, which renders the payout chip only when the computed `total_payout > 0` (or payout is declined). But `UpvoteButton` is reused in four places, not just waves cards:

- `postCard/children/postCardActionsPanel.tsx` (feed cards)
- `comment/view/commentView.tsx` (comments **and** waves)
- `postView/view/postDisplayView.tsx` (post/content detail action bar)

So on any entry whose computed payout was 0, the chip disappeared entirely instead of showing `$0.000`. This diverges from the web client, where `entry-payout` always renders the amount (posts, comments, waves alike: `entry-payout/index.tsx`, `discussion-item.tsx`, `wave-actions.tsx` with `showPayout` defaulting to `true`).

Note: real wave/comment payouts were never missing from the data. `bridge.get_discussion` returns `pending_payout_value` as a proper `"X.XXX HBD"` string (verified live waves at 0.001 to 0.034 HBD), and `parsePost` already parses them correctly. The gate only blanked the chip when the value was exactly 0.000.

## Changes

1. **Drop the `_hasPayoutToShow` gate** in `UpvoteButton` so the payout renders consistently for posts, comments and waves, including `$0.000`, matching web. NaN/undefined is still coerced to 0 so `FormattedCurrency` never gets `undefined`.

2. **Numeric `payout` fallback** in `parsePost` and `parseComment`: some entries (search-API / RPC shapes) expose a numeric `payout` and lack the asset-string fields, so `parseAsset` would yield 0 and hide a real payout. Fall back to the numeric `payout` when the asset-string fields are absent (detected by missing `max_accepted_payout`), mirroring web's `entry-payout` `isSearchResult` branch.

## Tests

Added regression tests to `postParser.test.ts` for both `parsePost` and `parseComment`:
- numeric-payout fallback when asset-string fields are absent
- asset-string fields preferred when both present
- genuinely zero-payout entry stays at 0

`postParser.test.ts`: 58 passed. Lint: 0 errors on changed files.

## Follow-up (not in this PR)

The original waves report also had a stale vote count (3 vs real 29). That is a wave-card data-freshness issue (query `staleTime`/refetch), separate from display, and the right fix for the live count/payout staleness. Tracking separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the payout chip behavior so it reliably renders whenever payout display is enabled, including $0.000 cases that were previously suppressed.
  * Improved payout total parsing to correctly handle “numeric-only” payout inputs, falling back to numeric payout/total payout when asset-based fields are missing (including cross-post scenarios).

* **Tests**
  * Added/expanded coverage for payout computation for both posts and comments across multiple input shapes and edge cases (including true zero payouts).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->