### PR TITLE
Block exchange-like and uid-numeric usernames at signup

### DIFF
--- a/src/config/locales/ar-SA.json
+++ b/src/config/locales/ar-SA.json
@@ -999,6 +999,8 @@
       "username_contains_symbols_error": "يجب أن تحتوي على أحرف وأرقام وواصلة فقط",
       "username_no_ascii_first_letter_error": "يجب أن يبدأ بحرف",
       "username_contains_double_hyphens": "يجب ألا تحتوي على واصلات مزدوجة",
+      "username_resembles_exchange": "This username is too similar to a crypto exchange account and may confuse others. Please choose a more unique name.",
+      "username_restricted_prefix": "Usernames that start with 'uid' followed by numbers are not allowed, as they are commonly used to impersonate others. Please choose a different name.",
       "username_contains_underscore": "يجب ألا تحتوي على شرطة سفلية"
     },
     "500_error": "تعذر معالجة طلبك، قائمة انتظار التسجيل ممتلئة! حاول مرة أخرى في بضع دقائق...",

--- a/src/config/locales/az-AZ.json
+++ b/src/config/locales/az-AZ.json
@@ -999,6 +999,8 @@
       "username_contains_symbols_error": "Yalnız hərflər, rəqəmlər və defis ehtiva etməlidir",
       "username_no_ascii_first_letter_error": "Hərflə başlamalıdır",
       "username_contains_double_hyphens": "İkiqat defis ehtiva etməməlidir",
+      "username_resembles_exchange": "This username is too similar to a crypto exchange account and may confuse others. Please choose a more unique name.",
+      "username_restricted_prefix": "Usernames that start with 'uid' followed by numbers are not allowed, as they are commonly used to impersonate others. Please choose a different name.",
       "username_contains_underscore": "Alt xətt ehtiva etməməlidir"
     },
     "500_error": "Sorğunuz emal edilə bilmədi, qeydiyyat növbəsi çox güman ki, doludur! Bir neçə dəqiqədən sonra yenidən cəhd edin...",

--- a/src/config/locales/bg-BG.json
+++ b/src/config/locales/bg-BG.json
@@ -999,6 +999,8 @@
       "username_contains_symbols_error": "Трябва да съдържа само букви, цифри и тире",
       "username_no_ascii_first_letter_error": "Трябва да започва с буква",
       "username_contains_double_hyphens": "Не трябва да съдържа двойни тирета",
+      "username_resembles_exchange": "This username is too similar to a crypto exchange account and may confuse others. Please choose a more unique name.",
+      "username_restricted_prefix": "Usernames that start with 'uid' followed by numbers are not allowed, as they are commonly used to impersonate others. Please choose a different name.",
       "username_contains_underscore": "Не трябва да съдържа долна черта"
     },
     "500_error": "Заявката ви не можа да бъде обработена, опашката за регистрация вероятно е пълна! Опитайте отново след няколко минути ...",

--- a/src/config/locales/bn-BD.json
+++ b/src/config/locales/bn-BD.json
@@ -999,6 +999,8 @@
       "username_contains_symbols_error": "শুধুমাত্র অক্ষর, সংখ্যা, হাইফেন থাকা উচিত",
       "username_no_ascii_first_letter_error": "একটি অক্ষর দিয়ে শুরু হওয়া উচিত",
       "username_contains_double_hyphens": "দ্বৈত হাইফেন থাকা উচিত নয়",
+      "username_resembles_exchange": "This username is too similar to a crypto exchange account and may confuse others. Please choose a more unique name.",
+      "username_restricted_prefix": "Usernames that start with 'uid' followed by numbers are not allowed, as they are commonly used to impersonate others. Please choose a different name.",
       "username_contains_underscore": "আন্ডারস্কোর থাকা উচিত নয়"
     },
     "500_error": "আপনার অনুরোধটি প্রক্রিয়া করা যায়নি, সাইনআপ সারি সম্ভবত পূর্ণ! কয়েক মিনিটের মধ্যে আবার চেষ্টা করুন ...",

--- a/src/config/locales/cs-CZ.json
+++ b/src/config/locales/cs-CZ.json
@@ -999,6 +999,8 @@
       "username_contains_symbols_error": "Mělo by obsahovat pouze písmena, čísla a pomlčky",
       "username_no_ascii_first_letter_error": "Musí začínat písmenem",
       "username_contains_double_hyphens": "Nemělo by obsahovat dvojité pomlčky",
+      "username_resembles_exchange": "This username is too similar to a crypto exchange account and may confuse others. Please choose a more unique name.",
+      "username_restricted_prefix": "Usernames that start with 'uid' followed by numbers are not allowed, as they are commonly used to impersonate others. Please choose a different name.",
       "username_contains_underscore": "Nemělo by obsahovat podtržítko"
     },
     "500_error": "Váš požadavek nebylo možné zpracovat, fronta registrací je pravděpodobně plná! Zkuste to znovu za pár minut...",

--- a/src/config/locales/da-DK.json
+++ b/src/config/locales/da-DK.json
@@ -999,6 +999,8 @@
       "username_contains_symbols_error": "Må kun indeholde bogstaver, tal og bindestreg",
       "username_no_ascii_first_letter_error": "Skal starte med et bogstav",
       "username_contains_double_hyphens": "Må ikke indeholde dobbelte bindestreger",
+      "username_resembles_exchange": "This username is too similar to a crypto exchange account and may confuse others. Please choose a more unique name.",
+      "username_restricted_prefix": "Usernames that start with 'uid' followed by numbers are not allowed, as they are commonly used to impersonate others. Please choose a different name.",
       "username_contains_underscore": "Må ikke indeholde understregningstegn"
     },
     "500_error": "Din anmodning kunne ikke behandles, tilmeldingskøen er sandsynligvis fuld! Prøv igen om et par minutter...",

--- a/src/config/locales/de-DE.json
+++ b/src/config/locales/de-DE.json
@@ -999,6 +999,8 @@
       "username_contains_symbols_error": "Sollte nur Buchstaben, Zahlen und Bindestriche enthalten",
       "username_no_ascii_first_letter_error": "Sollte mit einem Buchstaben beginnen",
       "username_contains_double_hyphens": "Sollte keine doppelten Bindestriche enthalten",
