### PR TITLE
fix(chats): show replying username above the quoted reply

### DIFF
--- a/src/screens/chats/children/ThreadMessageItem.tsx
+++ b/src/screens/chats/children/ThreadMessageItem.tsx
@@ -122,8 +122,8 @@ export const ThreadMessageItem: React.FC<ThreadMessageItemProps> = React.memo(
             onLongPress={() => onShowActions(post, isOwnMessage)}
             activeOpacity={0.9}
           >
-            {post.root_id && renderReplyPreview(post.root_id, post.props as any, isOwnMessage)}
             {!isOwnMessage && <Text style={styles.author}>{author}</Text>}
+            {post.root_id && renderReplyPreview(post.root_id, post.props as any, isOwnMessage)}
             {!!messageText && (
               <Hyperlink
                 linkStyle={[


### PR DESCRIPTION
## What

In chat channels/DMs, when a message is a reply, the bubble currently renders:

```
[ quote block: original author + quoted text ]   ← who you're replying TO
[ replying username ]
[ reply text ]
```

This buries the sender's name between the quote and their reply, so the first name your eye lands on is the *quoted* person — making it harder to read who's actually speaking.

This PR moves the replying username **above** the quote block so it reads in natural order, matching Telegram/WhatsApp/Slack/Discord:

```
[ replying username ]            ← who's talking
[ quote block: original author + quoted text ]   ← what they're replying to
[ reply text ]                   ← what they say
```

## Change

A pure two-line JSX reorder in `ThreadMessageItem.tsx` — the `author` `<Text>` now renders before `renderReplyPreview(...)`. No style changes needed: `styles.author` already carries `marginBottom: 4`, so spacing above the quote stays clean.

## Notes

- Own messages still show no username (right-aligned, so it's already clear) — unchanged.
- The composer's "replying to…" banner (`ThreadComposer` → `ReplyPreview`) is a separate surface and is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the display order of message elements in thread conversations—author names now appear before reply previews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->