### PR TITLE
feat(register): localize signup error messages by backend code

### DIFF
--- a/src/config/locales/en-US.json
+++ b/src/config/locales/en-US.json
@@ -1025,6 +1025,20 @@
       "username_contains_underscore": "Should not contain underscore"
     },
     "500_error": "Your request could not be processed, signup queue is likely full! Try again in few minutes...",
+    "error_codes": {
+      "13": "Username has already been taken",
+      "14": "Email address already registered",
+      "15": "Please enter a valid email address",
+      "16": "Please enter a valid username",
+      "17": "Username is too long, please choose a shorter one",
+      "19": "Please use a permanent email address, or get a Premium account instead",
+      "21": "This referral isn't valid",
+      "28": "Your request couldn't be processed — the signup queue is likely full. Please try again in a few minutes.",
+      "107": "VPN connection detected. Please turn off your VPN and try again, or get a Premium account instead.",
+      "110": "To prevent abuse, we limit the number of accounts per person/network. Please try again from a different network.",
+      "111": "Tor connection detected. Please disable Tor while signing up.",
+      "112": "We couldn't verify your connection right now. Please try again in a few minutes."
+    },
     "have_account_text": "Already have an account?"
   },
   "messages": {

--- a/src/screens/register/children/registerAccountModal.tsx
+++ b/src/screens/register/children/registerAccountModal.tsx
@@ -86,13 +86,15 @@ export const RegisterAccountModal = forwardRef(({ username, email, refUsername }
       if (status === 500) {
         body = intl.formatMessage({ id: 'register.500_error' });
       } else if (message) {
-        // The backend already returns a complete, actionable message
-        // (e.g. "VPN connection detected, try changing your network connection or
-        // try Premium account"). Show it as-is — wrapping it with a generic
-        // "Try again or try purchasing account instead" suffix duplicated that
-        // guidance and read incoherently for messages like "Username has already
-        // been taken". Matches the web app's behaviour.
-        body = message;
+        // The backend returns a numeric `code` plus an English `message`. Prefer a
+        // localized, code-specific string so non-English users get a translated body,
+        // and fall back to the backend message (as defaultMessage) for any locale that
+        // hasn't translated the code, or any code we don't map. The backend message is
+        // already a complete sentence, so the fallback is always coherent on its own.
+        const code = get(err, 'data.code') || get(err, 'response.data.code');
+        body = code
+          ? intl.formatMessage({ id: `register.error_codes.${code}`, defaultMessage: message })
+          : message;
       }
       Alert.alert(title, body);
       _resetCaptcha();


### PR DESCRIPTION
## Why

Follow-up to #3290. The free-signup endpoint (`onboard` `AccountCreate`) returns a numeric **`code`** plus an English **`message`**. The modal showed the raw English `message`, so **non-English users always got an English error body**. This localizes the user-facing signup errors while keeping the backend message as a safety net.

## What

- Added `register.error_codes.<code>` to `en-US.json` for the **12 codes the free-signup endpoint can actually raise**: `13, 14, 15, 16, 17, 19, 21, 28, 107, 110, 111, 112`. Crowdin translates these into the other ~40 locales from the source.
- The catch block now reads `data.code` and looks up `register.error_codes.<code>`, passing the backend `message` as `defaultMessage`:

```ts
const code = get(err, 'data.code') || get(err, 'response.data.code');
body = code
  ? intl.formatMessage({ id: `register.error_codes.${code}`, defaultMessage: message })
  : message;
```

## Fallback behaviour (verified)

| case | result |
|------|--------|
| EN, mapped code | localized EN string |
| translated locale, mapped code | localized string for that locale |
| **untranslated** locale, mapped code | backend `message` (English) — never a raw key |
| **unmapped** code (e.g. future backend code) | backend `message` |
| no `code` on the error | backend `message` (unchanged) |

Verified with the app's real `flattenMessages` + react-intl: mapped lookup, untranslated-locale fallback, unmapped-code fallback, and apostrophe/ICU rendering (`isn't`, `couldn't`) all behave correctly.

## Scope notes

- Codes **106/108/109/104** are **not** raised by free signup — they live on the internal `QualityControl` / wallet / favorites endpoints (108/109 are effectively dead behind `required=True`). They're developer-facing API messages, so they're intentionally left out and no backend copy change is needed.
- The HTTP-500 path (`register.500_error`) and the no-message fallback (`alert.unknow_error`) are unchanged.

## Verification

- ESLint clean (no dynamic-id issues), Prettier (2.8.8) clean, `en-US.json` valid JSON
- `yarn test:ci` → 414 passed / 1 skipped