+      "username_resembles_exchange": "This username is too similar to a crypto exchange account and may confuse others. Please choose a more unique name.",
+      "username_restricted_prefix": "Usernames that start with 'uid' followed by numbers are not allowed, as they are commonly used to impersonate others. Please choose a different name.",
       "username_contains_underscore": "Sollte keinen Unterstrich enthalten"
     },
     "500_error": "Ihre Anfrage konnte nicht verarbeitet werden, die Anmeldewarteschlange ist wahrscheinlich voll! Versuchen Sie es in wenigen Minuten noch einmal...",

--- a/src/config/locales/el-GR.json
+++ b/src/config/locales/el-GR.json
@@ -999,6 +999,8 @@
       "username_contains_symbols_error": "Πρέπει να περιέχει μόνο γράμματα, αριθμούς, παύλα",
       "username_no_ascii_first_letter_error": "Πρέπει να ξεκινά με γράμμα",
       "username_contains_double_hyphens": "Δεν πρέπει να περιέχει διπλές παύλες",
+      "username_resembles_exchange": "This username is too similar to a crypto exchange account and may confuse others. Please choose a more unique name.",
+      "username_restricted_prefix": "Usernames that start with 'uid' followed by numbers are not allowed, as they are commonly used to impersonate others. Please choose a different name.",
       "username_contains_underscore": "Δεν πρέπει να περιέχει κάτω παύλα"
     },
     "500_error": "Το αίτημά σας δεν ήταν δυνατό να επεξεργαστεί, η ουρά εγγραφών είναι πιθανότατα γεμάτη! Δοκιμάστε ξανά σε λίγα λεπτά...",

--- a/src/config/locales/en-US.json
+++ b/src/config/locales/en-US.json
@@ -1022,6 +1022,8 @@
       "username_contains_symbols_error": "Should contain letters, numbers, hyphen only",
       "username_no_ascii_first_letter_error": "Should start with a letter",
       "username_contains_double_hyphens": "Should not contain double hyphens",
+      "username_resembles_exchange": "This username is too similar to a crypto exchange account and may confuse others. Please choose a more unique name.",
+      "username_restricted_prefix": "Usernames that start with 'uid' followed by numbers are not allowed, as they are commonly used to impersonate others. Please choose a different name.",
       "username_contains_underscore": "Should not contain underscore"
     },
     "500_error": "Your request could not be processed, signup queue is likely full! Try again in few minutes...",

--- a/src/config/locales/es-ES.json
+++ b/src/config/locales/es-ES.json
@@ -999,6 +999,8 @@
       "username_contains_symbols_error": "Sólo debe contener letras, números, símbolos",
       "username_no_ascii_first_letter_error": "Debe empezar con una letra",
       "username_contains_double_hyphens": "No debe contener Signos de Puntuación dobles",
+      "username_resembles_exchange": "This username is too similar to a crypto exchange account and may confuse others. Please choose a more unique name.",
+      "username_restricted_prefix": "Usernames that start with 'uid' followed by numbers are not allowed, as they are commonly used to impersonate others. Please choose a different name.",
       "username_contains_underscore": "No debe contener subrayado"
     },
     "500_error": "Su solicitud no pudo ser procesada, ¡la cola de registro probablemente está llena! Inténtelo de nuevo en unos minutos...",

--- a/src/config/locales/et-EE.json
+++ b/src/config/locales/et-EE.json
@@ -999,6 +999,8 @@
       "username_contains_symbols_error": "Tohib sisaldada ainult tähti, numbreid ja sidekriipsu",
       "username_no_ascii_first_letter_error": "Peab algama tähega",
       "username_contains_double_hyphens": "Ei tohi sisaldada topeltsidekriipse",
+      "username_resembles_exchange": "This username is too similar to a crypto exchange account and may confuse others. Please choose a more unique name.",
+      "username_restricted_prefix": "Usernames that start with 'uid' followed by numbers are not allowed, as they are commonly used to impersonate others. Please choose a different name.",
       "username_contains_underscore": "Ei tohi sisaldada alakriipsu"
     },
     "500_error": "Toiming ebaõnnestus, registreerumise järjekord on täis! Proovi uuesti mõne minuti pärast...",

--- a/src/config/locales/fa-IR.json
+++ b/src/config/locales/fa-IR.json
@@ -999,6 +999,8 @@
       "username_contains_symbols_error": "باید فقط شامل حروف، اعداد و خط تیره باشد",
       "username_no_ascii_first_letter_error": "باید با یک حرف شروع شود",
       "username_contains_double_hyphens": "نباید شامل خط تیره دوتایی باشد",
+      "username_resembles_exchange": "This username is too similar to a crypto exchange account and may confuse others. Please choose a more unique name.",
+      "username_restricted_prefix": "Usernames that start with 'uid' followed by numbers are not allowed, as they are commonly used to impersonate others. Please choose a different name.",
       "username_contains_underscore": "نباید شامل خط زیر باشد"
     },
     "500_error": "درخواست شما پردازش نشد ، صف ثبت نام احتمالاً پر است! چند دقیقه دیگر دوباره امتحان کنید...",

--- a/src/config/locales/fi-FI.json
+++ b/src/config/locales/fi-FI.json
@@ -999,6 +999,8 @@
       "username_contains_symbols_error": "Tulisi sisältää vain kirjaimia, numeroita ja tavuviivoja",
       "username_no_ascii_first_letter_error": "Tulee alkaa kirjaimella",
       "username_contains_double_hyphens": "Ei kaksinkertaisia tavuviivoja",
+      "username_resembles_exchange": "This username is too similar to a crypto exchange account and may confuse others. Please choose a more unique name.",
+      "username_restricted_prefix": "Usernames that start with 'uid' followed by numbers are not allowed, as they are commonly used to impersonate others. Please choose a different name.",
       "username_contains_underscore": "Ei alaviivoja"
     },
     "500_error": "Toiminto epäonnistui, rekisteröitymisjono lienee täynnä! Yritä uudelleen parin minuutin päästä...",

--- a/src/config/locales/fil-PH.json
+++ b/src/config/locales/fil-PH.json
@@ -999,6 +999,8 @@
       "username_contains_symbols_error": "Dapat maglaman lamang ng mga titik, numero, at gitling",
       "username_no_ascii_first_letter_error": "Dapat magsimula sa isang letra",
       "username_contains_double_hyphens": "Hindi dapat maglaman ng dobleng gitling",
