### PR TITLE
chore: bump @ecency/render-helper to 2.5.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@babel/preset-typescript": "^7.26.0",
     "@babel/runtime": "^7.26.7",
-    "@ecency/render-helper": "^2.5.14",
+    "@ecency/render-helper": "^2.5.15",
     "@ecency/sdk": "^2.3.24",
     "@esteemapp/react-native-autocomplete-input": "^4.2.1",
     "@esteemapp/react-native-multi-slider": "^1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1192,10 +1192,10 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@ecency/render-helper@^2.5.14":
-  version "2.5.14"
-  resolved "https://registry.yarnpkg.com/@ecency/render-helper/-/render-helper-2.5.14.tgz#d28b8d341e80a998d656cd7e38ec9491664c280a"
-  integrity sha512-hjeUP9EdUonpYWeaQ0XzJhHbMoA9XQSJsn638q7qbwq06chSaYfs169Rf7cig0KhjEmpFEno2R8krtVqeqEG5Q==
+"@ecency/render-helper@^2.5.15":
+  version "2.5.15"
+  resolved "https://registry.yarnpkg.com/@ecency/render-helper/-/render-helper-2.5.15.tgz#393ab93eb421a26b8e2d5255207c61a8b2be90c8"
+  integrity sha512-m5/fqC4R7s2+4vsO5YeBWOtl08fcnbqi/moJR7eV8b5MJPOJAxiVqzMBB2EAm2LwDTh7YLBAF2JO9JQDodpfoQ==
   dependencies:
     "@xmldom/xmldom" "^0.9.10"
     dom-serializer "^2.0.0"


### PR DESCRIPTION
Bumps `@ecency/render-helper` from 2.5.14 to 2.5.15 so the mobile app picks up the recent autoplay fix: Skatehive IPFS videos in waves now render as a controlled `<video>` element instead of an autoplaying iframe media document.

- `package.json`: `^2.5.14` → `^2.5.15`
- `yarn.lock`: updated the render-helper entry (version/resolved/integrity). Dependency set is identical between 2.5.14 and 2.5.15, so no other lockfile changes.

Patch bump, no API changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a dependency to the latest patch version, with no expected changes to app behavior or settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->