### PR TITLE
fix(register): block chain-invalid usernames before paid-account purchase

### DIFF
--- a/src/containers/inAppPurchaseContainer.tsx
+++ b/src/containers/inAppPurchaseContainer.tsx
@@ -18,6 +18,7 @@ import { default as ROUTES } from '../constants/routeNames';
 import { UserAvatar } from '../components';
 import { PurchaseRequestData } from '../providers/ecency/ecency.types';
 import { SheetNames } from '../navigation/sheets';
+import { getUsernameError, USERNAME_ERROR_MESSAGE_IDS } from '../utils/usernameValidation';
 
 // Username/email entered when a paid-account purchase is started. Persisted so a
 // purchase that Google has charged but that was not finalized (network drop, app
@@ -173,6 +174,14 @@ class InAppPurchaseContainer extends Component {
           const meta = providedMeta || (await this._resolveAccountMeta());
           if (!meta || !meta.username || !meta.email) {
             throw new Error('Email and username are required for 999accounts consumption');
+          }
+          // Final guard before the order reaches the backend: a chain-invalid
+          // username can never be created on-chain, so don't record an order for
+          // it. New purchases are blocked at buy time; this only catches a name
+          // charged on an older build, which is then left unconsumed to be
+          // auto-refunded rather than charged for an uncreatable account.
+          if (getUsernameError(String(meta.username).toLowerCase())) {
+            throw new Error(`Invalid Hive username for 999accounts: ${meta.username}`);
           }
           data.user = name || 'ecency'; // if user logged in use that name else use ecency
           data.meta = {
@@ -345,7 +354,8 @@ class InAppPurchaseContainer extends Component {
   };
 
   _buyItem = async (sku) => {
-    const { navigation, isLoggedIn, intl, username, email, referral } = this.props;
+    const { navigation, isLoggedIn, intl, username, email, referral, handleOnPurchaseFailure } =
+      this.props;
     const { unconsumedPurchases } = this.state;
     // if user is not loggedIn and purchase is other than account purchase
     // add more skus here for account purchase
@@ -355,6 +365,26 @@ class InAppPurchaseContainer extends Component {
         intl.formatMessage({ id: 'login.not_loggedin_alert_desc' }),
       );
       return;
+    }
+
+    // Never charge for a paid account whose username the blockchain would reject
+    // (e.g. a dot-segment under 3 chars). The register modal guards this too, but
+    // _buyItem can be reached by other entry points, so block the charge here as
+    // well rather than let the buyer pay for an account that can never be created.
+    if (sku === '999accounts') {
+      const errorCode = getUsernameError((username || '').toLowerCase());
+      if (errorCode) {
+        const message = intl.formatMessage({ id: USERNAME_ERROR_MESSAGE_IDS[errorCode] });
+        // Notify the caller so any in-progress UI state is reset (the register modal
+        // sets isRegistering before calling buyItem), and fall back to an Alert for
+        // callers that don't pass a failure handler.
+        if (handleOnPurchaseFailure) {
+          handleOnPurchaseFailure(new Error(message));
+        } else {
+          Alert.alert(intl.formatMessage({ id: 'alert.fail' }), message);
+        }
+        return;
+      }
     }
 
     if (sku !== 'freePoints') {

--- a/src/screens/register/children/registerAccountModal.tsx
+++ b/src/screens/register/children/registerAccountModal.tsx
@@ -14,6 +14,7 @@ import { Icon, MainButton, Modal, PostCardPlaceHolder, TextButton } from '../../
 import LOGO_ESTM from '../../../assets/esteemcoin_boost.png';
 import ROUTES from '../../../constants/routeNames';
 import TurnstileWebView from './turnstileWebView';
+import { getUsernameError, USERNAME_ERROR_MESSAGE_IDS } from '../../../utils/usernameValidation';
 
 type Props = {
   username: string;
@@ -61,7 +62,27 @@ export const RegisterAccountModal = forwardRef(({ username, email, refUsername }
     openInbox();
   };
 
+  // Last-line guard before either signup path runs. The register screen already
+  // blocks a chain-invalid username, but this modal can also be opened directly
+  // (e.g. the purchaseOnly deep link), so re-check here so a name the blockchain
+  // would reject (the buyer is still charged for the paid path) never reaches the
+  // backend.
+  const _isUsernameCreatable = () => {
+    const errorCode = getUsernameError(_username);
+    if (errorCode) {
+      Alert.alert(
+        intl.formatMessage({ id: 'alert.fail' }),
+        intl.formatMessage({ id: USERNAME_ERROR_MESSAGE_IDS[errorCode] }),
+      );
+      return false;
+    }
+    return true;
+  };
+
   const _handleOnPressRegister = async () => {
+    if (!_isUsernameCreatable()) {
+      return;
+    }
     setIsRegistering(true);
 
     try {
@@ -229,6 +250,9 @@ export const RegisterAccountModal = forwardRef(({ username, email, refUsername }
                   },
                 ),
             onPress: () => {
+              if (!_isUsernameCreatable()) {
+                return;
+              }
               setIsRegistering(true);
               buyItem(product.productId);
             },

--- a/src/screens/register/registerScreen.tsx
+++ b/src/screens/register/registerScreen.tsx
@@ -17,18 +17,7 @@ import { RegisterAccountModal } from './children/registerAccountModal';
 import { ECENCY_TERMS_URL } from '../../config/ecencyApi';
 import { useAppSelector } from '../../hooks';
 import { selectIsConnected } from '../../redux/selectors';
-import { getUsernameError, UsernameValidationError } from '../../utils/usernameValidation';
-
-const USERNAME_ERROR_MESSAGE_IDS: Record<UsernameValidationError, string> = {
-  length: 'register.validation.username_length_error',
-  start_letter: 'register.validation.username_no_ascii_first_letter_error',
-  symbols: 'register.validation.username_contains_symbols_error',
-  double_hyphens: 'register.validation.username_contains_double_hyphens',
-  // reuses the symbols message: a dedicated string would be missing from the
-  // 38 non-en locale files until the next translation sync
-  trailing_hyphen: 'register.validation.username_contains_symbols_error',
-  underscore: 'register.validation.username_contains_underscore',
-};
+import { getUsernameError, USERNAME_ERROR_MESSAGE_IDS } from '../../utils/usernameValidation';
 
 const RegisterScreen = ({ navigation, route }) => {
   const intl = useIntl();

--- a/src/utils/usernameValidation.test.ts
+++ b/src/utils/usernameValidation.test.ts
@@ -1,4 +1,4 @@
-import { getUsernameError } from './usernameValidation';
+import { getUsernameError, USERNAME_ERROR_MESSAGE_IDS } from './usernameValidation';
 
 describe('getUsernameError', () => {
   it('accepts valid usernames', () => {
@@ -34,6 +34,13 @@ describe('getUsernameError', () => {
     expect(getUsernameError('abc.')).toBe('length'); // empty segment
   });
 
+  it('rejects a too-short trailing dot-segment (paid-signup incident)', () => {
+    // A buyer was charged for `bitgethive.uk`: the whole name is 13 chars but the
+    // `uk` segment is only 2, which the blockchain rejects (RFC 1035). The paid
+    // path had no client-side check, so the on-chain create failed after payment.
+    expect(getUsernameError('bitgethive.uk')).toBe('length');
+  });
+
   it('rejects invalid symbols', () => {
     expect(getUsernameError('ab@c')).toBe('symbols');
     expect(getUsernameError('abc!')).toBe('symbols');
@@ -48,5 +55,21 @@ describe('getUsernameError', () => {
   it('rejects double hyphens and underscores', () => {
     expect(getUsernameError('ab--cd')).toBe('double_hyphens');
     expect(getUsernameError('ab_cd')).toBe('underscore');
+  });
+});
+
+describe('USERNAME_ERROR_MESSAGE_IDS', () => {
+  it('maps every validation error code to a register.validation message id', () => {
+    const codes = [
+      'length',
+      'start_letter',
+      'symbols',
+      'double_hyphens',
+      'trailing_hyphen',
+      'underscore',
+    ] as const;
+    codes.forEach((code) => {
+      expect(USERNAME_ERROR_MESSAGE_IDS[code]).toMatch(/^register\.validation\./);
+    });
   });
 });

--- a/src/utils/usernameValidation.ts
+++ b/src/utils/usernameValidation.ts
@@ -10,6 +10,20 @@ export type UsernameValidationError =
   | 'trailing_hyphen'
   | 'underscore';
 
+// Maps a validation error to its react-intl message id. Kept beside the rule so
+// every place that blocks a chain-invalid username (the register form AND the
+// paid-account purchase) surfaces the same localized reason from one source.
+export const USERNAME_ERROR_MESSAGE_IDS: Record<UsernameValidationError, string> = {
+  length: 'register.validation.username_length_error',
+  start_letter: 'register.validation.username_no_ascii_first_letter_error',
+  symbols: 'register.validation.username_contains_symbols_error',
+  double_hyphens: 'register.validation.username_contains_double_hyphens',
+  // reuses the symbols message: a dedicated string would be missing from the
+  // 38 non-en locale files until the next translation sync
+  trailing_hyphen: 'register.validation.username_contains_symbols_error',
+  underscore: 'register.validation.username_contains_underscore',
+};
+
 const getSegmentError = (segment: string): UsernameValidationError | null => {
   if (segment.length < 3) {
     return 'length';


### PR DESCRIPTION
## Problem

The paid-account (IAP) signup path had no client-side username validation. A username the blockchain rejects under RFC 1035 (for example a dot-segment shorter than 3 characters, like `name.uk`) could be paid for, then fail on-chain account creation, leaving the buyer charged with no account and no keys.

The free signup path is validated server-side, and the register form already blocks invalid names, but neither covers the IAP purchase trigger, and the modal can be opened directly via the `purchaseOnly` deep link.

## Fix

- Move `USERNAME_ERROR_MESSAGE_IDS` into `usernameValidation` so the form and the purchase flow share one source of truth.
- `RegisterAccountModal`: re-check the username before both the free signup and the IAP purchase.
- `InAppPurchaseContainer`:
  - `_buyItem` refuses to start a `999accounts` charge for an invalid username.
  - `_consumePurchase` refuses to post a `999accounts` order with an invalid username (covers the recovery/listener path), so a doomed name is never recorded server-side. A name charged on an older build is left unconsumed to be auto-refunded rather than charged for an account that can never be created.

## Tests

`usernameValidation.test.ts` adds the incident case (`name.uk`-style short segment) and asserts every error code maps to a `register.validation.*` message id. Existing suite still passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved username checks during registration and account purchase so invalid usernames are blocked earlier.
  * Prevented purchases from being charged or recorded when the username can’t be created, reducing failed or stuck purchases.
  * Added clearer, localized error messages for username validation issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->