+      "username_resembles_exchange": "This username is too similar to a crypto exchange account and may confuse others. Please choose a more unique name.",
+      "username_restricted_prefix": "Usernames that start with 'uid' followed by numbers are not allowed, as they are commonly used to impersonate others. Please choose a different name.",
       "username_contains_underscore": "Hindi dapat maglaman ng underscore"
     },
     "500_error": "Ang iyong request ay hindi maproseso, ang pila ng pagsali ay maaaring puno na! Subukan ulit nang ilang minuto...",

--- a/src/config/locales/fr-FR.json
+++ b/src/config/locales/fr-FR.json
@@ -999,6 +999,8 @@
       "username_contains_symbols_error": "Ne doit contenir que des lettres, des chiffres et des traits d'union",
       "username_no_ascii_first_letter_error": "Doit commencer par une lettre",
       "username_contains_double_hyphens": "Ne doit pas contenir de doubles traits d'union",
+      "username_resembles_exchange": "This username is too similar to a crypto exchange account and may confuse others. Please choose a more unique name.",
+      "username_restricted_prefix": "Usernames that start with 'uid' followed by numbers are not allowed, as they are commonly used to impersonate others. Please choose a different name.",
       "username_contains_underscore": "Ne doit pas contenir de trait de soulignement"
     },
     "500_error": "Votre demande n’a pas pu être traitée, la file d’inscription est probablement pleine ! Réessayez dans quelques minutes...",

--- a/src/config/locales/he-IL.json
+++ b/src/config/locales/he-IL.json
@@ -999,6 +999,8 @@
       "username_contains_symbols_error": "צריך להכיל אותיות, מספרים ומקף בלבד",
       "username_no_ascii_first_letter_error": "חייב להתחיל באות",
       "username_contains_double_hyphens": "אסור שיכיל מקף כפול",
+      "username_resembles_exchange": "This username is too similar to a crypto exchange account and may confuse others. Please choose a more unique name.",
+      "username_restricted_prefix": "Usernames that start with 'uid' followed by numbers are not allowed, as they are commonly used to impersonate others. Please choose a different name.",
       "username_contains_underscore": "אסור שיכיל קו תחתון"
     },
     "500_error": "לא ניתן היה לעבד את בקשתך, ייתכן שתור ההרשמה מלא! נסה שוב בעוד מספר דקות...",

--- a/src/config/locales/hi-IN.json
+++ b/src/config/locales/hi-IN.json
@@ -999,6 +999,8 @@
       "username_contains_symbols_error": "केवल अक्षर, अंक, हाइफ़न होना चाहिए",
       "username_no_ascii_first_letter_error": "किसी अक्षर से शुरू होना चाहिए",
       "username_contains_double_hyphens": "डबल हाइफ़न नहीं होना चाहिए",
+      "username_resembles_exchange": "This username is too similar to a crypto exchange account and may confuse others. Please choose a more unique name.",
+      "username_restricted_prefix": "Usernames that start with 'uid' followed by numbers are not allowed, as they are commonly used to impersonate others. Please choose a different name.",
       "username_contains_underscore": "अंडरस्कोर नहीं होना चाहिए"
     },
     "500_error": "आपके अनुरोध को संसाधित नहीं किया जा सका, साइनअप कतार पूर्ण होने की संभावना है! कुछ मिनटों में पुन: प्रयास करें...",

--- a/src/config/locales/hu-HU.json
+++ b/src/config/locales/hu-HU.json
@@ -999,6 +999,8 @@
       "username_contains_symbols_error": "Csak betűket, számokat és kötőjelet tartalmazhat",
       "username_no_ascii_first_letter_error": "Betűvel kell kezdődnie",
       "username_contains_double_hyphens": "Nem tartalmazhat dupla kötőjelet",
+      "username_resembles_exchange": "This username is too similar to a crypto exchange account and may confuse others. Please choose a more unique name.",
+      "username_restricted_prefix": "Usernames that start with 'uid' followed by numbers are not allowed, as they are commonly used to impersonate others. Please choose a different name.",
       "username_contains_underscore": "Nem tartalmazhat aláhúzásjelet"
     },
     "500_error": "Kérésedet nem sikerült feldolgozni, a regisztrációs sor valószínűleg megtelt! Próbálkozzon újra néhány perc múlva...",

--- a/src/config/locales/id-ID.json
+++ b/src/config/locales/id-ID.json
@@ -999,6 +999,8 @@
       "username_contains_symbols_error": "Hanya boleh berisi huruf, angka, dan tanda hubung",
       "username_no_ascii_first_letter_error": "Harus diawali dengan huruf",
       "username_contains_double_hyphens": "Tidak boleh mengandung tanda hubung ganda",
+      "username_resembles_exchange": "This username is too similar to a crypto exchange account and may confuse others. Please choose a more unique name.",
+      "username_restricted_prefix": "Usernames that start with 'uid' followed by numbers are not allowed, as they are commonly used to impersonate others. Please choose a different name.",
       "username_contains_underscore": "Tidak boleh mengandung garis bawah"
     },
     "500_error": "Permintaan Anda tidak dapat diproses, antrian pendaftaran sepertinya penuh! Silakan ulangi kembali dalam beberapa menit...",

--- a/src/config/locales/it-IT.json
+++ b/src/config/locales/it-IT.json
@@ -999,6 +999,8 @@
       "username_contains_symbols_error": "Deve contenere solo lettere, numeri e trattini",
       "username_no_ascii_first_letter_error": "Deve iniziare con una lettera",
       "username_contains_double_hyphens": "Non deve contenere doppi trattini",
+      "username_resembles_exchange": "This username is too similar to a crypto exchange account and may confuse others. Please choose a more unique name.",
+      "username_restricted_prefix": "Usernames that start with 'uid' followed by numbers are not allowed, as they are commonly used to impersonate others. Please choose a different name.",
       "username_contains_underscore": "Non deve contenere trattini bassi"
     },
     "500_error": "La tua richiesta non può essere elaborata, la coda di registrazione è probabilmente piena! Riprova tra pochi minuti...",

