### PR TITLE
fix(waves): optimistic vote count on populous waves + bump @ecency/sdk to 2.3.25

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@babel/preset-typescript": "^7.26.0",
     "@babel/runtime": "^7.26.7",
     "@ecency/render-helper": "^2.5.15",
-    "@ecency/sdk": "^2.3.24",
+    "@ecency/sdk": "^2.3.25",
     "@esteemapp/react-native-autocomplete-input": "^4.2.1",
     "@esteemapp/react-native-multi-slider": "^1.1.0",
     "@native-html/iframe-plugin": "^2.6.1",

--- a/src/providers/queries/postQueries/voteCacheUtils.test.ts
+++ b/src/providers/queries/postQueries/voteCacheUtils.test.ts
@@ -55,6 +55,46 @@ describe('applyVoteToPost net_votes (custom waves feed)', () => {
     expect(result.active_votes).toHaveLength(0);
   });
 
+  it('decrements net_votes for a new downvote on a feed wave', () => {
+    const wave = {
+      author: 'alice',
+      permlink: 'wave-1',
+      net_votes: 29,
+      pending_payout_value: '5.000 HBD',
+    };
+
+    const result = applyVoteToPost(wave, {
+      ...upvote,
+      isDownvote: true,
+      rshares: -100,
+      percent: -5000,
+    });
+
+    // net_votes is net (up - down), so a downvote moves the count down.
+    expect(result.net_votes).toBe(28);
+    expect(result.isDownVoted).toBe(true);
+  });
+
+  it('increments net_votes when removing a downvote', () => {
+    const wave = {
+      author: 'alice',
+      permlink: 'wave-1',
+      net_votes: 28,
+      active_votes: [{ voter: 'dave', rshares: -100, percent: -5000, amount: 0 }],
+    };
+
+    const result = applyVoteToPost(wave, {
+      ...upvote,
+      status: 'DELETED',
+      rshares: 0,
+      percent: 0,
+      amount: 0,
+    });
+
+    expect(result.net_votes).toBe(29);
+    expect(result.active_votes).toHaveLength(0);
+  });
+
   it('does not change net_votes when re-weighting an existing vote', () => {
     const wave = {
       author: 'alice',

--- a/src/providers/queries/postQueries/voteCacheUtils.test.ts
+++ b/src/providers/queries/postQueries/voteCacheUtils.test.ts
@@ -1,0 +1,86 @@
+import { applyVoteToPost, VoteCacheEntry } from './voteCacheUtils';
+
+// voteCacheUtils imports getQueryClient from the queries barrel at module load;
+// stub it so this unit test doesn't pull in the heavy query/provider graph.
+jest.mock('../index', () => ({ getQueryClient: jest.fn() }));
+
+const upvote: VoteCacheEntry = {
+  amount: 0.012,
+  isDownvote: false,
+  rshares: 100,
+  percent: 5000,
+  incrementStep: 0,
+  voter: 'dave',
+  votedAt: 0,
+  status: 'PUBLISHED',
+};
+
+describe('applyVoteToPost net_votes (custom waves feed)', () => {
+  it('increments net_votes for a feed wave with no active_votes/stats', () => {
+    const wave = {
+      author: 'alice',
+      permlink: 'wave-1',
+      net_votes: 29,
+      pending_payout_value: '0.000 HBD',
+    };
+
+    const result = applyVoteToPost(wave, upvote);
+
+    // Count ticks up optimistically instead of staying pinned at 29.
+    expect(result.net_votes).toBe(30);
+    expect(result.active_votes).toHaveLength(1);
+    expect(result.isUpVoted).toBe(true);
+    // Payout string is bumped by the estimated amount as well.
+    expect(result.pending_payout_value).toBe('0.012 HBD');
+  });
+
+  it('decrements net_votes on unvote when the voter is in active_votes', () => {
+    const wave = {
+      author: 'alice',
+      permlink: 'wave-1',
+      net_votes: 30,
+      active_votes: [{ voter: 'dave', rshares: 100, percent: 5000, amount: 0.012 }],
+      pending_payout_value: '0.012 HBD',
+    };
+
+    const result = applyVoteToPost(wave, {
+      ...upvote,
+      status: 'DELETED',
+      rshares: 0,
+      percent: 0,
+      amount: 0,
+    });
+
+    expect(result.net_votes).toBe(29);
+    expect(result.active_votes).toHaveLength(0);
+  });
+
+  it('does not change net_votes when re-weighting an existing vote', () => {
+    const wave = {
+      author: 'alice',
+      permlink: 'wave-1',
+      net_votes: 30,
+      active_votes: [{ voter: 'dave', rshares: 100, percent: 5000, amount: 0.01 }],
+    };
+
+    const result = applyVoteToPost(wave, { ...upvote, rshares: 200, percent: 10000, amount: 0.02 });
+
+    expect(result.net_votes).toBe(30);
+    expect(result.active_votes).toHaveLength(1);
+  });
+
+  it('leaves net_votes untouched when the post does not carry it', () => {
+    const post = {
+      author: 'alice',
+      permlink: 'p',
+      active_votes: [{ voter: 'bob', rshares: 50, percent: 5000, amount: 0.005 }],
+      stats: { total_votes: 1 },
+    };
+
+    const result = applyVoteToPost(post, upvote);
+
+    expect(result.net_votes).toBeUndefined();
+    // The existing stats-based count path is unaffected.
+    expect(result.stats.total_votes).toBe(2);
+  });
+});

--- a/src/providers/queries/postQueries/voteCacheUtils.ts
+++ b/src/providers/queries/postQueries/voteCacheUtils.ts
@@ -199,10 +199,11 @@ export function applyVoteToPost(post: any, vote: VoteCacheEntry): any {
     if (post.stats) {
       cloned.stats = { ...post.stats, total_votes: cloned.active_votes.length };
     }
-    // Custom waves feeds carry net_votes but no active_votes/stats; mirror the
-    // removal in net_votes so the displayed count ticks down optimistically.
+    // Custom waves feeds carry net_votes but no active_votes/stats; net_votes is
+    // Hive's net (upvotes - downvotes). Removing an upvote lowers it; removing a
+    // downvote raises it, so mirror the removed vote's direction.
     if (typeof post.net_votes === 'number') {
-      cloned.net_votes = Math.max(0, post.net_votes - 1);
+      cloned.net_votes = wasDownvote ? post.net_votes + 1 : Math.max(0, post.net_votes - 1);
     }
     return cloned;
   }
@@ -223,12 +224,13 @@ export function applyVoteToPost(post: any, vote: VoteCacheEntry): any {
     if (post.stats) {
       cloned.stats = { ...post.stats, total_votes: cloned.active_votes.length };
     }
-    // Custom waves feeds carry net_votes but no active_votes/stats; bump it so
-    // the displayed count (which takes Math.max(activeVotes.length, net_votes))
-    // ticks up optimistically instead of staying pinned to the stale net_votes
-    // for an already-populous wave (e.g. 29 -> 30 rather than staying 29).
-    if (typeof post.net_votes === 'number') {
-      cloned.net_votes = post.net_votes + 1;
+    // Custom waves feeds carry net_votes but no active_votes/stats; net_votes is
+    // Hive's net (upvotes - downvotes), which commentView falls back to as the
+    // count. Move it by the vote direction so an already-populous wave ticks the
+    // right way immediately (e.g. an upvote 29 -> 30) instead of staying pinned
+    // to the stale value until refetch.
+    if (typeof post.net_votes === 'number' && vote.rshares !== 0) {
+      cloned.net_votes = post.net_votes + (vote.rshares > 0 ? 1 : -1);
     }
     return cloned;
   }

--- a/src/providers/queries/postQueries/voteCacheUtils.ts
+++ b/src/providers/queries/postQueries/voteCacheUtils.ts
@@ -176,7 +176,7 @@ function updateDiscussionMap(
  * Applies vote data to a post/comment object.
  * Works with both raw API data and parsed post data.
  */
-function applyVoteToPost(post: any, vote: VoteCacheEntry): any {
+export function applyVoteToPost(post: any, vote: VoteCacheEntry): any {
   const activeVotes = Array.isArray(post.active_votes) ? post.active_votes : [];
   const voteIdx = activeVotes.findIndex((v: any) => v.voter === vote.voter);
 
@@ -199,6 +199,11 @@ function applyVoteToPost(post: any, vote: VoteCacheEntry): any {
     if (post.stats) {
       cloned.stats = { ...post.stats, total_votes: cloned.active_votes.length };
     }
+    // Custom waves feeds carry net_votes but no active_votes/stats; mirror the
+    // removal in net_votes so the displayed count ticks down optimistically.
+    if (typeof post.net_votes === 'number') {
+      cloned.net_votes = Math.max(0, post.net_votes - 1);
+    }
     return cloned;
   }
 
@@ -217,6 +222,13 @@ function applyVoteToPost(post: any, vote: VoteCacheEntry): any {
     cloned.isDownVoted = vote.rshares < 0;
     if (post.stats) {
       cloned.stats = { ...post.stats, total_votes: cloned.active_votes.length };
+    }
+    // Custom waves feeds carry net_votes but no active_votes/stats; bump it so
+    // the displayed count (which takes Math.max(activeVotes.length, net_votes))
+    // ticks up optimistically instead of staying pinned to the stale net_votes
+    // for an already-populous wave (e.g. 29 -> 30 rather than staying 29).
+    if (typeof post.net_votes === 'number') {
+      cloned.net_votes = post.net_votes + 1;
     }
     return cloned;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1211,10 +1211,10 @@
     url "^0.11.0"
     xss "^1.0.9"
 
-"@ecency/sdk@^2.3.24":
-  version "2.3.24"
-  resolved "https://registry.yarnpkg.com/@ecency/sdk/-/sdk-2.3.24.tgz#5a769f1091b00dd3163d6cdd4eded2ba1bd5c69d"
-  integrity sha512-25K5edzI/9Yppmcr8vrU9QiypcLWxumuuw468lVVUGwsA8eyS86ReKDaRPFQk5rOWmMuJ32nz2XwznyWRpdIWA==
+"@ecency/sdk@^2.3.25":
+  version "2.3.25"
+  resolved "https://registry.yarnpkg.com/@ecency/sdk/-/sdk-2.3.25.tgz#13440efa19b4b4587cac44b6d47556dda8872ab6"
+  integrity sha512-cQ3mtxWEWkRzhDH2fDoPcKsVDP8teZgBwTgM0gngIhk6ecoMeL0CdHuH0nygDJHSODoSyEYPHtzn3awWzW1vpQ==
   dependencies:
     "@noble/ciphers" "^2.1.1"
     "@noble/curves" "^2.0.1"


### PR DESCRIPTION
Follow-up to the web fix (vision-next #1016) for the unified waves feed.

## Optimistic vote count on already-populous waves
The unified waves feed returns lightweight rows with a `net_votes` count but no `active_votes` array. `applyVoteToPost` only appended to the (newly created) `active_votes` list and updated payout, but never touched `net_votes`. Since `commentView` derives the displayed count as `Math.max(activeVotes.length, net_votes)`, an optimistic vote on a wave that already had votes (e.g. 29) left the count pinned at 29 until the feed refetched.

Now `applyVoteToPost` adjusts `net_votes` by the vote delta (+1 on a new vote, -1 on unvote), so the count ticks up/down immediately. Payout and the upvote-button state already updated optimistically; this brings the count to parity with them and with the web client.

Adds a focused unit test for the `net_votes` adjustment.

## Bump @ecency/sdk 2.3.24 -> 2.3.25
Picks up the fragment (snippets) add/edit cache fix: the SDK mutations now rebuild the cache entry from the submitted title/body instead of writing the minimal server acknowledgement, so an edited snippet can't go blank.

## Test / checks
- `yarn lint` and `yarn test:ci` pass for the changed files (new test: 4 cases).
- Lockfile updated for the SDK bump (deps unchanged between 2.3.24 and 2.3.25).