### PR TITLE
feat(waves): show Ecency source badge on wave header

### DIFF
--- a/src/components/comment/view/commentView.tsx
+++ b/src/components/comment/view/commentView.tsx
@@ -353,6 +353,7 @@ const CommentView = ({
   // Ecency client (e.g. ecency/x-vision, ecency.waves, ecency-mobile). Mirrors
   // the web wave badge; only an explicit "ecency" app matches (not a missing app).
   const isFromEcency = String(comment.json_metadata?.app || '')
+    .split('/')[0]
     .toLowerCase()
     .includes('ecency');
 

--- a/src/components/comment/view/commentView.tsx
+++ b/src/components/comment/view/commentView.tsx
@@ -349,6 +349,13 @@ const CommentView = ({
     [_depth],
   );
 
+  // Show the Ecency source badge when the wave/comment was published from an
+  // Ecency client (e.g. ecency/x-vision, ecency.waves, ecency-mobile). Mirrors
+  // the web wave badge; only an explicit "ecency" app matches (not a missing app).
+  const isFromEcency = String(comment.json_metadata?.app || '')
+    .toLowerCase()
+    .includes('ecency');
+
   return (
     <Fragment key={comment.permlink}>
       <View style={{ ...styles.commentContainer, ...customContainerStyle }}>
@@ -363,6 +370,7 @@ const CommentView = ({
           isShowPromotedIndicator={comment.is_promoted}
           isHideImage={isHideImage}
           inlineTime={true}
+          isFromEcency={isFromEcency}
           customStyle={{ alignItems: 'flex-start', paddingLeft: 12 }}
           showDotMenuButton={true}
           handleOnDotPress={() => handleOnMenuPress(comment)}

--- a/src/components/postElements/headerDescription/view/postHeaderDescription.tsx
+++ b/src/components/postElements/headerDescription/view/postHeaderDescription.tsx
@@ -1,5 +1,5 @@
 import React, { PureComponent } from 'react';
-import { View, Text, TouchableOpacity } from 'react-native';
+import { View, Text, TouchableOpacity, Image } from 'react-native';
 import { injectIntl } from 'react-intl';
 
 // Components
@@ -15,6 +15,7 @@ import RootNavigation from '../../../../navigation/rootNavigation';
 
 // Constants
 import DEFAULT_IMAGE from '../../../../assets/ecency.png';
+import ECENCY_LOGO from '../../../../assets/ecency-logo-round.png';
 
 class PostHeaderDescription extends PureComponent {
   // Component Life Cycles
@@ -124,6 +125,7 @@ class PostHeaderDescription extends PureComponent {
       isPromoted,
       intl,
       inlineTime,
+      isFromEcency,
       customStyle,
       secondaryContentComponent,
       showDotMenuButton,
@@ -158,6 +160,8 @@ class PostHeaderDescription extends PureComponent {
               </TouchableOpacity>
 
               {inlineTime && <Text style={styles.date}>{date}</Text>}
+
+              {isFromEcency && <Image source={ECENCY_LOGO} style={styles.ecencySourceBadge} />}
 
               {isShowOwnerIndicator && (
                 <Icon style={styles.ownerIndicator} name="stars" iconType="MaterialIcons" />

--- a/src/components/postElements/headerDescription/view/postHeaderDescription.tsx
+++ b/src/components/postElements/headerDescription/view/postHeaderDescription.tsx
@@ -161,7 +161,9 @@ class PostHeaderDescription extends PureComponent {
 
               {inlineTime && <Text style={styles.date}>{date}</Text>}
 
-              {isFromEcency && <Image source={ECENCY_LOGO} style={styles.ecencySourceBadge} />}
+              {inlineTime && isFromEcency && (
+                <Image source={ECENCY_LOGO} style={styles.ecencySourceBadge} />
+              )}
 
               {isShowOwnerIndicator && (
                 <Icon style={styles.ownerIndicator} name="stars" iconType="MaterialIcons" />

--- a/src/components/postElements/headerDescription/view/postHeaderDescriptionStyles.ts
+++ b/src/components/postElements/headerDescription/view/postHeaderDescriptionStyles.ts
@@ -85,6 +85,12 @@ export default EStyleSheet.create({
     marginLeft: 10,
     alignSelf: 'center',
   },
+  ecencySourceBadge: {
+    width: 12,
+    height: 12,
+    marginLeft: 6,
+    alignSelf: 'center',
+  },
   ownerIndicator: {
     color: '$primaryBlue',
     alignSelf: 'center',


### PR DESCRIPTION
Mirrors the web wave badge on mobile. When a wave was published from an Ecency client (its `json_metadata.app` contains "ecency"), a small Ecency logo is shown next to the timestamp in the wave header, so it's easy to spot which content originated from Ecency.

- Reuses the existing `ecency-logo-round.png` asset and the same badge style already used on the post view (`postDisplayView`).
- `PostHeaderDescription` gains an optional `isFromEcency` prop (default off, so other callers are unaffected); `commentView` computes it from the wave's app metadata and passes it.
- Detection requires an explicit "ecency" app string (e.g. `ecency/x-vision`, `ecency.waves`, `ecency-mobile`), so other clients like `skatehive-mobile` are not badged.

Note: the wave header component (`PostHeaderDescription` via `commentView`) is shared with comment threads, so Ecency-published comments will show the badge too, which is consistent with the "published via Ecency" intent. ESLint/prettier clean; no new warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Ecency source badge to comment/post headers for content published from Ecency clients.
* **UI Updates**
  * Displayed a small Ecency icon next to the time/date in the header for eligible content.
  * Improved Ecency detection by reading app metadata case-insensitively.
  * Added badge styling for consistent size and alignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->