--- a/src/config/locales/ja-JP.json
+++ b/src/config/locales/ja-JP.json
@@ -999,6 +999,8 @@
       "username_contains_symbols_error": "使用できるのは英字、数字、ハイフンのみです",
       "username_no_ascii_first_letter_error": "先頭は英字で始めてください",
       "username_contains_double_hyphens": "ハイフンを連続して使用することはできません",
+      "username_resembles_exchange": "This username is too similar to a crypto exchange account and may confuse others. Please choose a more unique name.",
+      "username_restricted_prefix": "Usernames that start with 'uid' followed by numbers are not allowed, as they are commonly used to impersonate others. Please choose a different name.",
       "username_contains_underscore": "アンダースコアは使用できません"
     },
     "500_error": "リクエストは処理されませんでした、サインアップのキューが一杯です！時間を置いて再度お試しください。。。",

--- a/src/config/locales/ko-KR.json
+++ b/src/config/locales/ko-KR.json
@@ -999,6 +999,8 @@
       "username_contains_symbols_error": "문자, 숫자, 하이픈만 포함할 수 있습니다",
       "username_no_ascii_first_letter_error": "문자로 시작해야 합니다",
       "username_contains_double_hyphens": "연속된 하이픈을 포함할 수 없습니다",
+      "username_resembles_exchange": "This username is too similar to a crypto exchange account and may confuse others. Please choose a more unique name.",
+      "username_restricted_prefix": "Usernames that start with 'uid' followed by numbers are not allowed, as they are commonly used to impersonate others. Please choose a different name.",
       "username_contains_underscore": "밑줄을 포함할 수 없습니다"
     },
     "500_error": "귀하의 요청을 처리할 수 없습니다. 등록 대기열이 가득 찼을 수 있습니다! 몇 분 후에 다시 시도하세요...",

--- a/src/config/locales/ku-TR.json
+++ b/src/config/locales/ku-TR.json
@@ -999,6 +999,8 @@
       "username_contains_symbols_error": "Divê tenê tîp, hejmar û xêzika navberê hebe",
       "username_no_ascii_first_letter_error": "Divê bi tîpekê dest pê bike",
       "username_contains_double_hyphens": "Divê du xêzikên navberê li pey hev nehebin",
+      "username_resembles_exchange": "This username is too similar to a crypto exchange account and may confuse others. Please choose a more unique name.",
+      "username_restricted_prefix": "Usernames that start with 'uid' followed by numbers are not allowed, as they are commonly used to impersonate others. Please choose a different name.",
       "username_contains_underscore": "Divê xêzika binî (underscore) nehebe"
     },
     "500_error": "Daxwaza te nehat hilanîn, dibe ku rêza qeydkirinê tijî be! Çend deqeyan din dîsa biceribîne...",

--- a/src/config/locales/lt-LT.json
+++ b/src/config/locales/lt-LT.json
@@ -999,6 +999,8 @@
       "username_contains_symbols_error": "Gali būti tik raidės, skaičiai ir brūkšnelis",
       "username_no_ascii_first_letter_error": "Turi prasidėti raide",
       "username_contains_double_hyphens": "Negali būti dvigubų brūkšnelių",
+      "username_resembles_exchange": "This username is too similar to a crypto exchange account and may confuse others. Please choose a more unique name.",
+      "username_restricted_prefix": "Usernames that start with 'uid' followed by numbers are not allowed, as they are commonly used to impersonate others. Please choose a different name.",
       "username_contains_underscore": "Negali būti pabraukimo brūkšnio"
     },
     "500_error": "Jūsų užklausa negali būti įvykdyta, greičiausiai registracijos eilėje nėra vietos! Pabandykite vėl už kelių minučių...",

--- a/src/config/locales/ms-MY.json
+++ b/src/config/locales/ms-MY.json
@@ -999,6 +999,8 @@
       "username_contains_symbols_error": "Hanya boleh mengandungi huruf, nombor, sengkang",
       "username_no_ascii_first_letter_error": "Mestilah bermula dengan huruf",
       "username_contains_double_hyphens": "Tidak boleh mengandungi sengkang berganda",
+      "username_resembles_exchange": "This username is too similar to a crypto exchange account and may confuse others. Please choose a more unique name.",
+      "username_restricted_prefix": "Usernames that start with 'uid' followed by numbers are not allowed, as they are commonly used to impersonate others. Please choose a different name.",
       "username_contains_underscore": "Tidak boleh mengandungi garis bawah"
     },
     "500_error": "Permintaan anda tidak dapat ditunaikan, barisan pendaftaran kemungkinan sudah penuh! Sila cuba lagi dalam masa beberapa minit...",

--- a/src/config/locales/nl-NL.json
+++ b/src/config/locales/nl-NL.json
@@ -999,6 +999,8 @@
       "username_contains_symbols_error": "Mag alleen letters, cijfers en koppeltekens bevatten",
       "username_no_ascii_first_letter_error": "Moet met een letter beginnen",
       "username_contains_double_hyphens": "Mag geen dubbele koppeltekens bevatten",
+      "username_resembles_exchange": "This username is too similar to a crypto exchange account and may confuse others. Please choose a more unique name.",
+      "username_restricted_prefix": "Usernames that start with 'uid' followed by numbers are not allowed, as they are commonly used to impersonate others. Please choose a different name.",
       "username_contains_underscore": "Mag geen underscore bevatten"
     },
     "500_error": "Je verzoek kon niet worden verwerkt, de aanmeldwachtrij is waarschijnlijk vol! Probeer het over enkele minuten opnieuw...",

--- a/src/config/locales/pl-PL.json
+++ b/src/config/locales/pl-PL.json
@@ -999,6 +999,8 @@
       "username_contains_symbols_error": "Powinna zawierać tylko litery, cyfry i myślnik",
       "username_no_ascii_first_letter_error": "Powinno zaczynać się od litery",
       "username_contains_double_hyphens": "Nie powinna zawierać podwójnych myślników",
+      "username_resembles_exchange": "This username is too similar to a crypto exchange account and may confuse others. Please choose a more unique name.",
+      "username_restricted_prefix": "Usernames that start with 'uid' followed by numbers are not allowed, as they are commonly used to impersonate others. Please choose a different name.",
       "username_contains_underscore": "Nie powinna zawierać podkreślenia"
     },
     "500_error": "Twoje żądanie nie może być przetworzone, kolejka rejestracji jest prawdopodobnie pełna! Spróbuj ponownie za kilka minut...",

