### PR TITLE
fix(register): allow all WebView frame schemes so the Turnstile challenge completes on iOS

### DIFF
--- a/src/screens/register/children/turnstileWebView.tsx
+++ b/src/screens/register/children/turnstileWebView.tsx
@@ -19,14 +19,16 @@ interface Props {
   height?: number;
 }
 
-// Cloudflare's Managed challenge runs its verification compute in about:srcdoc / about:blank
-// child frames (nested inside the challenges.cloudflare.com iframe). iOS WKWebView gates
-// SUB-FRAME navigations by originWhitelist / onShouldStartLoadWithRequest too, so without the
-// about: scheme those frames are silently dropped and the widget spins on "Verifying…" forever
-// (the outer widget still renders, since it loaded over https). Allow https + about: only.
-const _allowTurnstileFrame = (req: { url: string }) =>
-  req.url.startsWith('https://') || req.url.startsWith('about:');
-
+// Cloudflare's Managed challenge renders in a challenges.cloudflare.com iframe and runs its
+// verification compute in nested sub-frames across several schemes: about:srcdoc / about:blank
+// and, on iOS, often blob: / data:. react-native-webview gates EVERY frame navigation against
+// originWhitelist. The previous list (['https://*', 'about:']) plus a custom
+// onShouldStartLoadWithRequest that returned true only for https/about therefore CANCELLED the
+// challenge's blob:/data: compute frames: about: was allowed, but that alone was not enough, so
+// the challenge never issued a token and the widget stayed blank.
+// This widget only ever loads our own first-party embed page plus that CF challenge, so rather
+// than enumerate every scheme Cloudflare may use, allow them all (originWhitelist ['*']) and
+// drop the custom handler (with ['*'] a handler could only re-add the same restriction).
 const TurnstileWebView = ({ onVerify, onExpire, onError, height = 76 }: Props) => {
   const intl = useIntl();
   // A failed load of the hosted page (network error, or a 404 while the web
@@ -73,14 +75,17 @@ const TurnstileWebView = ({ onVerify, onExpire, onError, height = 76 }: Props) =
     <View style={[styles.container, { height }]}>
       <WebView
         source={{ uri: TURNSTILE_EMBED_URL }}
-        originWhitelist={['https://*', 'about:']}
-        onShouldStartLoadWithRequest={_allowTurnstileFrame}
+        originWhitelist={['*']}
         javaScriptEnabled
         domStorageEnabled
         sharedCookiesEnabled
         thirdPartyCookiesEnabled
         scrollEnabled={false}
         androidLayerType="software"
+        // Make the widget inspectable via Safari Web Inspector in dev builds only,
+        // so a future challenge issue can be diagnosed on-device without shipping
+        // an inspectable WebView to release/TestFlight.
+        webviewDebuggingEnabled={__DEV__}
         style={styles.webview}
         onMessage={_onMessage}
         onError={() => setLoadFailed(true)}

--- a/src/screens/register/children/turnstileWebView.tsx
+++ b/src/screens/register/children/turnstileWebView.tsx
@@ -20,15 +20,22 @@ interface Props {
 }
 
 // Cloudflare's Managed challenge renders in a challenges.cloudflare.com iframe and runs its
-// verification compute in nested sub-frames across several schemes: about:srcdoc / about:blank
-// and, on iOS, often blob: / data:. react-native-webview gates EVERY frame navigation against
-// originWhitelist. The previous list (['https://*', 'about:']) plus a custom
-// onShouldStartLoadWithRequest that returned true only for https/about therefore CANCELLED the
-// challenge's blob:/data: compute frames: about: was allowed, but that alone was not enough, so
-// the challenge never issued a token and the widget stayed blank.
-// This widget only ever loads our own first-party embed page plus that CF challenge, so rather
-// than enumerate every scheme Cloudflare may use, allow them all (originWhitelist ['*']) and
-// drop the custom handler (with ['*'] a handler could only re-add the same restriction).
+// verification compute in nested SUB-frames across several schemes: about:srcdoc / about:blank
+// and, on iOS, often blob: / data:. react-native-webview gates EVERY frame against
+// originWhitelist, and the previous narrow list (['https://*', 'about:']) plus a handler that
+// returned true only for https/about CANCELLED the challenge's blob:/data: frames, so it never
+// issued a token and the widget stayed blank. about: alone was not enough.
+//
+// Fix: pass every frame to the handler (originWhitelist ['*']) and gate only the TOP-LEVEL
+// document. Sub-frames are always allowed, whatever scheme Cloudflare uses, so the challenge
+// completes; the top frame must stay on our own first-party origin, which keeps a compromised
+// page or open redirect from steering the WebView to file:/javascript:/another origin.
+const TURNSTILE_ORIGIN = 'https://ecency.com/';
+const _shouldStartLoad = (req: { url: string; isTopFrame?: boolean }) =>
+  // isTopFrame is iOS-only; on Android the handler only fires for the main frame, so a missing
+  // flag is treated as the top frame too. Only the top document is constrained to our origin.
+  req.isTopFrame === false || req.url.startsWith(TURNSTILE_ORIGIN);
+
 const TurnstileWebView = ({ onVerify, onExpire, onError, height = 76 }: Props) => {
   const intl = useIntl();
   // A failed load of the hosted page (network error, or a 404 while the web
@@ -76,6 +83,7 @@ const TurnstileWebView = ({ onVerify, onExpire, onError, height = 76 }: Props) =
       <WebView
         source={{ uri: TURNSTILE_EMBED_URL }}
         originWhitelist={['*']}
+        onShouldStartLoadWithRequest={_shouldStartLoad}
         javaScriptEnabled
         domStorageEnabled
         sharedCookiesEnabled


### PR DESCRIPTION
## Problem

On iOS the free-signup Turnstile widget renders blank and **"Register Free" stays disabled** (the challenge never issues a token). Reproduced on the latest TestFlight build from `development`, which already includes #3284.

## Root cause

react-native-webview gates **every** frame navigation against `originWhitelist` (`WebViewShared.js` → `compileWhitelist`/`passesWhitelist`). #3284 set the list to `['https://*', 'about:']` and added an `onShouldStartLoadWithRequest` that returned `true` only for `https`/`about`.

Cloudflare's Managed challenge renders in a `challenges.cloudflare.com` iframe and runs its verification compute in nested sub-frames across several schemes — `about:srcdoc` / `about:blank` **and, on iOS, often `blob:` / `data:`**. The narrow whitelist plus the restrictive handler **cancelled the `blob:`/`data:` compute frames**, so the challenge could never complete. #3284 unblocked `about:` (which is why the symptom moved from "spins on Verifying…" to fully blank) but that alone was not sufficient.

The embed page itself is healthy on prod (returns the correct widget HTML, the enforced CSP permits the CF script, and Cloudflare is not challenging it) — the failure is entirely in the iOS WebView's per-scheme frame gating.

## Fix

This WebView only ever loads our own first-party `/embed/turnstile` page plus the Cloudflare challenge it pulls in, so there is no value in enumerating which schemes Cloudflare uses:

- `originWhitelist={['*']}` so no scheme the challenge needs (`about:`, `blob:`, `data:`) is dropped. This is a **superset** of the previous list — `about:` is still allowed.
- Remove the custom `onShouldStartLoadWithRequest` (with `['*']` a handler could only re-add the same restriction).
- `webviewDebuggingEnabled={__DEV__}` so any remaining issue can be inspected on-device via Safari Web Inspector on a dev build, without shipping an inspectable WebView to release/TestFlight.

## Testing

- prettier 2.8.8 + eslint clean.
- **Needs on-device iOS verification:** run a dev build (`yarn ios`) on a real device, open free signup, and confirm the Turnstile widget renders and "Register Free" enables after the check. If anything is still off, attach Safari Web Inspector (now enabled in dev) and capture the failing frame/console.
