### PR TITLE
feat(waves): unify the waves tab bar with the home-feed style

### DIFF
--- a/src/components/tabbedPosts/container/tabbedPosts.tsx
+++ b/src/components/tabbedPosts/container/tabbedPosts.tsx
@@ -7,7 +7,7 @@ import EStyleSheet from 'react-native-extended-stylesheet';
 import { TabbedPostsProps } from '../types/tabbedPosts.types';
 import { FeedTabBar } from '../view/feedTabBar';
 import PostsTabContent from '../view/postsTabContent';
-import { Tag } from '../..';
+import { renderPillTabLabel } from '../view/renderPillTabLabel';
 
 const styles = EStyleSheet.create({
   container: {
@@ -59,14 +59,8 @@ export const TabbedPosts = ({
     );
   };
 
-  const _renderTabLabel = ({ labelText, focused }: { focused: boolean; labelText: string }) => (
-    <Tag
-      key={labelText}
-      value={intl.formatMessage({ id: labelText.toLowerCase() }).toUpperCase()}
-      isFilter
-      isPin={focused}
-    />
-  );
+  const _renderTabLabel = ({ labelText, focused }: { focused: boolean; labelText: string }) =>
+    renderPillTabLabel({ labelText: intl.formatMessage({ id: labelText.toLowerCase() }), focused });
 
   const _setIndex = (i: number) => {
     Image.clearMemoryCache();

--- a/src/components/tabbedPosts/view/renderPillTabLabel.tsx
+++ b/src/components/tabbedPosts/view/renderPillTabLabel.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Tag } from '../..';
+
+/**
+ * Shared "pill" tab label used by both the home-feed and the waves tab bars:
+ * an uppercase Tag that fills with the active colour when the tab is focused.
+ * The caller passes an already-resolved display string as `labelText` (the
+ * home feed resolves its i18n key first; the waves bar passes the route title
+ * directly), so this helper stays intl-free and is the single source of truth
+ * for the tab-bar pill look.
+ */
+export const renderPillTabLabel = ({
+  labelText,
+  focused,
+}: {
+  labelText: string;
+  focused: boolean;
+}) => <Tag key={labelText} value={(labelText || '').toUpperCase()} isFilter isPin={focused} />;
+
+export default renderPillTabLabel;

--- a/src/components/tabbedPosts/view/renderPillTabLabel.tsx
+++ b/src/components/tabbedPosts/view/renderPillTabLabel.tsx
@@ -16,5 +16,3 @@ export const renderPillTabLabel = ({
   labelText: string;
   focused: boolean;
 }) => <Tag key={labelText} value={(labelText || '').toUpperCase()} isFilter isPin={focused} />;
-
-export default renderPillTabLabel;

--- a/src/components/wavesTabBar/wavesTabBar.tsx
+++ b/src/components/wavesTabBar/wavesTabBar.tsx
@@ -1,5 +1,5 @@
 import React, { useRef } from 'react';
-import { View } from 'react-native';
+import { useWindowDimensions, View } from 'react-native';
 import { TabBar, TabBarProps, Route } from 'react-native-tab-view';
 import { IconButton } from '../index';
 import WavesTagPickerModal, {
@@ -13,14 +13,17 @@ interface Props extends TabBarProps<Route> {
 }
 
 /**
- * Waves tab bar: For you / Following / #tag tabs plus a trailing "+" that opens
- * the tag picker. With just the two base tabs the bar fills the width evenly
- * (X-style); once enough tags are pinned to overflow it switches to scrolling.
+ * Waves tab bar. Mirrors the home-feed FeedTabBar look: uppercase blue "pill"
+ * active tab (via the TabView commonOptions.label renderer) over a transparent
+ * indicator, scrollable tabs, and a trailing "+" that opens the tag picker.
+ *
+ * Always scrollable: an even-fill (scrollEnabled=false) layout sizes the tabs
+ * to the full window width and pushes the "+" off-screen, which is exactly the
+ * bug that hid it. Content-width scrollable tabs leave room for the "+".
  */
 const WavesTabBar = ({ onTabPress, ...props }: Props) => {
   const pickerRef = useRef<WavesTagPickerModalRef>(null);
-
-  const scrollEnabled = props.navigationState.routes.length > 2;
+  const layout = useWindowDimensions();
 
   return (
     <View style={styles.container}>
@@ -28,8 +31,8 @@ const WavesTabBar = ({ onTabPress, ...props }: Props) => {
         {...props}
         style={styles.tabBarStyle}
         indicatorStyle={styles.indicatorStyle}
-        tabStyle={scrollEnabled ? styles.tabStyleScroll : undefined}
-        scrollEnabled={scrollEnabled}
+        tabStyle={{ ...styles.tabStyle, minWidth: layout.width / 3 - 14 }}
+        scrollEnabled={true}
         onTabPress={({ route, preventDefault }) => {
           preventDefault();
           onTabPress(route.key);
@@ -38,9 +41,9 @@ const WavesTabBar = ({ onTabPress, ...props }: Props) => {
       <IconButton
         style={styles.addButtonWrapper}
         iconStyle={styles.addButtonIcon}
-        // No iconType -> Icon's default renders Ionicons "add", the exact same
-        // glyph as the main feed tab bar's "+" (feedTabBar reaches it via the
-        // "MaterialIcon" typo; we select the default explicitly instead).
+        // No iconType -> Icon's default renders Ionicons "add", identical to the
+        // main feed tab bar's "+" (feedTabBar reaches it via a "MaterialIcon"
+        // typo; we select the default explicitly).
         iconType={undefined}
         name="add"
         size={28}

--- a/src/components/wavesTabBar/wavesTabBar.tsx
+++ b/src/components/wavesTabBar/wavesTabBar.tsx
@@ -31,6 +31,8 @@ const WavesTabBar = ({ onTabPress, ...props }: Props) => {
         {...props}
         style={styles.tabBarStyle}
         indicatorStyle={styles.indicatorStyle}
+        // minWidth mirrors FeedTabBar: a third of the width, minus ~14px for the
+        // trailing "+" button's padding (paddingLeft 8 + paddingRight 12).
         tabStyle={{ ...styles.tabStyle, minWidth: layout.width / 3 - 14 }}
         scrollEnabled={true}
         onTabPress={({ route, preventDefault }) => {

--- a/src/components/wavesTabBar/wavesTabBarStyles.ts
+++ b/src/components/wavesTabBar/wavesTabBarStyles.ts
@@ -1,47 +1,42 @@
 import EStyleSheet from 'react-native-extended-stylesheet';
 import { TextStyle, ViewStyle } from 'react-native';
-import getWindowDimensions from '../../utils/getWindowDimensions';
 
-const deviceWidth = getWindowDimensions().width;
-
+// Mirrors src/components/tabbedPosts/styles/feedTabBar.styles.ts so the waves
+// tab bar is visually identical to the home feed's (pill active tab over a
+// transparent indicator, trailing "+").
 export default EStyleSheet.create({
   container: {
     flexDirection: 'row',
     alignItems: 'center',
-    backgroundColor: '$primaryBackgroundColor',
+    backgroundColor: '$primaryLightBackground',
   } as ViewStyle,
 
   tabBarStyle: {
     flex: 1,
-    backgroundColor: 'transparent',
+    backgroundColor: '$primaryLightBackground',
     shadowColor: 'transparent',
-    elevation: 0,
   } as ViewStyle,
 
   indicatorStyle: {
-    backgroundColor: '$primaryBlue',
-    height: 2,
+    backgroundColor: 'transparent',
   } as ViewStyle,
 
-  // Only applied when scrolling (3+ tabs); the two base tabs are left to flex
-  // evenly across the full width.
-  tabStyleScroll: {
+  // minWidth is applied inline (layout.width / 3 - 14) to match FeedTabBar.
+  tabStyle: {
     width: 'auto',
-    minWidth: deviceWidth / 3 - 16,
-    paddingHorizontal: 12,
-    height: 44,
+    paddingHorizontal: 0,
+    height: 38,
+    paddingTop: 0,
   } as ViewStyle,
 
   addButtonWrapper: {
-    paddingHorizontal: 14,
-    height: 44,
-    alignItems: 'center',
-    justifyContent: 'center',
+    paddingRight: 12,
+    paddingLeft: 8,
+    width: 44,
+    alignSelf: 'center',
   } as ViewStyle,
 
   addButtonIcon: {
-    // Matches the main feed's "+" exactly (Ionicons "add" via iconType
-    // "MaterialIcon", $darkIconColor) for cross-tab-bar consistency.
     color: '$darkIconColor',
     textAlign: 'center',
   } as TextStyle,

--- a/src/screens/waves/screen/wavesScreen.tsx
+++ b/src/screens/waves/screen/wavesScreen.tsx
@@ -23,6 +23,7 @@ import {
   FabButton,
 } from '../../../components/index';
 import WavesTabBar from '../../../components/wavesTabBar/wavesTabBar';
+import { renderPillTabLabel } from '../../../components/tabbedPosts/view/renderPillTabLabel';
 import styles from '../styles/wavesScreen.styles';
 import { wavesQueries } from '../../../providers/queries';
 import { useAppSelector } from '../../../hooks';
@@ -454,7 +455,7 @@ const WavesScreen = () => {
             lazy={true}
             swipeEnabled={isLoggedIn}
             commonOptions={{
-              labelStyle: styles.tabLabelColor,
+              label: renderPillTabLabel,
             }}
           />
         ) : null}


### PR DESCRIPTION
## Why
Two problems with the waves tab bar (follow-up to #3297/#3300):
1. It didn't match the home feed — plain blue underline + sentence-case labels vs. the feed's uppercase blue **pill** active tab.
2. The **"+" was getting clipped**: with 2 tabs it used `scrollEnabled={false}`, which makes react-native-tab-view size each tab to `layout.width / tabCount` (full screen width), overflowing the row and pushing the trailing `+` off-screen.

## What
Adopt the home-feed (`FeedTabBar`) look for waves, with a small shared extraction so the pill style has one source of truth:

- **New `renderPillTabLabel`** (`components/tabbedPosts/view/`): the feed's `<Tag isFilter isPin={focused}>` pill label, extracted as an intl-free helper. The home feed's `tabbedPosts` now delegates to it (keeping its own i18n key resolution) — **behaviour-identical**, so the four `FeedTabBar` screens (feed, community, profile, tag-result) are unchanged.
- **`WavesTabBar` mirrors `FeedTabBar`**: transparent indicator + uppercase pill active tab (via the TabView `commonOptions.label`), always-scrollable tabs (so the `+` is never clipped), feed-matched `tabStyle`, and a `+` identical to the feed's (Ionicons "add", size 28, `$darkIconColor`). `wavesScreen` sets `commonOptions.label = renderPillTabLabel`.

Chose this over a single generic tab-bar shell: `FeedTabBar` is used on 4 screens with hardwired Redux/walkthrough/login coupling through `CustomiseFiltersModal`, so folding it into one component is high blast-radius for a cosmetic goal. Each bar keeps owning its own "+" modal (waves → tag picker, feed → customise filters).

## Verification
- ESLint clean; full jest suite **442 passing**.
- On-device checklist (styling can't be verified in CI): waves tabs render as uppercase blue pills (active filled, inactive gray, no underline); the **"+" is visible** at the right on both 2-tab and 3+-tab states; tapping it opens the tag picker; the home feed / community / profile / tag-result tabs are unchanged and the feed "+" still opens customise-filters. Check iOS + Android (the `Tag` pill padding differs by platform).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Refreshed pill-style tab labels for a more consistent look across tabbed views.
  * Updated Waves tab bar to calculate responsive tab sizing and keep tab scrolling enabled for smoother navigation.

* **Bug Fixes**
  * Improved Waves tab bar styling, including spacing and alignment for tabs and the “+” add button.
  * Tab label rendering is now more consistent and correctly reflects the focused/active state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->