--- a/src/config/locales/pt-PT.json
+++ b/src/config/locales/pt-PT.json
@@ -999,6 +999,8 @@
       "username_contains_symbols_error": "Pode conter apenas letras, números e hífen",
       "username_no_ascii_first_letter_error": "Deve começar com uma letra",
       "username_contains_double_hyphens": "Não deve conter hífens duplos",
+      "username_resembles_exchange": "This username is too similar to a crypto exchange account and may confuse others. Please choose a more unique name.",
+      "username_restricted_prefix": "Usernames that start with 'uid' followed by numbers are not allowed, as they are commonly used to impersonate others. Please choose a different name.",
       "username_contains_underscore": "Não pode conter sublinhado"
     },
     "500_error": "A sua solicitação não pôde ser processada, a fila de inscrição provavelmente está cheia! Tente novamente em alguns minutos...",

--- a/src/config/locales/ro-RO.json
+++ b/src/config/locales/ro-RO.json
@@ -999,6 +999,8 @@
       "username_contains_symbols_error": "Trebuie să conțină doar litere, cifre și cratimă",
       "username_no_ascii_first_letter_error": "Trebuie să înceapă cu o literă",
       "username_contains_double_hyphens": "Nu trebuie să conțină cratimă dublă",
+      "username_resembles_exchange": "This username is too similar to a crypto exchange account and may confuse others. Please choose a more unique name.",
+      "username_restricted_prefix": "Usernames that start with 'uid' followed by numbers are not allowed, as they are commonly used to impersonate others. Please choose a different name.",
       "username_contains_underscore": "Nu trebuie să conțină liniuță de subliniere"
     },
     "500_error": "Solicitarea dvs. nu a putut fi procesată, coada de înregistrare este probabil plină! Încercați din nou peste câteva minute...",

--- a/src/config/locales/ru-RU.json
+++ b/src/config/locales/ru-RU.json
@@ -999,6 +999,8 @@
       "username_contains_symbols_error": "Должно содержать только буквы, цифры и дефисы",
       "username_no_ascii_first_letter_error": "Должно начинаться с буквы",
       "username_contains_double_hyphens": "Не должно содержать двойные дефисы",
+      "username_resembles_exchange": "This username is too similar to a crypto exchange account and may confuse others. Please choose a more unique name.",
+      "username_restricted_prefix": "Usernames that start with 'uid' followed by numbers are not allowed, as they are commonly used to impersonate others. Please choose a different name.",
       "username_contains_underscore": "Не должно содержать подчеркивания"
     },
     "500_error": "Ваш запрос не удалось обработать, скорее всего, очередь регистрации заполнена! Повторите попытку через несколько минут...",

--- a/src/config/locales/sr-CS.json
+++ b/src/config/locales/sr-CS.json
@@ -999,6 +999,8 @@
       "username_contains_symbols_error": "Sme da sadrži samo slova, brojeve i crticu",
       "username_no_ascii_first_letter_error": "Treba da počinje slovom",
       "username_contains_double_hyphens": "Ne sme da sadrži dvostruke crtice",
+      "username_resembles_exchange": "This username is too similar to a crypto exchange account and may confuse others. Please choose a more unique name.",
+      "username_restricted_prefix": "Usernames that start with 'uid' followed by numbers are not allowed, as they are commonly used to impersonate others. Please choose a different name.",
       "username_contains_underscore": "Ne sme da sadrži donju crtu"
     },
     "500_error": "Vaš zahtev nije mogao da se obradi, red za registraciju je verovatno pun! Pokušajte ponovo za nekoliko minuta...",

--- a/src/config/locales/sv-SE.json
+++ b/src/config/locales/sv-SE.json
@@ -999,6 +999,8 @@
       "username_contains_symbols_error": "Får endast innehålla bokstäver, siffror och bindestreck",
       "username_no_ascii_first_letter_error": "Bör börja med en bokstav",
       "username_contains_double_hyphens": "Får inte innehålla dubbla bindestreck",
+      "username_resembles_exchange": "This username is too similar to a crypto exchange account and may confuse others. Please choose a more unique name.",
+      "username_restricted_prefix": "Usernames that start with 'uid' followed by numbers are not allowed, as they are commonly used to impersonate others. Please choose a different name.",
       "username_contains_underscore": "Får inte innehålla understreck"
     },
     "500_error": "Din begäran kunde inte behandlas, registreringskön är förmodligen full! Försök igen om några minuter...",

--- a/src/config/locales/th-TH.json
+++ b/src/config/locales/th-TH.json
@@ -999,6 +999,8 @@
       "username_contains_symbols_error": "ควรมีเฉพาะตัวอักษร ตัวเลข และเครื่องหมายขีดกลางเท่านั้น",
       "username_no_ascii_first_letter_error": "ควรขึ้นต้นด้วยตัวอักษร",
       "username_contains_double_hyphens": "ไม่ควรมีเครื่องหมายขีดกลางซ้อนกัน",
+      "username_resembles_exchange": "This username is too similar to a crypto exchange account and may confuse others. Please choose a more unique name.",
+      "username_restricted_prefix": "Usernames that start with 'uid' followed by numbers are not allowed, as they are commonly used to impersonate others. Please choose a different name.",
       "username_contains_underscore": "ไม่ควรมีเครื่องหมายขีดล่าง"
     },
     "500_error": "ไม่สามารถดำเนินการตามคำขอของคุณได้ คิวสมัครสมาชิกน่าจะเต็ม! ลองอีกครั้งในอีกไม่กี่นาที...",

--- a/src/config/locales/tr-TR.json
+++ b/src/config/locales/tr-TR.json
@@ -999,6 +999,8 @@
       "username_contains_symbols_error": "Yalnızca harf, rakam ve tire içermelidir",
       "username_no_ascii_first_letter_error": "Bir harfle başlamalı",
       "username_contains_double_hyphens": "Çift tire içermemelidir",
+      "username_resembles_exchange": "This username is too similar to a crypto exchange account and may confuse others. Please choose a more unique name.",
+      "username_restricted_prefix": "Usernames that start with 'uid' followed by numbers are not allowed, as they are commonly used to impersonate others. Please choose a different name.",
       "username_contains_underscore": "Alt çizgi içermemelidir"
     },
     "500_error": "İsteğiniz işlenemedi, kayıt sırası büyük olasılıkla dolu! Birkaç dakika sonra yeniden deneyiniz...",

