### PR TITLE
fix(register): show backend signup error as-is instead of incoherent wrapped message

### DIFF
--- a/src/config/locales/en-US.json
+++ b/src/config/locales/en-US.json
@@ -1005,7 +1005,6 @@
   },
   "register": {
     "username": "Pick a username",
-    "error_message": "{message}\nTry again or try purchasing account instead",
     "title_description": "One account to manage everything",
     "form_description": "By signing up with us, you agree to our Terms of Service and Privacy Policies.",
     "registering": "Registering Your Account...",

--- a/src/screens/register/children/registerAccountModal.tsx
+++ b/src/screens/register/children/registerAccountModal.tsx
@@ -86,7 +86,13 @@ export const RegisterAccountModal = forwardRef(({ username, email, refUsername }
       if (status === 500) {
         body = intl.formatMessage({ id: 'register.500_error' });
       } else if (message) {
-        body = intl.formatMessage({ id: 'register.error_message' }, { message });
+        // The backend already returns a complete, actionable message
+        // (e.g. "VPN connection detected, try changing your network connection or
+        // try Premium account"). Show it as-is — wrapping it with a generic
+        // "Try again or try purchasing account instead" suffix duplicated that
+        // guidance and read incoherently for messages like "Username has already
+        // been taken". Matches the web app's behaviour.
+        body = message;
       }
       Alert.alert(title, body);
       _resetCaptcha();


### PR DESCRIPTION
## Problem

On the **Get Hive Account** free-registration modal, a rejected signup shows an alert whose body repeats itself / reads incoherently. The server already returns a complete, actionable message, but the client wrapped it with a generic suffix:

> **Fail!**
> VPN connection detected, try changing your network connection or try Premium account
> _Try again or try purchasing account instead_  ← redundant

The suffix (`register.error_message` = `"{message}\nTry again or try purchasing account instead"`) duplicated the "try Premium account" / retry guidance for the VPN, rate-limit and queue-full messages, and read nonsensically for messages like _"Username has already been taken"_.

## Fix

Show the backend message as-is — matching what the web app (`vision-next` `signup/free`) already does — and drop the now-unused `register.error_message` locale key.

```diff
  } else if (message) {
-   body = intl.formatMessage({ id: 'register.error_message' }, { message });
+   // backend already returns a complete, actionable message; show it as-is
+   body = message;
  }
```

Result:

> **Fail!**
> VPN connection detected, try changing your network connection or try Premium account

## Notes

- The 12 backend signup messages (`onboard` `error.py`) are all complete sentences; verified each reads coherently without the suffix. The "Buy Account" card remains visible in the same modal, and the VPN/permanent-email messages already say "try Premium account", so no guidance is lost.
- The `register.error_message` key is removed from the Crowdin **source** (`en-US.json`); the translated copies are pruned by Crowdin on source sync (not hand-edited).
- The HTTP-500 path (`register.500_error`) and the no-message fallback (`alert.unknow_error`) are unchanged.

## Verification

- ESLint clean, Prettier (2.8.8) clean, `en-US.json` valid JSON
- `yarn test:ci` → 414 passed / 1 skipped