### PR TITLE
fix(register): let the Turnstile WebView load the challenge's about: frames

### DIFF
--- a/src/screens/register/children/turnstileWebView.tsx
+++ b/src/screens/register/children/turnstileWebView.tsx
@@ -19,6 +19,14 @@ interface Props {
   height?: number;
 }
 
+// Cloudflare's Managed challenge runs its verification compute in about:srcdoc / about:blank
+// child frames (nested inside the challenges.cloudflare.com iframe). iOS WKWebView gates
+// SUB-FRAME navigations by originWhitelist / onShouldStartLoadWithRequest too, so without the
+// about: scheme those frames are silently dropped and the widget spins on "Verifying…" forever
+// (the outer widget still renders, since it loaded over https). Allow https + about: only.
+const _allowTurnstileFrame = (req: { url: string }) =>
+  req.url.startsWith('https://') || req.url.startsWith('about:');
+
 const TurnstileWebView = ({ onVerify, onExpire, onError, height = 76 }: Props) => {
   const intl = useIntl();
   // A failed load of the hosted page (network error, or a 404 while the web
@@ -65,7 +73,8 @@ const TurnstileWebView = ({ onVerify, onExpire, onError, height = 76 }: Props) =
     <View style={[styles.container, { height }]}>
       <WebView
         source={{ uri: TURNSTILE_EMBED_URL }}
-        originWhitelist={['https://*']}
+        originWhitelist={['https://*', 'about:']}
+        onShouldStartLoadWithRequest={_allowTurnstileFrame}
         javaScriptEnabled
         domStorageEnabled
         sharedCookiesEnabled


### PR DESCRIPTION
## Problem
On the signup screen the Cloudflare Turnstile widget renders but hangs on **"Verifying…" forever** (never "Failed to load"), so the register button never enables.

## Root cause
Turnstile's Managed challenge runs its verification compute inside **`about:srcdoc` / `about:blank` child frames** (nested within the `challenges.cloudflare.com` iframe). On **iOS WKWebView**, `originWhitelist` gates *sub-frame* navigations too — with only `['https://*']`, those `about:` frames are silently dropped. The outer widget still renders (it loaded over https), but the inner challenge context never loads → the spinner never resolves.

## Fix (this PR)
`src/screens/register/children/turnstileWebView.tsx`:
- `originWhitelist={['https://*', 'about:']}`
- explicit `onShouldStartLoadWithRequest` permitting `https` + `about:`

Strictly additive (allows the challenge frames; the https top-level load is unchanged). The embed page is itself a locked-down, first-party document, so this isn't a meaningful trust widening. eslint + prettier (2.8.8) + tsc all clean.

## What was ruled out (so we don't waste a web release)
- **Web embed CSP** (`vision-next route.ts`): investigated and **ruled out** — a live probe of `https://ecency.com/embed/turnstile` shows that route's strict CSP is **never enforced** (the global `next.config.js` `/:path*` `headers()` overrides the route handler), so the browser sees a permissive CSP that blocks nothing. Editing it would change nothing.
- **Route not deployed**: ruled out — prod serves the widget HTML (200, byte-matches).
- `androidLayerType="software"` (Android-only, the hang is iOS) and UA: not factors.

## ⚠️ Needs on-device verification before shipping
I can't drive a real device here, and the iOS WKWebView simulator can differ on storage/ITP. Before this goes out in an app release, please verify on a **real iOS device**: open signup → the widget should resolve to a token within a few seconds (register button enables) instead of spinning. Confirm no regression on a real Android device. (To confirm the diagnosis pre-fix: remote-inspect the WKWebView via Safari Web Inspector and watch the `about:srcdoc`/`about:blank` child frame fail to load.)

## Separate, non-urgent web follow-up (not this PR)
The dead `route.ts` CSP should be removed or actually wired up to avoid future confusion, and the global **report-only** CSP's `frame-src` should gain `about:blank about:srcdoc` *before* it's ever promoted to enforcing — otherwise web Turnstile would hit this same stall.