--- a/src/config/locales/uk-UA.json
+++ b/src/config/locales/uk-UA.json
@@ -999,6 +999,8 @@
       "username_contains_symbols_error": "Повинен містити тільки літери, цифри або дефіс",
       "username_no_ascii_first_letter_error": "Має починатися з літери",
       "username_contains_double_hyphens": "Не повинно містити подвійних дефісів",
+      "username_resembles_exchange": "This username is too similar to a crypto exchange account and may confuse others. Please choose a more unique name.",
+      "username_restricted_prefix": "Usernames that start with 'uid' followed by numbers are not allowed, as they are commonly used to impersonate others. Please choose a different name.",
       "username_contains_underscore": "Не повинно містити підкреслення"
     },
     "500_error": "Не вдалося обробити ваш запит, скоріш за все, черга реєстрації переповнена! Спробуйте ще раз через кілька хвилин...",

--- a/src/config/locales/uz-UZ.json
+++ b/src/config/locales/uz-UZ.json
@@ -999,6 +999,8 @@
       "username_contains_symbols_error": "Faqat harflar, raqamlar va defis bo‘lishi kerak",
       "username_no_ascii_first_letter_error": "Harf bilan boshlanishi kerak",
       "username_contains_double_hyphens": "Ikkita ketma-ket defis bo‘lmasligi kerak",
+      "username_resembles_exchange": "This username is too similar to a crypto exchange account and may confuse others. Please choose a more unique name.",
+      "username_restricted_prefix": "Usernames that start with 'uid' followed by numbers are not allowed, as they are commonly used to impersonate others. Please choose a different name.",
       "username_contains_underscore": "Tag chiziq bo‘lmasligi kerak"
     },
     "500_error": "So‘rovingizni ko‘rib bo‘lmadi, katta ehtimol bilan ro‘yxatdan o‘tish navbati to‘lgan! Bir necha daqiqadan so‘ng qayta urinib ko‘ring...",

--- a/src/config/locales/vi-VN.json
+++ b/src/config/locales/vi-VN.json
@@ -999,6 +999,8 @@
       "username_contains_symbols_error": "Chỉ được chứa chữ cái, số và dấu gạch nối",
       "username_no_ascii_first_letter_error": "Phải bắt đầu bằng một chữ cái",
       "username_contains_double_hyphens": "Không được chứa dấu gạch nối kép",
+      "username_resembles_exchange": "This username is too similar to a crypto exchange account and may confuse others. Please choose a more unique name.",
+      "username_restricted_prefix": "Usernames that start with 'uid' followed by numbers are not allowed, as they are commonly used to impersonate others. Please choose a different name.",
       "username_contains_underscore": "Không được chứa dấu gạch dưới"
     },
     "500_error": "Yêu cầu của bạn không thể được xử lý, hàng đợi đăng ký có thể đã đầy! Hãy thử lại sau vài phút...",

--- a/src/config/locales/zh-CN.json
+++ b/src/config/locales/zh-CN.json
@@ -999,6 +999,8 @@
       "username_contains_symbols_error": "只能包含字母、数字和连字符",
       "username_no_ascii_first_letter_error": "需以字母开头",
       "username_contains_double_hyphens": "不能包含连续的连字符",
+      "username_resembles_exchange": "This username is too similar to a crypto exchange account and may confuse others. Please choose a more unique name.",
+      "username_restricted_prefix": "Usernames that start with 'uid' followed by numbers are not allowed, as they are commonly used to impersonate others. Please choose a different name.",
       "username_contains_underscore": "不能包含下划线"
     },
     "500_error": "您的请求无法处理，注册队列可能已满！请几分钟后再试……",

--- a/src/config/locales/zh-TW.json
+++ b/src/config/locales/zh-TW.json
@@ -999,6 +999,8 @@
       "username_contains_symbols_error": "只能包含字母、數字與連字號",
       "username_no_ascii_first_letter_error": "開頭必須是英文字母",
       "username_contains_double_hyphens": "不應包含連續兩個連字號",
+      "username_resembles_exchange": "This username is too similar to a crypto exchange account and may confuse others. Please choose a more unique name.",
+      "username_restricted_prefix": "Usernames that start with 'uid' followed by numbers are not allowed, as they are commonly used to impersonate others. Please choose a different name.",
       "username_contains_underscore": "不應包含底線"
     },
     "500_error": "您的申請暫時未能通過，很可能是滿了。請稍候重試…",

--- a/src/constants/exchangeAccounts.ts
+++ b/src/constants/exchangeAccounts.ts
@@ -26,7 +26,111 @@ export const EXCHANGE_ACCOUNTS = [
   'upbit-exchange',
   'onepagex',
   'bdhivesteem',
+  'bitgethive',
 ];
 
 export const isExchangeAccount = (username?: string | null) =>
   !!username && EXCHANGE_ACCOUNTS.includes(username.trim().toLowerCase());
