### PR TITLE
feat(waves): unify feeds onto the combined cross-container endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
   "dependencies": {
     "@babel/preset-typescript": "^7.26.0",
     "@babel/runtime": "^7.26.7",
-    "@ecency/render-helper": "^2.5.11",
-    "@ecency/sdk": "^2.3.22",
+    "@ecency/render-helper": "^2.5.14",
+    "@ecency/sdk": "^2.3.24",
     "@esteemapp/react-native-autocomplete-input": "^4.2.1",
     "@esteemapp/react-native-multi-slider": "^1.1.0",
     "@native-html/iframe-plugin": "^2.6.1",

--- a/src/components/profile/children/wavesTabContent.tsx
+++ b/src/components/profile/children/wavesTabContent.tsx
@@ -24,7 +24,9 @@ const WavesTabContent = ({ username, isOwnProfile, onScroll }: WavesTabContentPr
   // (across every container). No observer is passed: you're deliberately
   // viewing this profile, so a mute of theirs shouldn't blank their waves.
   const queryOptions = useMemo(() => getWavesFeedQueryOptions({ author: username }), [username]);
-  const wavesQuery = wavesQueries.useWavesQuery(queryOptions);
+  // injectPromoted=false (no promoted cards on a profile), applyMuteFilter=false
+  // so a muted author's own profile tab still shows their waves.
+  const wavesQuery = wavesQueries.useWavesQuery(queryOptions, false, false);
 
   const _renderListEmpty = () => {
     if (wavesQuery.isLoading) {

--- a/src/components/profile/children/wavesTabContent.tsx
+++ b/src/components/profile/children/wavesTabContent.tsx
@@ -1,8 +1,8 @@
-import React, { useCallback } from 'react';
+import React, { useMemo } from 'react';
 import { ActivityIndicator, RefreshControl, View } from 'react-native';
 import { useIntl } from 'react-intl';
 import EStyleSheet from 'react-native-extended-stylesheet';
-import { getWavesByAccountQueryOptions } from '@ecency/sdk';
+import { getWavesFeedQueryOptions } from '@ecency/sdk';
 import { Comments, NoPost } from '../..';
 import { useAppSelector } from '../../../hooks';
 import { selectHidePostsThumbnails } from '../../../redux/selectors';
@@ -20,11 +20,11 @@ const WavesTabContent = ({ username, isOwnProfile, onScroll }: WavesTabContentPr
   const intl = useIntl();
   const isHideImage = useAppSelector(selectHidePostsThumbnails);
 
-  const buildQueryOptions = useCallback(
-    (host: string) => getWavesByAccountQueryOptions(host, username),
-    [username],
-  );
-  const wavesQuery = wavesQueries.useWavesQuery(buildQueryOptions);
+  // The per-author feed is the same combined endpoint scoped to one author
+  // (across every container). No observer is passed: you're deliberately
+  // viewing this profile, so a mute of theirs shouldn't blank their waves.
+  const queryOptions = useMemo(() => getWavesFeedQueryOptions({ author: username }), [username]);
+  const wavesQuery = wavesQueries.useWavesQuery(queryOptions);
 
   const _renderListEmpty = () => {
     if (wavesQuery.isLoading) {

--- a/src/components/quickPostModal/usePostSubmitter.ts
+++ b/src/components/quickPostModal/usePostSubmitter.ts
@@ -197,14 +197,19 @@ export const usePostSubmitter = () => {
         parentPermlink,
       );
 
-      // Build cache entry for wave optimistic prepend
+      // Build cache entry for wave optimistic prepend. Keep it WaveEntry-shaped:
+      // `body` (parsePost derives markdownBody/rendered body from it for the
+      // current author) and `created` (the card's timestamp). Without these the
+      // optimistic card renders blank until the next feed refetch.
       const _cacheCommentData = {
         author,
         permlink,
         url,
         parent_author: parentAuthor,
         parent_permlink: parentPermlink,
+        body: commentBody,
         markdownBody: commentBody,
+        created: new Date().toISOString(),
         json_metadata: jsonMetadata,
       };
 

--- a/src/constants/waves.ts
+++ b/src/constants/waves.ts
@@ -2,15 +2,16 @@
  * Hive accounts that host waves (short-content) "containers".
  *
  * A waves container is a root post published by the host account; individual
- * waves are comments on that container. Following the cross-team unification
- * of ecency.waves and peak.snaps under the shared `hive.flow` account, the
- * feed reads from the primary host first and falls back to the next host when
- * the primary has no containers, or its containers are exhausted while
- * scrolling. New waves are likewise posted to the first host that has a
- * container, so they appear at the top of the primary feed.
- *
- * Order matters: earlier entries take precedence. Keep `ecency.waves` last as
- * the legacy backstop so historical waves remain reachable.
+ * waves are comments on that container. The unified waves feed merges every
+ * container below in time order, so a wave in the feed can belong to any of
+ * them — not just the accounts Ecency posts new waves into.
+ */
+
+/**
+ * Hosts Ecency posts NEW waves into, in priority order. A freshly posted wave
+ * lands on the first host that has a live container (`hive.flow`), falling back
+ * to the legacy `ecency.waves`. Keep `ecency.waves` last as the backstop so
+ * historical waves remain reachable.
  */
 export const WAVES_PRIMARY_HOST = 'hive.flow';
 export const WAVES_FALLBACK_HOST = 'ecency.waves';
@@ -18,9 +19,25 @@ export const WAVES_FALLBACK_HOST = 'ecency.waves';
 export const WAVES_HOSTS: readonly string[] = [WAVES_PRIMARY_HOST, WAVES_FALLBACK_HOST];
 
 /**
+ * Every account whose root posts are waves containers, across all integrated
+ * apps. The unified feed surfaces waves from ALL of these, so post/comment
+ * views must recognise any of them as a wave (not just the accounts we post
+ * into). Keep in sync with the backend (esync) container set and the web's
+ * `CONTAINER_ACCOUNTS`.
+ */
+export const WAVES_CONTAINER_HOSTS: readonly string[] = [
+  WAVES_PRIMARY_HOST,
+  WAVES_FALLBACK_HOST,
+  'leothreads',
+  'peak.snaps',
+  'liketu.moments',
+  'liketu.speak',
+];
+
+/**
  * True when `account` is one of the recognised waves container hosts. Use this
  * instead of comparing against a single hard-coded host so that waves served
  * from any unified container account are classified correctly.
  */
 export const isWavesHost = (account?: string | null): boolean =>
-  !!account && WAVES_HOSTS.includes(account);
+  !!account && WAVES_CONTAINER_HOSTS.includes(account);

--- a/src/providers/queries/postQueries/wavesQueries.ts
+++ b/src/providers/queries/postQueries/wavesQueries.ts
@@ -15,45 +15,33 @@ import { useIntl } from 'react-intl';
 import {
   getAccountPosts,
   getPromotedPostsQuery,
-  getWavesByHostQueryOptions,
-  getWavesFollowingQueryOptions,
-  getWavesByTagQueryOptions,
-  getWavesByAccountQueryOptions,
+  getWavesFeedQueryOptions,
   useDeleteComment,
   WaveEntry,
 } from '@ecency/sdk';
 
 import { parsePost } from '../../../utils/postParser';
-import { WAVES_PRIMARY_HOST, WAVES_FALLBACK_HOST } from '../../../constants/waves';
+import { WAVES_PRIMARY_HOST } from '../../../constants/waves';
 import { useAppSelector } from '../../../hooks';
 import { toastNotification } from '../../../redux/actions/uiAction';
 import { useBotAuthorsQuery } from './postQueries';
 import { selectCurrentAccount, selectCurrentAccountMutes } from '../../../redux/selectors';
 import { useAuthContext } from '../../sdk';
 
-type WavesQueryOptions =
-  | ReturnType<typeof getWavesByHostQueryOptions>
-  | ReturnType<typeof getWavesFollowingQueryOptions>
-  | ReturnType<typeof getWavesByTagQueryOptions>
-  | ReturnType<typeof getWavesByAccountQueryOptions>;
+type CombinedWavesQueryOptions = ReturnType<typeof getWavesFeedQueryOptions>;
 
 /**
- * Drives a waves feed across an ordered pair of container hosts. The primary
- * host (`hive.flow`) is paginated first; once it has no more containers — be
- * that because it has none at all or because scrolling exhausted them — the
- * fallback host (`ecency.waves`) is enabled and its waves are appended. The
- * two SDK queries stay independent; this hook just merges their pages and
- * presents a single feed-shaped API to the screen.
- *
- * `buildQueryOptions` is invoked once per host so the same feed flavour
- * (for-you / following / tag / account) can be requested from either account.
+ * Drives a waves feed from the single combined, cross-container esync endpoint.
+ * Every flavour (for-you / following / tag / account) is powered by the same
+ * hook; the flavour is encoded entirely in the `queryOptions` passed in, built
+ * via `getWavesFeedQueryOptions({ observer, following, tag, author })`. One
+ * keyset-paginated infinite query backs the list — the per-container
+ * primary/fallback host chaining is gone, the backend already merges every
+ * container in time order. This hook layers the shared visibility filter,
+ * promoted-wave interleaving, optimistic delete and pull-to-refresh on top.
  */
 export const useWavesQuery = (
-  buildQueryOptions: (host: string) => WavesQueryOptions,
-  hosts: { primary: string; fallback: string } = {
-    primary: WAVES_PRIMARY_HOST,
-    fallback: WAVES_FALLBACK_HOST,
-  },
+  queryOptions: CombinedWavesQueryOptions,
   // When true (for-you / following feeds, not tag feeds), promoted waves are
   // fetched and interleaved into the list like the web waves feed.
   injectPromoted = false,
@@ -71,39 +59,8 @@ export const useWavesQuery = (
 
   const [isRefreshing, setIsRefreshing] = useState(false);
 
-  const primaryOptions = useMemo(
-    () => buildQueryOptions(hosts.primary),
-    [buildQueryOptions, hosts.primary],
-  );
-  const fallbackOptions = useMemo(
-    () => buildQueryOptions(hosts.fallback),
-    [buildQueryOptions, hosts.fallback],
-  );
-
-  // The SDK gates following/account feeds with their own `enabled` flag (e.g.
-  // disabled until a username is known); honour it so we never force a query
-  // the SDK intends to skip.
-  const primaryBaseEnabled = (primaryOptions as { enabled?: boolean }).enabled ?? true;
-  const fallbackBaseEnabled = (fallbackOptions as { enabled?: boolean }).enabled ?? true;
-
-  // All SDK wave query options share the same runtime shape but differ in
-  // page-param generics; cast to satisfy useInfiniteQuery.
-  const primaryQuery = useInfiniteQuery({
-    ...(primaryOptions as ReturnType<typeof getWavesByHostQueryOptions>),
-    refetchInterval: 60000,
-  });
-
-  // The fallback host activates only once the primary has finished loading and
-  // reports no further containers. That single condition covers both
-  // "primary has nothing at all" and "primary exhausted while scrolling"; on a
-  // primary error `hasNextPage` is false and `isFetched` true, so the feed
-  // still falls back rather than dead-ending.
-  const primaryExhausted =
-    primaryBaseEnabled && primaryQuery.isFetched && !primaryQuery.hasNextPage;
-
-  const fallbackQuery = useInfiniteQuery({
-    ...(fallbackOptions as ReturnType<typeof getWavesByHostQueryOptions>),
-    enabled: fallbackBaseEnabled && primaryExhausted,
+  const wavesQuery = useInfiniteQuery({
+    ...queryOptions,
     refetchInterval: 60000,
   });
 
@@ -116,19 +73,15 @@ export const useWavesQuery = (
   });
 
   const data = useMemo(() => {
-    const primaryItems: WaveEntry[] = primaryQuery.data?.pages?.flat() ?? [];
-    // Surface fallback items only while the primary is exhausted, so a primary
-    // refetch that brings back fresh containers hides the fallback again
-    // instead of interleaving the two sources.
-    const fallbackItems: WaveEntry[] = primaryExhausted
-      ? fallbackQuery.data?.pages?.flat() ?? []
-      : [];
-    const flatData: WaveEntry[] = [...primaryItems, ...fallbackItems];
+    const flatData: WaveEntry[] = wavesQuery.data?.pages?.flat() ?? [];
     const botAuthors = botAuthorsQuery.data ?? [];
 
     // Shared visibility filter: drop empty parses, muted authors, downvoted /
     // gray waves, and bot authors. Applied to BOTH organic and promoted waves
     // so the user's own mutes (and bot/gray hiding) hold even for promoted cards.
+    // Server-side observer-mute already excludes muted authors from the combined
+    // feed; this client filter stays as a backstop (and still covers promoted
+    // cards, which bypass the feed query).
     const isVisibleWave = (post: any) => {
       if (!post) {
         return false;
@@ -151,7 +104,7 @@ export const useWavesQuery = (
     const parsed = flatData
       // Shallow-copy before parsing: parsePost mutates its argument, and `flatData`
       // holds the SDK query cache objects (mutating re-renders the body each refetch).
-      // The SDK (>= 2.3.19) normalizes `created` on the custom feeds, so no client-side
+      // The SDK normalizes `created` on the combined feed, so no client-side
       // timestamp mapping is needed here. Organic waves are never promoted (isPromoted=false).
       .map((item) => parsePost({ ...item }, currentAccount?.name, false))
       .filter(isVisibleWave);
@@ -187,9 +140,7 @@ export const useWavesQuery = (
         return acc;
       }, [] as typeof parsed);
   }, [
-    primaryQuery.data,
-    fallbackQuery.data,
-    primaryExhausted,
+    wavesQuery.data,
     mutes,
     botAuthorsQuery.data,
     currentAccount?.name,
@@ -197,57 +148,20 @@ export const useWavesQuery = (
     injectPromoted,
   ]);
 
-  const primaryItemCount = primaryQuery.data?.pages?.flat()?.length ?? 0;
-
-  // More remains if the primary still has pages, or it is exhausted and the
-  // fallback either has more pages or hasn't yet loaded its first page.
-  const hasNextPage =
-    !!primaryQuery.hasNextPage ||
-    (primaryExhausted &&
-      (!!fallbackQuery.hasNextPage ||
-        (fallbackBaseEnabled && !fallbackQuery.isFetched && !fallbackQuery.isError)));
-
-  const isFetchingNextPage =
-    primaryQuery.isFetchingNextPage ||
-    fallbackQuery.isFetchingNextPage ||
-    // The fallback's first page loads automatically (via `enabled`) once the
-    // primary exhausts. Count that as "fetching" — including when the primary
-    // had zero items — so callers don't see `hasNextPage && !isFetchingNextPage`
-    // and fire a no-op `fetchNextPage()` (a no-op because the fallback has no
-    // `hasNextPage` until its first page lands). An empty FlatList raises
-    // `onEndReached` immediately, so without this it would loop on every scroll.
-    (primaryExhausted && fallbackQuery.isLoading);
-
-  const isLoading =
-    primaryQuery.isLoading ||
-    // Primary returned nothing and we're now loading the fallback's first page.
-    (primaryExhausted && primaryItemCount === 0 && fallbackQuery.isLoading);
+  const hasNextPage = !!wavesQuery.hasNextPage;
+  const { isFetchingNextPage, isLoading } = wavesQuery;
 
   const fetchNextPage = useCallback(() => {
-    if (primaryQuery.hasNextPage) {
-      return primaryQuery.fetchNextPage();
-    }
-    if (primaryExhausted && fallbackQuery.hasNextPage) {
-      return fallbackQuery.fetchNextPage();
+    if (wavesQuery.hasNextPage && !wavesQuery.isFetchingNextPage) {
+      return wavesQuery.fetchNextPage();
     }
     return undefined;
-  }, [
-    primaryQuery.hasNextPage,
-    primaryQuery.fetchNextPage,
-    primaryExhausted,
-    fallbackQuery.hasNextPage,
-    fallbackQuery.fetchNextPage,
-  ]);
+  }, [wavesQuery.hasNextPage, wavesQuery.isFetchingNextPage, wavesQuery.fetchNextPage]);
 
   const refresh = async () => {
     setIsRefreshing(true);
     try {
-      await primaryQuery.refetch();
-      // Only refetch the fallback if it actually loaded; otherwise its
-      // `enabled` gate re-evaluates from the refreshed primary state.
-      if (fallbackQuery.data) {
-        await fallbackQuery.refetch();
-      }
+      await wavesQuery.refetch();
       // Keep interleaved promoted waves fresh on pull-to-refresh too; skip when
       // promoted injection is off (tag feeds / profile tab) so we don't fire a
       // disabled query.
@@ -278,10 +192,10 @@ export const useWavesQuery = (
         return;
       }
 
-      // A wave's container account (its parent_author) decides which host to
-      // broadcast the delete against. Fall back to the primary host for
-      // callers that don't carry it.
-      const targetHost = _parent_author || hosts.primary;
+      // Each wave carries its own container account (its parent_author), which
+      // decides which container to broadcast the delete against. Fall back to
+      // the primary host only for callers that don't carry it.
+      const targetHost = _parent_author || WAVES_PRIMARY_HOST;
 
       try {
         await sdkDeleteMutation.mutateAsync({
@@ -291,20 +205,17 @@ export const useWavesQuery = (
           parentPermlink: _parent_permlink,
         });
 
-        // The merged feed may hold the wave under either host's key, so prune
-        // both caches. Match author too — a permlink is only unique per author,
-        // so filtering on permlink alone could drop another user's wave that
-        // happens to share it.
-        [primaryOptions.queryKey, fallbackOptions.queryKey].forEach((queryKey) => {
-          queryClient.setQueryData<InfiniteData<WaveEntry[]>>(queryKey, (oldData) => {
-            if (!oldData) return oldData;
-            return {
-              ...oldData,
-              pages: oldData.pages.map((page) =>
-                page.filter((w) => !(w.author === currentAccount.name && w.permlink === _permlink)),
-              ),
-            };
-          });
+        // Prune the wave from this feed's combined-feed cache. Match author too
+        // — a permlink is only unique per author, so filtering on permlink alone
+        // could drop another user's wave that happens to share it.
+        queryClient.setQueryData<InfiniteData<WaveEntry[]>>(queryOptions.queryKey, (oldData) => {
+          if (!oldData) return oldData;
+          return {
+            ...oldData,
+            pages: oldData.pages.map((page) =>
+              page.filter((w) => !(w.author === currentAccount.name && w.permlink === _permlink)),
+            ),
+          };
         });
 
         dispatch(toastNotification(intl.formatMessage({ id: 'alert.success' })));
@@ -315,14 +226,12 @@ export const useWavesQuery = (
     },
     [
       currentAccount?.name,
-      hosts.primary,
       // Use `mutateAsync` (stable across renders via TanStack Query's
       // internal ref) rather than the whole mutation result object, which
       // gets a fresh identity on every state transition (idle → pending →
       // success/error) and would re-rotate `deleteWave` after each delete.
       sdkDeleteMutation.mutateAsync,
-      primaryOptions.queryKey,
-      fallbackOptions.queryKey,
+      queryOptions.queryKey,
       queryClient,
       dispatch,
       intl,
@@ -348,9 +257,16 @@ interface PublishWaveContext {
 
 export const usePublishWaveMutation = () => {
   const queryClient = useQueryClient();
+  const currentAccount = useAppSelector(selectCurrentAccount);
+
+  // A freshly posted wave belongs at the top of the for-you combined feed; its
+  // cache key is the observer-scoped feed, where the observer is the poster.
+  const observer = currentAccount?.name || undefined;
 
   const _mutationFn = async (cachePostData: any) => {
     if (cachePostData) {
+      // Return the container host purely so onError/onSuccess have something to
+      // key on; the optimistic write itself targets the combined feed below.
       const _host = cachePostData.parent_author;
       return _host;
     }
@@ -359,8 +275,7 @@ export const usePublishWaveMutation = () => {
 
   const _options: UseMutationOptions<string, unknown, any, PublishWaveContext> = {
     onMutate: async (cacheCommentData: any) => {
-      const _host = cacheCommentData.parent_author;
-      const sdkOptions = getWavesByHostQueryOptions(_host);
+      const sdkOptions = getWavesFeedQueryOptions({ observer });
 
       await queryClient.cancelQueries({ queryKey: sdkOptions.queryKey });
 
@@ -386,10 +301,10 @@ export const usePublishWaveMutation = () => {
       }
     },
 
-    onSuccess: async (host) => {
-      const sdkOptions = getWavesByHostQueryOptions(host);
-      queryClient.invalidateQueries({ queryKey: sdkOptions.queryKey });
-    },
+    // No invalidate on success: the combined feed is esync-backed and a just-
+    // broadcast wave isn't indexed there yet, so an immediate refetch would drop
+    // the optimistic card. The 60s refetchInterval (and pull-to-refresh)
+    // reconciles the feed once esync has indexed it.
   };
 
   return useMutation({ mutationFn: _mutationFn, ..._options });

--- a/src/providers/queries/postQueries/wavesQueries.ts
+++ b/src/providers/queries/postQueries/wavesQueries.ts
@@ -45,6 +45,11 @@ export const useWavesQuery = (
   // When true (for-you / following feeds, not tag feeds), promoted waves are
   // fetched and interleaved into the list like the web waves feed.
   injectPromoted = false,
+  // When true (the firehose feeds), waves from authors the viewer mutes are
+  // dropped client-side. Pass false for the profile author feed: you opened
+  // that profile on purpose, so a mute of theirs must not blank their waves
+  // (consistent with that feed omitting the server-side `observer`).
+  applyMuteFilter = true,
 ) => {
   const queryClient = useQueryClient();
   const dispatch = useDispatch();
@@ -86,8 +91,8 @@ export const useWavesQuery = (
       if (!post) {
         return false;
       }
-      // discard wave if author is muted
-      if (isArray(mutes) && mutes.indexOf(post.author) >= 0) {
+      // discard wave if author is muted (skipped for the profile author feed)
+      if (applyMuteFilter && isArray(mutes) && mutes.indexOf(post.author) >= 0) {
         return false;
       }
       // discard if wave is downvoted or marked gray
@@ -142,6 +147,7 @@ export const useWavesQuery = (
   }, [
     wavesQuery.data,
     mutes,
+    applyMuteFilter,
     botAuthorsQuery.data,
     currentAccount?.name,
     promotedQuery.data,
@@ -264,16 +270,15 @@ export const usePublishWaveMutation = () => {
   const observer = currentAccount?.name || undefined;
 
   const _mutationFn = async (cachePostData: any) => {
-    if (cachePostData) {
-      // Return the container host purely so onError/onSuccess have something to
-      // key on; the optimistic write itself targets the combined feed below.
-      const _host = cachePostData.parent_author;
-      return _host;
+    // The optimistic prepend happens in onMutate (and is rolled back in
+    // onError); this only validates the input. There is no return value —
+    // nothing downstream consumes one.
+    if (!cachePostData) {
+      throw new Error('invalid mutations data');
     }
-    throw new Error('invalid mutations data');
   };
 
-  const _options: UseMutationOptions<string, unknown, any, PublishWaveContext> = {
+  const _options: UseMutationOptions<void, unknown, any, PublishWaveContext> = {
     onMutate: async (cacheCommentData: any) => {
       const sdkOptions = getWavesFeedQueryOptions({ observer });
 

--- a/src/screens/waves/screen/wavesScreen.tsx
+++ b/src/screens/waves/screen/wavesScreen.tsx
@@ -14,11 +14,7 @@ import { TabView } from 'react-native-tab-view';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { SheetManager } from 'react-native-actions-sheet';
 import { useIntl } from 'react-intl';
-import {
-  getWavesByHostQueryOptions,
-  getWavesFollowingQueryOptions,
-  getWavesByTagQueryOptions,
-} from '@ecency/sdk';
+import { getWavesFeedQueryOptions } from '@ecency/sdk';
 import {
   Comments,
   EmptyScreen,
@@ -51,7 +47,7 @@ type DeleteWaveFn = (args: {
 }) => Promise<void>;
 
 const WavesFeed = ({
-  buildQueryOptions,
+  queryOptions,
   queryKey,
   listRef,
   onTagPress,
@@ -62,10 +58,11 @@ const WavesFeed = ({
   isDarkTheme,
 }: {
   /**
-   * Builds the SDK query options for a given waves container host. Invoked
-   * once per host (primary + fallback) inside `useWavesQuery`.
+   * The combined-feed query options for this flavour, built via
+   * `getWavesFeedQueryOptions({ observer, following, tag })`. A single
+   * keyset-paginated query backs the list.
    */
-  buildQueryOptions: Parameters<typeof wavesQueries.useWavesQuery>[0];
+  queryOptions: ReturnType<typeof getWavesFeedQueryOptions>;
   queryKey: string;
   listRef: React.RefObject<FlatList | null>;
   onTagPress: (tag: string) => void;
@@ -88,7 +85,7 @@ const WavesFeed = ({
 }) => {
   // Interleave promoted waves on the for-you / following feeds, but never on a
   // tag feed (matches the web waves feed's `enabled: !tag`).
-  const wavesQuery = wavesQueries.useWavesQuery(buildQueryOptions, undefined, feedKey !== 'tag');
+  const wavesQuery = wavesQueries.useWavesQuery(queryOptions, feedKey !== 'tag');
   const blockPopupRef = useRef(false);
   const scrollOffsetRef = useRef(0);
 
@@ -209,20 +206,22 @@ const WavesScreen = () => {
   const isDarkTheme = useAppSelector(selectIsDarkTheme);
   const insets = useSafeAreaInsets();
 
-  // Per-host query-option builders. `useWavesQuery` invokes each one for both
-  // the primary (hive.flow) and fallback (ecency.waves) container hosts, so
-  // each feed flavour is requested from both accounts and chained.
-  const buildForYouQueryOptions = useCallback(
-    (host: string) => getWavesByHostQueryOptions(host),
-    [],
+  // The logged-in user is the observer on every feed: the backend drops authors
+  // they currently mute, so each page stays full of waves they can see (a
+  // client-side filter would shrink pages). Logged-out users get the public
+  // combined feed (observer undefined).
+  const observer = currentAccount?.name || undefined;
+
+  // One combined, cross-container, keyset-paginated endpoint backs all three
+  // feeds; `following` and `tag` are just filters on the same stream.
+  const forYouQueryOptions = useMemo(() => getWavesFeedQueryOptions({ observer }), [observer]);
+  const followingQueryOptions = useMemo(
+    () => getWavesFeedQueryOptions({ following: currentAccount?.name, observer }),
+    [currentAccount?.name, observer],
   );
-  const buildFollowingQueryOptions = useCallback(
-    (host: string) => getWavesFollowingQueryOptions(host, currentAccount?.name ?? ''),
-    [currentAccount?.name],
-  );
-  const buildTagQueryOptions = useCallback(
-    (host: string) => getWavesByTagQueryOptions(host, activeTag ?? ''),
-    [activeTag],
+  const tagQueryOptions = useMemo(
+    () => getWavesFeedQueryOptions({ tag: activeTag ?? undefined, observer }),
+    [activeTag, observer],
   );
 
   const activeListRef = activeTag
@@ -330,7 +329,7 @@ const WavesScreen = () => {
       return (
         <View style={styles.tabScene}>
           <WavesFeed
-            buildQueryOptions={buildFollowingQueryOptions}
+            queryOptions={followingQueryOptions}
             queryKey={`following:${currentAccount?.name}`}
             listRef={followingListRef}
             onTagPress={_handleTagFilter}
@@ -349,7 +348,7 @@ const WavesScreen = () => {
         <View style={styles.tabScene}>
           {_renderFilterChip}
           <WavesFeed
-            buildQueryOptions={buildTagQueryOptions}
+            queryOptions={tagQueryOptions}
             queryKey={`tag:${activeTag}`}
             listRef={tagListRef}
             onTagPress={_handleTagFilter}
@@ -366,7 +365,7 @@ const WavesScreen = () => {
     return (
       <View style={styles.tabScene}>
         <WavesFeed
-          buildQueryOptions={buildForYouQueryOptions}
+          queryOptions={forYouQueryOptions}
           queryKey="for-you"
           listRef={forYouListRef}
           onTagPress={_handleTagFilter}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1192,10 +1192,10 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@ecency/render-helper@^2.5.11":
-  version "2.5.11"
-  resolved "https://registry.yarnpkg.com/@ecency/render-helper/-/render-helper-2.5.11.tgz#dc36de6f4d1a9bcc06e7d191bda9a9b2014353fd"
-  integrity sha512-U/2qVJ+tyUZwx2KQSXMowS7saeNrVLttdN5sWby7yudyF+Jz2ndsdVXs1z1TbbZHUlhqME7TboseiXE7ugGFBA==
+"@ecency/render-helper@^2.5.14":
+  version "2.5.14"
+  resolved "https://registry.yarnpkg.com/@ecency/render-helper/-/render-helper-2.5.14.tgz#d28b8d341e80a998d656cd7e38ec9491664c280a"
+  integrity sha512-hjeUP9EdUonpYWeaQ0XzJhHbMoA9XQSJsn638q7qbwq06chSaYfs169Rf7cig0KhjEmpFEno2R8krtVqeqEG5Q==
   dependencies:
     "@xmldom/xmldom" "^0.9.10"
     dom-serializer "^2.0.0"
@@ -1211,10 +1211,10 @@
     url "^0.11.0"
     xss "^1.0.9"
 
-"@ecency/sdk@^2.3.22":
-  version "2.3.22"
-  resolved "https://registry.yarnpkg.com/@ecency/sdk/-/sdk-2.3.22.tgz#a92f995e1c9c1cfd46d5548da3609922700552ee"
-  integrity sha512-+JdZiAFvQwSyhQvZ2GSxng9WNHx1AK69FhFQHBNZebSbf8Oyl/2P1wa7mR8LQOfj59zwUeH9NaT1V2U0qFguPw==
+"@ecency/sdk@^2.3.24":
+  version "2.3.24"
+  resolved "https://registry.yarnpkg.com/@ecency/sdk/-/sdk-2.3.24.tgz#5a769f1091b00dd3163d6cdd4eded2ba1bd5c69d"
+  integrity sha512-25K5edzI/9Yppmcr8vrU9QiypcLWxumuuw468lVVUGwsA8eyS86ReKDaRPFQk5rOWmMuJ32nz2XwznyWRpdIWA==
   dependencies:
     "@noble/ciphers" "^2.1.1"
     "@noble/curves" "^2.0.1"


### PR DESCRIPTION
## Summary

Moves the mobile waves feeds onto the same single, combined, cross-container feed the web now uses, replacing the per-container primary/fallback (`hive.flow` -> `ecency.waves`) host chaining.

- Bump `@ecency/sdk` 2.3.22 -> 2.3.24 and `@ecency/render-helper` 2.5.11 -> 2.5.14.
- `useWavesQuery` now drives a single keyset-paginated infinite query (`getWavesFeedQueryOptions`) instead of merging two host queries. The shared visibility filter, promoted-wave interleave, optimistic delete and pull-to-refresh are unchanged.
- For-you / following / tag feeds and the profile waves tab all read the combined feed: `following` and `tag` are filters on the same stream, the profile tab uses the `author` filter (full history).
- The logged-in user is passed as `observer`, so authors they mute are dropped server-side and each page stays full (no client-side page shrinking). The profile/author feed intentionally omits `observer` so a mute doesn't blank a profile you deliberately opened.
- `isWavesHost` now recognises every unified container (leothreads, peak.snaps, liketu.moments, liketu.speak, ...), so a wave opened from any container still renders as a wave.
- The render-helper bump makes Liketu Speak (and 3Speak) audio posts playable in the feed.

## Notes

Lint + jest pass locally. Needs on-device validation (feed scroll/pagination, following gate, tag filter, profile tab, posting a wave + delete) since the RN runtime isn't exercised in CI here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced the Waves feed to use a unified combined source for smoother pagination and refresh.
  * Expanded which container accounts are recognized for Waves, so more wave content is shown correctly.
* **Bug Fixes**
  * Made published-wave updates and optimistic submission behavior more consistent so new waves appear reliably.
  * Improved Waves tab loading behavior to prevent unintended mute-related blanks for the viewed author’s own waves.
* **Chores**
  * Updated Waves-related SDK/render helper dependency versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->