### PR TITLE
fix(chats): expand quoting message bubble to full width

### DIFF
--- a/src/screens/chats/children/ThreadMessageItem.tsx
+++ b/src/screens/chats/children/ThreadMessageItem.tsx
@@ -80,6 +80,13 @@ export const ThreadMessageItem: React.FC<ThreadMessageItemProps> = React.memo(
 
     const showUnreadMarker = firstUnreadIndex !== null && index === firstUnreadIndex;
 
+    // Render the quoted-reply preview once so the bubble can both display it and
+    // widen itself to fit it (a short reply otherwise squeezes the quote into a
+    // narrow column, wrapping the author/quoted text line-by-line).
+    const replyPreview = post.root_id
+      ? renderReplyPreview(post.root_id, post.props as any, isOwnMessage)
+      : null;
+
     // Auto-detect Hive post URLs when sender didn't attach link_* props
     // (e.g. message sent from web or before the composer's metadata debounce fired)
     const detectedHiveLink = useMemo(() => {
@@ -118,12 +125,13 @@ export const ThreadMessageItem: React.FC<ThreadMessageItemProps> = React.memo(
             style={[
               styles.messageBubble,
               isOwnMessage ? styles.messageBubbleOwn : styles.messageBubbleOther,
+              replyPreview && styles.messageBubbleWithReply,
             ]}
             onLongPress={() => onShowActions(post, isOwnMessage)}
             activeOpacity={0.9}
           >
             {!isOwnMessage && <Text style={styles.author}>{author}</Text>}
-            {post.root_id && renderReplyPreview(post.root_id, post.props as any, isOwnMessage)}
+            {replyPreview}
             {!!messageText && (
               <Hyperlink
                 linkStyle={[

--- a/src/screens/chats/styles/chatThread.styles.ts
+++ b/src/screens/chats/styles/chatThread.styles.ts
@@ -62,6 +62,12 @@ export const chatThreadStyles = EStyleSheet.create({
     borderRadius: 16,
     position: 'relative',
   },
+  // Messages that quote another message expand to the full bubble width so the
+  // reply preview (author + quoted line) renders on its own line instead of
+  // being squeezed — and wrapped awkwardly — into a bubble sized to short reply text.
+  messageBubbleWithReply: {
+    minWidth: '80%',
+  },
   messageBubbleOwn: {
     backgroundColor: '$primaryBlue',
     borderTopRightRadius: 4,


### PR DESCRIPTION
## Problem

A chat message bubble is sized to its text content (`maxWidth: 80%`, no `minWidth`). When a **short** message **quotes** another message, the bubble shrinks to the reply text and squeezes the quote preview into a narrow column — wrapping the quoted author and text line-by-line:

> `melin` / `da01` / `0100` / `Have` / `you...`

(reported in-app; the "No really" reply in the Ecency group is the example.)

## Fix

Add a `messageBubbleWithReply` style (`minWidth: 80%`, matching the existing `maxWidth: 80%`) and apply it **only** to bubbles that actually render a quoted-reply preview. Those bubbles now expand to the full bubble width so the quote header + preview line render cleanly; normal short messages without a quote stay compact as before.

The reply preview is rendered once into a local (`replyPreview`) and reused for both the width condition and the body, so the widening exactly tracks whether a quote is shown (a `root_id` with no resolvable preview won't widen).

## Files

- `src/screens/chats/styles/chatThread.styles.ts` — new `messageBubbleWithReply` style
- `src/screens/chats/children/ThreadMessageItem.tsx` — capture `replyPreview`, apply the style conditionally

## Validation

- Prettier 2.8.8 (CI-pinned) ✓ · ESLint ✓ · no new type errors in changed files
- Behavior: only quoting bubbles widen; non-quote messages unchanged. (RN style-only change; please sanity-check visually on device.)

## Before → After (expected)

Before: short quoting reply → quote text wraps `melin/da01/0100`, `Have you...`
After: quoting bubble expands to ~full width → quote author + preview render on their own lines without per-word wrapping.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the rendering and styling of message bubbles that contain reply previews in chat threads, ensuring consistent layout and visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