+
+// Strip everything but lowercase letters and digits so separator-only variations
+// ('huobi-pro' vs 'huobipro') and casing collapse to the same comparable form.
+const normalizeForExchangeMatch = (value: string): string =>
+  value.toLowerCase().replace(/[^a-z0-9]/g, '');
+
+// Generic tails that exchanges append to a brand when naming a deposit account.
+const GENERIC_EXCHANGE_SUFFIXES = ['deposit', 'exchange', 'steem', 'hive', 'pro'];
+
+// Reduce a normalized account name to its distinctive brand, dropping a trailing
+// generic suffix and trailing digits ('gateiodeposit' -> 'gateio',
+// 'deepcrypto8' -> 'deepcrypto'). Single-token names without such a tail
+// ('bittrex', 'blocktrades', 'changelly') are returned unchanged, so their
+// ordinary-word prefixes ('block', 'change') never become a match target.
+const exchangeBrandCore = (normalized: string): string => {
+  const core = normalized.replace(/\d+$/, '');
+  const suffix = GENERIC_EXCHANGE_SUFFIXES.find((s) => core.length > s.length && core.endsWith(s));
+  return suffix ? core.slice(0, -suffix.length) : core;
+};
+
+// Classic iterative Levenshtein (single rolling row) for short username strings.
+const levenshtein = (a: string, b: string): number => {
+  if (a === b) {
+    return 0;
+  }
+  if (a.length === 0) {
+    return b.length;
+  }
+  if (b.length === 0) {
+    return a.length;
+  }
+
+  let prev = Array.from({ length: b.length + 1 }, (_, i) => i);
+  for (let i = 0; i < a.length; i++) {
+    const curr = [i + 1];
+    for (let j = 0; j < b.length; j++) {
+      const cost = a[i] === b[j] ? 0 : 1;
+      curr.push(Math.min(prev[j + 1] + 1, curr[j] + 1, prev[j] + cost));
+    }
+    prev = curr;
+  }
+  return prev[b.length];
+};
+
+/**
+ * True when `username` is identical or close enough to a known exchange deposit
+ * account that it could be mistaken for one. Matching is intentionally
+ * conservative to avoid false positives on ordinary names:
+ *   1. exact match against the full account or its brand core, ignoring
+ *      separators/casing ('huobi-pro' ~ 'huobipro', 'coinex' -> coinexdeposit);
+ *   2. the chosen name embeds the full account name ('mybittrex') or, when the
+ *      brand is distinct from the full name, the brand core ('upbitcoin');
+ *   3. a single-character typo of the full account name ('bittrx').
+ *
+ * Mirrors vision-next's isExchangeLikeUsername — keep the two in sync.
+ */
+export const isExchangeLikeUsername = (username?: string | null): boolean => {
+  if (!username) {
+    return false;
+  }
+  const candidate = normalizeForExchangeMatch(username);
+  // Too short to meaningfully resemble any (>= 7 char) exchange account name.
+  if (candidate.length < 3) {
+    return false;
+  }
+
+  return EXCHANGE_ACCOUNTS.some((account) => {
+    const exchange = normalizeForExchangeMatch(account);
+    if (!exchange) {
+      return false;
+    }
+    const core = exchangeBrandCore(exchange);
+
+    // 1. exact match against the full account or its (>= 4 char) brand core
+    if (candidate === exchange) {
+      return true;
+    }
+    if (core.length >= 4 && candidate === core) {
+      return true;
+    }
+    // 2. the chosen name wraps the whole account name, or the distinct brand core
+    if (candidate.length > exchange.length && candidate.includes(exchange)) {
+      return true;
+    }
+    if (
+      core !== exchange &&
+      core.length >= 4 &&
+      candidate.length > core.length &&
+      candidate.includes(core)
+    ) {
+      return true;
+    }
+    // 3. single-character typo of the full account name at comparable length
+    if (
+      Math.abs(candidate.length - exchange.length) <= 1 &&
+      levenshtein(candidate, exchange) <= 1
+    ) {
+      return true;
+    }
+
+    return false;
+  });
+};

