### PR TITLE
fix(register): gate Turnstile WebView by https scheme, not origin (fixes Android)

### DIFF
--- a/src/screens/register/children/turnstileWebView.tsx
+++ b/src/screens/register/children/turnstileWebView.tsx
@@ -26,16 +26,19 @@ interface Props {
 // returned true only for https/about CANCELLED the challenge's blob:/data: frames, so it never
 // issued a token and the widget stayed blank. about: alone was not enough.
 //
-// Fix: pass every frame to the handler (originWhitelist ['*']) and gate by SCHEME. Sub-frames
-// are always allowed so the challenge's about:/blob:/data: frames load; a top-level navigation
-// is allowed only over https, which still blocks a compromised page from steering the WebView
-// to a top-level file:/javascript: navigation.
-// The gate is https, NOT our origin, on purpose: iOS reports isTopFrame=false for sub-frames,
-// but Android does NOT report isTopFrame and ALSO routes the challenge's https iframe
-// (challenges.cloudflare.com) through this handler -- an origin-only check would block that
-// frame and break Turnstile on Android.
+// Fix: pass every frame to the handler (originWhitelist ['*']). Sub-frames are always allowed
+// so the challenge's about:/blob:/data: compute frames load -- iOS reports isTopFrame=false for
+// them. For the top document, pin to the two hosts the widget legitimately loads: our own embed
+// page and Cloudflare's challenge. This is deliberately host-pinned, NOT "any https":
+//   - The ReactNativeWebView bridge + _onMessage accept a `verify` token from whatever page is
+//     loaded, so a stray top-level navigation to an arbitrary https page could post a fake token.
+//   - challenges.cloudflare.com MUST be allowed explicitly because Android does NOT report
+//     isTopFrame (always undefined) AND routes the challenge's https iframe through this handler;
+//     an origin-only (ecency.com) gate would block that iframe and break Turnstile on Android.
+const _isAllowedTopUrl = (url: string) =>
+  url.startsWith('https://ecency.com/') || url.startsWith('https://challenges.cloudflare.com/');
 const _shouldStartLoad = (req: { url: string; isTopFrame?: boolean }) =>
-  req.isTopFrame === false || req.url.startsWith('https://');
+  req.isTopFrame === false || _isAllowedTopUrl(req.url);
 
 const TurnstileWebView = ({ onVerify, onExpire, onError, height = 76 }: Props) => {
   const intl = useIntl();

--- a/src/screens/register/children/turnstileWebView.tsx
+++ b/src/screens/register/children/turnstileWebView.tsx
@@ -26,15 +26,16 @@ interface Props {
 // returned true only for https/about CANCELLED the challenge's blob:/data: frames, so it never
 // issued a token and the widget stayed blank. about: alone was not enough.
 //
-// Fix: pass every frame to the handler (originWhitelist ['*']) and gate only the TOP-LEVEL
-// document. Sub-frames are always allowed, whatever scheme Cloudflare uses, so the challenge
-// completes; the top frame must stay on our own first-party origin, which keeps a compromised
-// page or open redirect from steering the WebView to file:/javascript:/another origin.
-const TURNSTILE_ORIGIN = 'https://ecency.com/';
+// Fix: pass every frame to the handler (originWhitelist ['*']) and gate by SCHEME. Sub-frames
+// are always allowed so the challenge's about:/blob:/data: frames load; a top-level navigation
+// is allowed only over https, which still blocks a compromised page from steering the WebView
+// to a top-level file:/javascript: navigation.
+// The gate is https, NOT our origin, on purpose: iOS reports isTopFrame=false for sub-frames,
+// but Android does NOT report isTopFrame and ALSO routes the challenge's https iframe
+// (challenges.cloudflare.com) through this handler -- an origin-only check would block that
+// frame and break Turnstile on Android.
 const _shouldStartLoad = (req: { url: string; isTopFrame?: boolean }) =>
-  // isTopFrame is iOS-only; on Android the handler only fires for the main frame, so a missing
-  // flag is treated as the top frame too. Only the top document is constrained to our origin.
-  req.isTopFrame === false || req.url.startsWith(TURNSTILE_ORIGIN);
+  req.isTopFrame === false || req.url.startsWith('https://');
 
 const TurnstileWebView = ({ onVerify, onExpire, onError, height = 76 }: Props) => {
   const intl = useIntl();


### PR DESCRIPTION
Follow-up to #3287 (iOS Turnstile fix — confirmed working on TestFlight).

## Problem

#3287's top-frame guard gates the WebView's top document to our origin:

```js
req.isTopFrame === false || req.url.startsWith('https://ecency.com/')
```

That works on iOS but **breaks Turnstile on Android**. Android's react-native-webview `shouldStart` event (`createWebViewEvent`, `RNCWebViewClient.java`) does **not** include `isTopFrame`, so on Android `req.isTopFrame` is always `undefined` and the handler collapses to:

```js
req.url.startsWith('https://ecency.com/')
```

Android routes **iframe** navigations through `shouldOverrideUrlLoading` too, so the Cloudflare challenge's `https://challenges.cloudflare.com/...` frame is evaluated by this handler — it doesn't start with `ecency.com`, so it's cancelled and the challenge never completes.

## Fix

Gate by **scheme** instead of origin:

```js
req.isTopFrame === false || req.url.startsWith('https://')
```

- **iOS**: unchanged behaviour — sub-frames allowed via `isTopFrame === false`, top frame is our https embed page. (The real flow never navigates the top frame off `ecency.com`, so dropping the origin check is a no-op for it.)
- **Android**: the Cloudflare https iframe now passes, so the challenge completes.
- Still blocks a top-level `file:`/`javascript:` navigation (Greptile's defense-in-depth concern from #3287).

## Testing

- prettier 2.8.8 + eslint clean.
- iOS already verified working on TestFlight with #3287; this change does not alter the iOS happy path.
- **Android needs its own on-device check** (TestFlight is iOS-only): a debug/internal-testing build → free signup → confirm the widget renders and "Register Free" enables. `chrome://inspect` can attach to the WebView on a dev build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced WebView navigation in the registration flow by updating navigation gating behavior, allowing non-top frame requests while restricting top-frame navigations to explicitly allowed HTTPS hosts (`https://ecency.com/` and `https://challenges.cloudflare.com/`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->