### PR TITLE
fix(waves): even-fill the 2-tab waves bar + make the + visible

### DIFF
--- a/src/components/wavesTabBar/wavesTabBar.tsx
+++ b/src/components/wavesTabBar/wavesTabBar.tsx
@@ -38,7 +38,10 @@ const WavesTabBar = ({ onTabPress, ...props }: Props) => {
       <IconButton
         style={styles.addButtonWrapper}
         iconStyle={styles.addButtonIcon}
-        iconType="MaterialIcon"
+        // No iconType -> Icon's default renders Ionicons "add", the exact same
+        // glyph as the main feed tab bar's "+" (feedTabBar reaches it via the
+        // "MaterialIcon" typo; we select the default explicitly instead).
+        iconType={undefined}
         name="add"
         size={28}
         accessibilityLabel="Add tag feed"

--- a/src/components/wavesTabBar/wavesTabBar.tsx
+++ b/src/components/wavesTabBar/wavesTabBar.tsx
@@ -13,11 +13,14 @@ interface Props extends TabBarProps<Route> {
 }
 
 /**
- * Waves tab bar: the scrollable For you / Following / #tag tabs plus a trailing
- * "+" that opens the tag picker, mirroring the home feed's customisable tab bar.
+ * Waves tab bar: For you / Following / #tag tabs plus a trailing "+" that opens
+ * the tag picker. With just the two base tabs the bar fills the width evenly
+ * (X-style); once enough tags are pinned to overflow it switches to scrolling.
  */
 const WavesTabBar = ({ onTabPress, ...props }: Props) => {
   const pickerRef = useRef<WavesTagPickerModalRef>(null);
+
+  const scrollEnabled = props.navigationState.routes.length > 2;
 
   return (
     <View style={styles.container}>
@@ -25,8 +28,8 @@ const WavesTabBar = ({ onTabPress, ...props }: Props) => {
         {...props}
         style={styles.tabBarStyle}
         indicatorStyle={styles.indicatorStyle}
-        tabStyle={styles.tabStyle}
-        scrollEnabled={true}
+        tabStyle={scrollEnabled ? styles.tabStyleScroll : undefined}
+        scrollEnabled={scrollEnabled}
         onTabPress={({ route, preventDefault }) => {
           preventDefault();
           onTabPress(route.key);
@@ -37,7 +40,8 @@ const WavesTabBar = ({ onTabPress, ...props }: Props) => {
         iconStyle={styles.addButtonIcon}
         iconType="MaterialIcons"
         name="add"
-        size={26}
+        size={24}
+        accessibilityLabel="Add tag feed"
         onPress={() => pickerRef.current?.show()}
       />
       <WavesTagPickerModal ref={pickerRef} />

--- a/src/components/wavesTabBar/wavesTabBar.tsx
+++ b/src/components/wavesTabBar/wavesTabBar.tsx
@@ -38,9 +38,9 @@ const WavesTabBar = ({ onTabPress, ...props }: Props) => {
       <IconButton
         style={styles.addButtonWrapper}
         iconStyle={styles.addButtonIcon}
-        iconType="MaterialIcons"
+        iconType="MaterialIcon"
         name="add"
-        size={24}
+        size={28}
         accessibilityLabel="Add tag feed"
         onPress={() => pickerRef.current?.show()}
       />

--- a/src/components/wavesTabBar/wavesTabBarStyles.ts
+++ b/src/components/wavesTabBar/wavesTabBarStyles.ts
@@ -40,7 +40,9 @@ export default EStyleSheet.create({
   } as ViewStyle,
 
   addButtonIcon: {
-    color: '$iconColor',
+    // Matches the main feed's "+" exactly (Ionicons "add" via iconType
+    // "MaterialIcon", $darkIconColor) for cross-tab-bar consistency.
+    color: '$darkIconColor',
     textAlign: 'center',
   } as TextStyle,
 });

--- a/src/components/wavesTabBar/wavesTabBarStyles.ts
+++ b/src/components/wavesTabBar/wavesTabBarStyles.ts
@@ -13,7 +13,7 @@ export default EStyleSheet.create({
 
   tabBarStyle: {
     flex: 1,
-    backgroundColor: '$primaryBackgroundColor',
+    backgroundColor: 'transparent',
     shadowColor: 'transparent',
     elevation: 0,
   } as ViewStyle,
@@ -23,20 +23,24 @@ export default EStyleSheet.create({
     height: 2,
   } as ViewStyle,
 
-  tabStyle: {
+  // Only applied when scrolling (3+ tabs); the two base tabs are left to flex
+  // evenly across the full width.
+  tabStyleScroll: {
     width: 'auto',
     minWidth: deviceWidth / 3 - 16,
-    paddingHorizontal: 8,
-    height: 40,
+    paddingHorizontal: 12,
+    height: 44,
   } as ViewStyle,
 
   addButtonWrapper: {
-    paddingHorizontal: 12,
-    alignSelf: 'center',
+    paddingHorizontal: 14,
+    height: 44,
+    alignItems: 'center',
+    justifyContent: 'center',
   } as ViewStyle,
 
   addButtonIcon: {
-    color: '$darkIconColor',
+    color: '$iconColor',
     textAlign: 'center',
   } as TextStyle,
 });


### PR DESCRIPTION
Follow-up to #3297. The waves tab bar always used `scrollEnabled` with a per-tab min-width, so the two base tabs (For you / Following) were cramped on the left with empty space, and the `+` was easy to miss.

- Scroll only when there are **3+ tabs** (i.e. once tags are pinned); with just the two base tabs, let them **flex evenly** across the full width (matches the X-style layout).
- Make the `+` clearer (`$iconColor`, centered, larger touch target).

No logic change to the tabs/feeds; styling only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tab bar behavior so tab-bar scrolling activates only when there are more than two tabs, keeping the layout consistent.
  * Refined tab and add-button spacing, sizing, and alignment for a cleaner multi-tab experience.
  * Updated the add-tag button’s icon sizing and accessibility label for clearer interaction.
  * Adjusted the tab bar background to transparent while maintaining the existing shadow and elevation look.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->