--- a/src/constants/exchangeAccounts.ts
+++ b/src/constants/exchangeAccounts.ts
@@ -45,6 +45,9 @@ const GENERIC_EXCHANGE_SUFFIXES = ['deposit', 'exchange', 'steem', 'hive', 'pro'
 // 'deepcrypto8' -> 'deepcrypto'). Single-token names without such a tail
 // ('bittrex', 'blocktrades', 'changelly') are returned unchanged, so their
 // ordinary-word prefixes ('block', 'change') never become a match target.
+// Strips a single (outermost) suffix, which covers every account in the current
+// list; a future account with a compounded tail (e.g. 'brandproexchange') would
+// need this extended to strip iteratively.
 const exchangeBrandCore = (normalized: string): string => {
   const core = normalized.replace(/\d+$/, '');
   const suffix = GENERIC_EXCHANGE_SUFFIXES.find((s) => core.length > s.length && core.endsWith(s));
@@ -92,7 +95,8 @@ export const isExchangeLikeUsername = (username?: string | null): boolean => {
     return false;
   }
   const candidate = normalizeForExchangeMatch(username);
-  // Too short to meaningfully resemble any (>= 7 char) exchange account name.
+  // Cheap early-out for 1-2 char inputs; anything still short simply fails every
+  // rule below (brand cores are >= 4, full names >= 7, embed/typo need length).
   if (candidate.length < 3) {
     return false;
   }
@@ -104,7 +108,9 @@ export const isExchangeLikeUsername = (username?: string | null): boolean => {
     }
     const core = exchangeBrandCore(exchange);
 
-    // 1. exact match against the full account or its (>= 4 char) brand core
+    // 1. exact match against the full account or its (>= 4 char) brand core.
+    //    The >= 4 guard drops the only sub-4 core ('mxc', from 'mxchive'), so a
+    //    3-char fragment can't over-match; 'mxchive' is still caught in full.
     if (candidate === exchange) {
       return true;
     }

--- a/src/utils/usernameValidation.test.ts
+++ b/src/utils/usernameValidation.test.ts
@@ -65,6 +65,7 @@ describe('getUsernameError', () => {
     expect(getUsernameError('coinex')).toBe('exchange'); // brand prefix of coinexdeposit
     expect(getUsernameError('bittrx')).toBe('exchange'); // single-char typo
     expect(getUsernameError('bitgethive')).toBe('exchange');
+    expect(getUsernameError('bitget')).toBe('exchange'); // brand core of bitgethive
   });
 
   it('rejects the uid + digits impersonation pattern', () => {

--- a/src/utils/usernameValidation.test.ts
+++ b/src/utils/usernameValidation.test.ts
@@ -56,6 +56,37 @@ describe('getUsernameError', () => {
     expect(getUsernameError('ab--cd')).toBe('double_hyphens');
     expect(getUsernameError('ab_cd')).toBe('underscore');
   });
+
+  it('rejects names that resemble a known exchange account', () => {
+    // chain-valid but confusable with an exchange deposit account
+    expect(getUsernameError('bittrex')).toBe('exchange');
+    expect(getUsernameError('huobi-pro')).toBe('exchange');
+    expect(getUsernameError('mybittrex')).toBe('exchange');
+    expect(getUsernameError('coinex')).toBe('exchange'); // brand prefix of coinexdeposit
+    expect(getUsernameError('bittrx')).toBe('exchange'); // single-char typo
+    expect(getUsernameError('bitgethive')).toBe('exchange');
+  });
+
+  it('rejects the uid + digits impersonation pattern', () => {
+    expect(getUsernameError('uid12345')).toBe('restricted');
+    expect(getUsernameError('uid007name')).toBe('restricted');
+  });
+
+  it('reports a format error before the exchange-resemblance error', () => {
+    // a malformed look-alike should surface its chain-validity error first
+    expect(getUsernameError('bittrex-')).toBe('trailing_hyphen');
+  });
+
+  it('does not flag ordinary names that merely share a fragment', () => {
+    expect(getUsernameError('trade')).toBeNull(); // substring of blocktrades, not a prefix
+    expect(getUsernameError('deposit')).toBeNull();
+    expect(getUsernameError('blockchain')).toBeNull();
+    expect(getUsernameError('changelog')).toBeNull(); // 2 edits from changelly
+    expect(getUsernameError('block')).toBeNull(); // prefix of blocktrades
+    expect(getUsernameError('change')).toBeNull(); // prefix of changelly
+    expect(getUsernameError('druid')).toBeNull(); // contains uid but not a prefix
+    expect(getUsernameError('uidev')).toBeNull(); // uid + letter, not the digit pattern
+  });
 });
 
 describe('USERNAME_ERROR_MESSAGE_IDS', () => {
@@ -67,6 +98,8 @@ describe('USERNAME_ERROR_MESSAGE_IDS', () => {
       'double_hyphens',
       'trailing_hyphen',
       'underscore',
+      'exchange',
+      'restricted',
     ] as const;
     codes.forEach((code) => {
       expect(USERNAME_ERROR_MESSAGE_IDS[code]).toMatch(/^register\.validation\./);

--- a/src/utils/usernameValidation.ts
+++ b/src/utils/usernameValidation.ts
@@ -1,14 +1,23 @@
+import { isExchangeLikeUsername } from '../constants/exchangeAccounts';
+
 // Mirrors the blockchain's account-name rules (is_valid_account_name): 3-16
 // chars total, dot-separated segments of 3+ chars, each starting with a letter,
 // containing only lowercase letters, digits and single hyphens, and ending with
 // a letter or digit. Expects already-lowercased input.
+//
+// `exchange` and `restricted` are policy checks layered on top of the chain
+// rules: the name is chain-valid but too easily confused with a known exchange
+// deposit account (`exchange`), or uses the "uid"-prefixed pattern abused for
+// impersonation/phishing (`restricted`).
 export type UsernameValidationError =
   | 'length'
   | 'start_letter'
   | 'symbols'
   | 'double_hyphens'
   | 'trailing_hyphen'
-  | 'underscore';
+  | 'underscore'
+  | 'exchange'
+  | 'restricted';
 
 // Maps a validation error to its react-intl message id. Kept beside the rule so
 // every place that blocks a chain-invalid username (the register form AND the
@@ -22,7 +31,16 @@ export const USERNAME_ERROR_MESSAGE_IDS: Record<UsernameValidationError, string>
   // 38 non-en locale files until the next translation sync
   trailing_hyphen: 'register.validation.username_contains_symbols_error',
   underscore: 'register.validation.username_contains_underscore',
+  exchange: 'register.validation.username_resembles_exchange',
+  restricted: 'register.validation.username_restricted_prefix',
 };
+
+// Names of the form "uid" + digits (e.g. "uid12345") mimic the numeric user IDs
+// that exchanges and services assign, and have been used to impersonate them.
+// The check is separator/case-insensitive so "u.i.d.1"-style evasion still trips
+// it, but plain words like "uidev" or "fluid" are left alone.
+export const hasRestrictedUsernamePrefix = (value: string): boolean =>
+  /^uid\d/.test(value.toLowerCase().replace(/[^a-z0-9]/g, ''));
 
 const getSegmentError = (segment: string): UsernameValidationError | null => {
   if (segment.length < 3) {
@@ -51,10 +69,25 @@ export const getUsernameError = (value: string): UsernameValidationError | null 
     return 'length';
   }
 
-  return (
+  const segmentError =
     value
       .split('.')
       .map(getSegmentError)
-      .find((error) => error !== null) ?? null
-  );
+      .find((error) => error !== null) ?? null;
+  if (segmentError) {
+    return segmentError;
+  }
+
+  // Checked last, after the chain-validity rules, so a malformed name shows its
+  // format error first. Blocks names confusable with an exchange deposit account.
+  if (isExchangeLikeUsername(value)) {
+    return 'exchange';
+  }
+
+  // Blocks the "uid"-prefixed pattern commonly abused for impersonation/phishing.
+  if (hasRestrictedUsernamePrefix(value)) {
+    return 'restricted';
+  }
+
+  return null;
 };


### PR DESCRIPTION
## What
Mirrors the web signup rule on mobile: blocks account usernames that **resemble a known exchange deposit account**, or that follow the **`uid` + digits** impersonation pattern. Applies to free registration, paid-account purchase and IAP, and the deep-link recovery path.

## Why
Names that look like an exchange deposit account (or a `uid12345`-style identifier) are easily confused with the real thing and have been used for impersonation. Funds sent to a look-alike account are typically unrecoverable.

## How
- `getUsernameError` returns two new codes: `exchange` (resembles an exchange account) and `restricted` (`uid` + digits), mapped via `USERNAME_ERROR_MESSAGE_IDS` to new `register.validation` messages.
- `isExchangeLikeUsername` + `hasRestrictedUsernamePrefix` match the web logic exactly (separator/case-insensitive, brand-core aware so `block`/`change` stay allowed, single-character typo, `uid`+digit only).
- Added `bitgethive` (Bitget) to the exchange list, kept in sync with web.
- New `username_resembles_exchange` / `username_restricted_prefix` strings added to all locale files (English; Crowdin to translate).

## Tests
Extended `usernameValidation.test.ts`. `yarn test usernameValidation` green; ESLint + Prettier clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added stronger registration username validation to detect exchange-like names and reject a restricted `uid` + numbers pattern.
  * Added new user-facing validation messages across supported languages.
* **Bug Fixes**
  * Improved validation precedence so format issues display before similarity-based warnings.
* **Tests**
  * Extended username validation coverage for the new exchange-like and restricted-prefix cases, including precedence and false-positive checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->