### PR TITLE
feat(waves): native audio player for Liketu Speak voice posts

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@babel/preset-typescript": "^7.26.0",
     "@babel/runtime": "^7.26.7",
-    "@ecency/render-helper": "^2.5.15",
+    "@ecency/render-helper": "^2.5.16",
     "@ecency/sdk": "^2.3.25",
     "@esteemapp/react-native-autocomplete-input": "^4.2.1",
     "@esteemapp/react-native-multi-slider": "^1.1.0",

--- a/src/components/comment/view/commentView.tsx
+++ b/src/components/comment/view/commentView.tsx
@@ -160,6 +160,8 @@ const CommentView = ({
         <CommentBody
           body={comment.body}
           metadata={comment.json_metadata}
+          author={comment.author}
+          permlink={comment.permlink}
           key={`key-${comment.permlink}`}
           hideContent={_hideContent}
           commentDepth={_depth}

--- a/src/components/postElements/body/view/commentBodyView.tsx
+++ b/src/components/postElements/body/view/commentBodyView.tsx
@@ -21,6 +21,8 @@ import { GLOBAL_POST_FILTERS_VALUE } from '../../../../constants/options/filters
 interface CommentBodyProps {
   body: string;
   metadata?: any;
+  author?: string;
+  permlink?: string;
   commentDepth: number;
   hideContent: boolean;
   handleOnUserPress: () => void;
@@ -37,6 +39,8 @@ interface CommentBodyProps {
 const CommentBody = ({
   body,
   metadata,
+  author,
+  permlink,
   commentDepth,
   hideContent,
   handleOnUserPress,
@@ -131,6 +135,8 @@ const CommentBody = ({
             contentWidth={_contentWidth}
             body={body}
             metadata={metadata}
+            author={author}
+            permlink={permlink}
             isComment={true}
             setSelectedImage={handleImagePress}
             setSelectedLink={handleLinkPress}

--- a/src/components/postElements/body/view/postBodyView.tsx
+++ b/src/components/postElements/body/view/postBodyView.tsx
@@ -23,6 +23,8 @@ import { SheetNames } from '../../../../navigation/sheets';
 interface PostBodyProps {
   body: string;
   metadata: any;
+  author?: string;
+  permlink?: string;
   width: number;
   enableViewabilityTracker?: boolean;
   onLoadEnd: () => void;
@@ -31,6 +33,8 @@ interface PostBodyProps {
 const PostBody = ({
   body,
   metadata,
+  author,
+  permlink,
   width,
   enableViewabilityTracker,
   onLoadEnd,
@@ -271,6 +275,8 @@ const PostBody = ({
           key={`html_content_${contentWidth}`} // makes sure html content is rerendered on width update
           body={html}
           metadata={metadata}
+          author={author}
+          permlink={permlink}
           contentWidth={contentWidth}
           enableViewabilityTracker={enableViewabilityTracker}
           onLoaded={_handleLoadEnd}

--- a/src/components/postHtmlRenderer/postHtmlRenderer.tsx
+++ b/src/components/postHtmlRenderer/postHtmlRenderer.tsx
@@ -41,6 +41,9 @@ interface PostHtmlRendererProps {
   contentWidth: number;
   body: string;
   metadata: any;
+  // Wave author/permlink, used to build the Speak voice-player stream URL.
+  author?: string;
+  permlink?: string;
   isComment?: boolean;
   enableViewabilityTracker?: boolean;
   onLoaded?: () => void;
@@ -60,6 +63,8 @@ export const PostHtmlRenderer = memo(
     contentWidth,
     body,
     metadata,
+    author,
+    permlink,
     isComment,
     enableViewabilityTracker,
     onLoaded,
@@ -756,7 +761,14 @@ export const PostHtmlRenderer = memo(
           WebView={WebView}
           pressableHightlightColor="transparent"
         />
-        {extractedSpeak && <SpeakAudioPlayer contentWidth={contentWidth} speak={extractedSpeak} />}
+        {extractedSpeak && (
+          <SpeakAudioPlayer
+            contentWidth={contentWidth}
+            speak={extractedSpeak}
+            author={author}
+            permlink={permlink}
+          />
+        )}
         {extractedVideo && (
           <VideoThumb
             contentWidth={contentWidth}
@@ -771,6 +783,8 @@ export const PostHtmlRenderer = memo(
   (next, prev) =>
     next.body === prev.body &&
     next.metadata === prev.metadata &&
+    next.author === prev.author &&
+    next.permlink === prev.permlink &&
     next.contentWidth === prev.contentWidth &&
     next.isComment === prev.isComment &&
     next.enableViewabilityTracker === prev.enableViewabilityTracker,

--- a/src/components/postHtmlRenderer/postHtmlRenderer.tsx
+++ b/src/components/postHtmlRenderer/postHtmlRenderer.tsx
@@ -13,6 +13,7 @@ import { postBodySummary } from '@ecency/render-helper';
 import styles from './postHtmlRendererStyles';
 import { LinkData, parseLinkData } from './linkDataParser';
 import VideoThumb from './videoThumb';
+import SpeakAudioPlayer, { SpeakMeta } from './speakAudioPlayer';
 import { AutoHeightImage } from '../autoHeightImage/autoHeightImage';
 import { HiveLinkPreview, UserAvatar, VideoPlayer } from '..';
 import {
@@ -75,9 +76,14 @@ export const PostHtmlRenderer = memo(
     const postImgUrlsRef = useRef<string[]>([]);
 
     // Memoize body processing to avoid expensive regex operations on every render
-    const { processedBody, extractedVideo } = useMemo(() => {
+    const { processedBody, extractedVideo, extractedSpeak } = useMemo(() => {
       let processed = body;
       let video: { embedSrc?: string; thumbUrl?: string } | null = null;
+
+      // Liketu Speak voice post: the audio + waveform live in json_metadata.speak.
+      // Render a native player from metadata (below) and suppress the body's own
+      // audio markup so it doesn't double up or get mistaken for a video embed.
+      const speak: SpeakMeta | null = metadata?.speak?.audio_url ? metadata.speak : null;
 
       if (processed) {
         processed = processed
@@ -85,6 +91,17 @@ export const PostHtmlRenderer = memo(
           .replace(/<\/center>/g, '</div>')
           .replace(/<span(.*?)>/g, '') // TODO: later handle span with propties lie <span class="ll-key"> and remove on raw <span/>
           .replace(/<\/span>/g, '');
+
+        if (speak) {
+          // render-helper emits either an <audio> element or a markdown link to
+          // the .webm; drop both — the native player replaces them.
+          processed = processed
+            .replace(/<audio[\s\S]*?<\/audio>/gi, '')
+            .replace(
+              /<a[^>]*href="[^"]*cdn\.liketu\.com[^"]*\.(?:webm|mp3|m4a|ogg|wav)[^"]*"[^>]*>[\s\S]*?<\/a>/gi,
+              '',
+            );
+        }
 
         // For waves, extract the *trailing* video link and render
         // it as a separate block below text. This avoids inline
@@ -104,7 +121,7 @@ export const PostHtmlRenderer = memo(
             'i',
           );
           const videoMatch = processed.match(videoTailRx);
-          if (videoMatch && !videoMatch[1].includes('markdown-video-link-youtube')) {
+          if (videoMatch && !speak && !videoMatch[1].includes('markdown-video-link-youtube')) {
             const html = videoMatch[1];
             const embedMatch = html.match(/data-embed-src="([^"]*)"/);
             const thumbRx = /class="[^"]*video-thumbnail[^"]*"[^>]*src="([^"]*)"/;
@@ -117,7 +134,7 @@ export const PostHtmlRenderer = memo(
           }
 
           // Match trailing iframe video embeds (3speak etc.)
-          if (!video) {
+          if (!video && !speak) {
             const iframeTailRx = new RegExp(
               `(<iframe[^>]*src="([^"]*)"[^>]*>[\\s\\S]*?</iframe>)${tail}`,
               'i',
@@ -142,7 +159,7 @@ export const PostHtmlRenderer = memo(
           );
         }
       }
-      return { processedBody: processed, extractedVideo: video };
+      return { processedBody: processed, extractedVideo: video, extractedSpeak: speak };
     }, [body, metadata]);
 
     const _minTableColWidth = contentWidth / 3 - 12;
@@ -739,6 +756,7 @@ export const PostHtmlRenderer = memo(
           WebView={WebView}
           pressableHightlightColor="transparent"
         />
+        {extractedSpeak && <SpeakAudioPlayer contentWidth={contentWidth} speak={extractedSpeak} />}
         {extractedVideo && (
           <VideoThumb
             contentWidth={contentWidth}

--- a/src/components/postHtmlRenderer/speakAudioPlayer.tsx
+++ b/src/components/postHtmlRenderer/speakAudioPlayer.tsx
@@ -1,0 +1,209 @@
+import React, { useMemo, useRef, useState } from 'react';
+import {
+  ActivityIndicator,
+  GestureResponderEvent,
+  LayoutChangeEvent,
+  Pressable,
+  Text,
+  View,
+} from 'react-native';
+import Video, { VideoRef } from 'react-native-video';
+import Svg, { Rect } from 'react-native-svg';
+import EStyleSheet from 'react-native-extended-stylesheet';
+import { Icon } from '../icon';
+import {
+  formatDuration,
+  getSpeakAudioStreamUrl,
+  playbackProgress,
+  playedBarCount,
+} from './speakAudioPlayer.utils';
+import styles from './speakAudioPlayerStyles';
+
+export interface SpeakMeta {
+  audio_url: string;
+  duration_ms?: number;
+  waveform_peaks?: number[];
+}
+
+const WAVE_HEIGHT = 34;
+const MIN_BAR_HEIGHT = 3;
+const BAR_GAP = 2;
+
+/**
+ * Native player for Liketu "Speak" voice posts. Plays the transcoded AAC stream
+ * (so iOS AVPlayer can decode it; the source is Opus/WebM) via react-native-video
+ * and draws json_metadata.speak.waveform_peaks as a tappable waveform. The Video
+ * element is mounted lazily on first play so we never transcode a clip the user
+ * never listens to.
+ */
+const SpeakAudioPlayer = ({ contentWidth, speak }: { contentWidth: number; speak: SpeakMeta }) => {
+  const playerRef = useRef<VideoRef>(null);
+  // When the user seeks before the stream has loaded, remember where to jump to
+  // once onLoad fires.
+  const seekOnLoadRef = useRef<number | null>(null);
+
+  const [started, setStarted] = useState(false);
+  const [paused, setPaused] = useState(true);
+  const [loading, setLoading] = useState(false);
+  const [currentTime, setCurrentTime] = useState(0);
+  const [duration, setDuration] = useState(
+    speak.duration_ms && speak.duration_ms > 0 ? speak.duration_ms / 1000 : 0,
+  );
+  const [waveWidth, setWaveWidth] = useState(0);
+
+  const uri = useMemo(() => getSpeakAudioStreamUrl(speak.audio_url), [speak.audio_url]);
+  const peaks =
+    Array.isArray(speak.waveform_peaks) && speak.waveform_peaks.length > 0
+      ? speak.waveform_peaks
+      : null;
+
+  const progress = playbackProgress(currentTime, duration);
+  const playedColor = EStyleSheet.value('$primaryBlue');
+  const unplayedColor = EStyleSheet.value('$borderColor');
+
+  const _togglePlay = () => {
+    if (!started) {
+      setStarted(true);
+    }
+    setPaused((p) => !p);
+  };
+
+  const _seekToFraction = (fraction: number) => {
+    if (duration <= 0) {
+      return;
+    }
+    const target = Math.max(0, Math.min(1, fraction)) * duration;
+    setCurrentTime(target);
+    if (started) {
+      playerRef.current?.seek(target);
+    } else {
+      // Start playback at the tapped position.
+      seekOnLoadRef.current = target;
+      setStarted(true);
+      setPaused(false);
+    }
+  };
+
+  const _onWaveLayout = (e: LayoutChangeEvent) => setWaveWidth(e.nativeEvent.layout.width);
+
+  const _onWavePress = (e: GestureResponderEvent) => {
+    if (waveWidth > 0) {
+      _seekToFraction(e.nativeEvent.locationX / waveWidth);
+    }
+  };
+
+  const _onLoad = (data: { duration: number }) => {
+    if (Number.isFinite(data?.duration) && data.duration > 0) {
+      setDuration(data.duration);
+    }
+    const pending = seekOnLoadRef.current;
+    seekOnLoadRef.current = null;
+    playerRef.current?.seek(pending ?? 0);
+    setLoading(false);
+  };
+
+  const _onProgress = (data: { currentTime: number }) => {
+    if (!loading) {
+      setCurrentTime(data.currentTime);
+    }
+  };
+
+  const _onEnd = () => {
+    setPaused(true);
+    setCurrentTime(0);
+    playerRef.current?.seek(0);
+  };
+
+  const _onError = () => {
+    // Endpoint not yet deployed / transient stream failure: stop the spinner and
+    // reset to a tappable paused state rather than spinning forever.
+    setLoading(false);
+    setPaused(true);
+    setStarted(false);
+  };
+
+  const _renderWaveform = () => {
+    if (waveWidth <= 0) {
+      return null;
+    }
+    if (!peaks) {
+      // No waveform data: a thin progress track.
+      return (
+        <View style={styles.fallbackTrack}>
+          <View style={[styles.fallbackFill, { width: waveWidth * progress }]} />
+        </View>
+      );
+    }
+    const maxPeak = Math.max(...peaks, 0.0001);
+    const barW = Math.max(1.5, (waveWidth - (peaks.length - 1) * BAR_GAP) / peaks.length);
+    const played = playedBarCount(peaks.length, progress);
+    return (
+      <Svg width={waveWidth} height={WAVE_HEIGHT}>
+        {peaks.map((peak, i) => {
+          const h = Math.max(MIN_BAR_HEIGHT, (peak / maxPeak) * WAVE_HEIGHT);
+          return (
+            <Rect
+              // positional waveform bars never reorder, so index is a stable key
+              // eslint-disable-next-line react/no-array-index-key
+              key={i}
+              x={i * (barW + BAR_GAP)}
+              y={(WAVE_HEIGHT - h) / 2}
+              width={barW}
+              height={h}
+              rx={barW / 2}
+              fill={i < played ? playedColor : unplayedColor}
+            />
+          );
+        })}
+      </Svg>
+    );
+  };
+
+  return (
+    <View style={[styles.container, { width: contentWidth }]}>
+      <Pressable
+        style={styles.playButton}
+        onPress={_togglePlay}
+        accessibilityRole="button"
+        accessibilityLabel={paused ? 'Play voice' : 'Pause voice'}
+      >
+        {loading ? (
+          <ActivityIndicator size="small" color={EStyleSheet.value('$pureWhite')} />
+        ) : (
+          <Icon
+            iconType="MaterialIcons"
+            name={paused ? 'play-arrow' : 'pause'}
+            size={24}
+            style={styles.playIcon}
+          />
+        )}
+      </Pressable>
+
+      <Pressable style={styles.waveArea} onPress={_onWavePress} onLayout={_onWaveLayout}>
+        {_renderWaveform()}
+      </Pressable>
+
+      <Text style={styles.time}>{formatDuration(started ? currentTime : duration)}</Text>
+
+      {started && !!uri && (
+        <Video
+          ref={playerRef}
+          source={{ uri }}
+          paused={paused}
+          onLoad={_onLoad}
+          onLoadStart={() => setLoading(true)}
+          onProgress={_onProgress}
+          onBuffer={({ isBuffering }) => setLoading(isBuffering)}
+          onEnd={_onEnd}
+          onError={_onError}
+          ignoreSilentSwitch="ignore"
+          playInBackground={false}
+          progressUpdateInterval={250}
+          style={styles.hiddenVideo}
+        />
+      )}
+    </View>
+  );
+};
+
+export default SpeakAudioPlayer;

--- a/src/components/postHtmlRenderer/speakAudioPlayer.tsx
+++ b/src/components/postHtmlRenderer/speakAudioPlayer.tsx
@@ -36,7 +36,17 @@ const BAR_GAP = 2;
  * element is mounted lazily on first play so we never transcode a clip the user
  * never listens to.
  */
-const SpeakAudioPlayer = ({ contentWidth, speak }: { contentWidth: number; speak: SpeakMeta }) => {
+const SpeakAudioPlayer = ({
+  contentWidth,
+  speak,
+  author,
+  permlink,
+}: {
+  contentWidth: number;
+  speak: SpeakMeta;
+  author?: string;
+  permlink?: string;
+}) => {
   const playerRef = useRef<VideoRef>(null);
   // When the user seeks before the stream has loaded, remember where to jump to
   // once onLoad fires.
@@ -51,7 +61,7 @@ const SpeakAudioPlayer = ({ contentWidth, speak }: { contentWidth: number; speak
   );
   const [waveWidth, setWaveWidth] = useState(0);
 
-  const uri = useMemo(() => getSpeakAudioStreamUrl(speak.audio_url), [speak.audio_url]);
+  const uri = useMemo(() => getSpeakAudioStreamUrl(author, permlink), [author, permlink]);
   const peaks =
     Array.isArray(speak.waveform_peaks) && speak.waveform_peaks.length > 0
       ? speak.waveform_peaks

--- a/src/components/postHtmlRenderer/speakAudioPlayer.utils.test.ts
+++ b/src/components/postHtmlRenderer/speakAudioPlayer.utils.test.ts
@@ -1,0 +1,65 @@
+import {
+  SPEAK_AUDIO_ENDPOINT,
+  getSpeakAudioStreamUrl,
+  formatDuration,
+  playedBarCount,
+  playbackProgress,
+} from './speakAudioPlayer.utils';
+
+describe('getSpeakAudioStreamUrl', () => {
+  it('builds the transcode endpoint url with an encoded src', () => {
+    const src = 'https://cdn.liketu.com/liketu/speak/erilej/re-x/1781649490185-10c50f00.webm';
+    const url = getSpeakAudioStreamUrl(src);
+    expect(url.startsWith(`${SPEAK_AUDIO_ENDPOINT}?src=`)).toBe(true);
+    expect(url).toContain(encodeURIComponent(src));
+    // the raw (unencoded) url must not leak through, so the query stays a single param
+    expect(url.split('?src=')[1]).toBe(encodeURIComponent(src));
+  });
+
+  it('returns an empty string for missing input', () => {
+    expect(getSpeakAudioStreamUrl(undefined)).toBe('');
+    expect(getSpeakAudioStreamUrl(null)).toBe('');
+    expect(getSpeakAudioStreamUrl('')).toBe('');
+  });
+});
+
+describe('formatDuration', () => {
+  it.each([
+    [60, '1:00'],
+    [5, '0:05'],
+    [0, '0:00'],
+    [125, '2:05'],
+    [59.9, '0:59'],
+  ])('formats %s seconds as %s', (input, expected) => {
+    expect(formatDuration(input)).toBe(expected);
+  });
+
+  it('treats invalid/negative input as zero', () => {
+    expect(formatDuration(undefined)).toBe('0:00');
+    expect(formatDuration(-10)).toBe('0:00');
+    expect(formatDuration(NaN)).toBe('0:00');
+  });
+});
+
+describe('playedBarCount', () => {
+  it('returns a clamped, rounded count of played bars', () => {
+    expect(playedBarCount(48, 0)).toBe(0);
+    expect(playedBarCount(48, 1)).toBe(48);
+    expect(playedBarCount(48, 0.5)).toBe(24);
+    expect(playedBarCount(48, 2)).toBe(48); // over-progress clamps to count
+    expect(playedBarCount(48, -1)).toBe(0);
+  });
+
+  it('handles empty waveforms', () => {
+    expect(playedBarCount(0, 0.5)).toBe(0);
+  });
+});
+
+describe('playbackProgress', () => {
+  it('returns the clamped fraction', () => {
+    expect(playbackProgress(30, 60)).toBe(0.5);
+    expect(playbackProgress(90, 60)).toBe(1);
+    expect(playbackProgress(10, 0)).toBe(0); // no duration yet
+    expect(playbackProgress(-5, 60)).toBe(0);
+  });
+});

--- a/src/components/postHtmlRenderer/speakAudioPlayer.utils.test.ts
+++ b/src/components/postHtmlRenderer/speakAudioPlayer.utils.test.ts
@@ -7,19 +7,22 @@ import {
 } from './speakAudioPlayer.utils';
 
 describe('getSpeakAudioStreamUrl', () => {
-  it('builds the transcode endpoint url with an encoded src', () => {
-    const src = 'https://cdn.liketu.com/liketu/speak/erilej/re-x/1781649490185-10c50f00.webm';
-    const url = getSpeakAudioStreamUrl(src);
-    expect(url.startsWith(`${SPEAK_AUDIO_ENDPOINT}?src=`)).toBe(true);
-    expect(url).toContain(encodeURIComponent(src));
-    // the raw (unencoded) url must not leak through, so the query stays a single param
-    expect(url.split('?src=')[1]).toBe(encodeURIComponent(src));
+  it('builds the endpoint url from author + permlink', () => {
+    const url = getSpeakAudioStreamUrl('erilej', 're-liketu-speak-x');
+    expect(url).toBe(`${SPEAK_AUDIO_ENDPOINT}?author=erilej&permlink=re-liketu-speak-x`);
   });
 
-  it('returns an empty string for missing input', () => {
-    expect(getSpeakAudioStreamUrl(undefined)).toBe('');
-    expect(getSpeakAudioStreamUrl(null)).toBe('');
-    expect(getSpeakAudioStreamUrl('')).toBe('');
+  it('encodes the params', () => {
+    expect(getSpeakAudioStreamUrl('a b', 'p/q')).toBe(
+      `${SPEAK_AUDIO_ENDPOINT}?author=a%20b&permlink=p%2Fq`,
+    );
+  });
+
+  it('returns an empty string when author or permlink is missing', () => {
+    expect(getSpeakAudioStreamUrl(undefined, undefined)).toBe('');
+    expect(getSpeakAudioStreamUrl('erilej', undefined)).toBe('');
+    expect(getSpeakAudioStreamUrl(undefined, 'permlink')).toBe('');
+    expect(getSpeakAudioStreamUrl('', '')).toBe('');
   });
 });
 

--- a/src/components/postHtmlRenderer/speakAudioPlayer.utils.ts
+++ b/src/components/postHtmlRenderer/speakAudioPlayer.utils.ts
@@ -3,12 +3,18 @@
 
 // The web endpoint that transcodes Liketu's Opus/WebM voice clips to AAC/m4a so
 // iOS AVPlayer (react-native-video) can play them. See vision-next
-// /api/speak-audio. The source audio is immutable, so responses are edge-cached.
+// /api/speak-audio. It takes the wave's author+permlink (NOT the raw audio URL):
+// the server looks the wave up on chain and derives audio_url itself, so the
+// fetch target is never user-supplied. The audio is immutable -> edge-cached.
 export const SPEAK_AUDIO_ENDPOINT = 'https://ecency.com/api/speak-audio';
 
-/** Build the playable (transcoded) stream URL for a Liketu Speak audio file. */
-export const getSpeakAudioStreamUrl = (audioUrl?: string | null): string =>
-  audioUrl ? `${SPEAK_AUDIO_ENDPOINT}?src=${encodeURIComponent(audioUrl)}` : '';
+/** Build the playable (transcoded) stream URL for a Liketu Speak wave. */
+export const getSpeakAudioStreamUrl = (author?: string | null, permlink?: string | null): string =>
+  author && permlink
+    ? `${SPEAK_AUDIO_ENDPOINT}?author=${encodeURIComponent(author)}&permlink=${encodeURIComponent(
+        permlink,
+      )}`
+    : '';
 
 /** Format seconds as "m:ss" (e.g. 60 -> "1:00", 5 -> "0:05"). */
 export const formatDuration = (seconds?: number): string => {

--- a/src/components/postHtmlRenderer/speakAudioPlayer.utils.ts
+++ b/src/components/postHtmlRenderer/speakAudioPlayer.utils.ts
@@ -1,0 +1,34 @@
+// Helpers for the Liketu Speak voice-post player. Kept pure + separate from the
+// component so the URL building and waveform/time math are unit-testable.
+
+// The web endpoint that transcodes Liketu's Opus/WebM voice clips to AAC/m4a so
+// iOS AVPlayer (react-native-video) can play them. See vision-next
+// /api/speak-audio. The source audio is immutable, so responses are edge-cached.
+export const SPEAK_AUDIO_ENDPOINT = 'https://ecency.com/api/speak-audio';
+
+/** Build the playable (transcoded) stream URL for a Liketu Speak audio file. */
+export const getSpeakAudioStreamUrl = (audioUrl?: string | null): string =>
+  audioUrl ? `${SPEAK_AUDIO_ENDPOINT}?src=${encodeURIComponent(audioUrl)}` : '';
+
+/** Format seconds as "m:ss" (e.g. 60 -> "1:00", 5 -> "0:05"). */
+export const formatDuration = (seconds?: number): string => {
+  const s = Number.isFinite(seconds) && (seconds as number) > 0 ? Math.floor(seconds as number) : 0;
+  const m = Math.floor(s / 60);
+  return `${m}:${(s % 60).toString().padStart(2, '0')}`;
+};
+
+/**
+ * How many of `barCount` waveform bars should render as "played" for a given
+ * progress fraction (0..1). Clamped so it never exceeds the bar count.
+ */
+export const playedBarCount = (barCount: number, progress: number): number => {
+  if (barCount <= 0) return 0;
+  const clamped = Math.max(0, Math.min(1, Number.isFinite(progress) ? progress : 0));
+  return Math.min(barCount, Math.round(clamped * barCount));
+};
+
+/** Playback progress fraction (0..1) from current time + total duration. */
+export const playbackProgress = (currentTime: number, duration: number): number => {
+  if (!Number.isFinite(duration) || duration <= 0) return 0;
+  return Math.max(0, Math.min(1, currentTime / duration));
+};

--- a/src/components/postHtmlRenderer/speakAudioPlayerStyles.ts
+++ b/src/components/postHtmlRenderer/speakAudioPlayerStyles.ts
@@ -1,0 +1,63 @@
+import EStyleSheet from 'react-native-extended-stylesheet';
+import { TextStyle, ViewStyle } from 'react-native';
+
+export default EStyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '$primaryLightBackground',
+    borderRadius: 14,
+    paddingVertical: 8,
+    paddingHorizontal: 10,
+    marginTop: 8,
+    marginBottom: 4,
+  } as ViewStyle,
+
+  playButton: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    backgroundColor: '$primaryBlue',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginRight: 10,
+  } as ViewStyle,
+
+  playIcon: {
+    color: '$pureWhite',
+  } as TextStyle,
+
+  waveArea: {
+    flex: 1,
+    height: 34,
+    justifyContent: 'center',
+  } as ViewStyle,
+
+  fallbackTrack: {
+    height: 4,
+    borderRadius: 2,
+    backgroundColor: '$borderColor',
+    overflow: 'hidden',
+  } as ViewStyle,
+
+  fallbackFill: {
+    height: 4,
+    borderRadius: 2,
+    backgroundColor: '$primaryBlue',
+  } as ViewStyle,
+
+  time: {
+    marginLeft: 10,
+    minWidth: 34,
+    textAlign: 'right',
+    color: '$primaryBlack',
+    fontSize: 12,
+    fontWeight: '600',
+  } as TextStyle,
+
+  // Audio-only: the Video element is mounted but not shown.
+  hiddenVideo: {
+    width: 0,
+    height: 0,
+  } as ViewStyle,
+});

--- a/src/components/postView/view/postDisplayView.tsx
+++ b/src/components/postView/view/postDisplayView.tsx
@@ -464,6 +464,8 @@ const PostDisplayView = ({
               <PostBody
                 body={post.body}
                 metadata={post.json_metadata}
+                author={post.author}
+                permlink={post.permlink}
                 enableViewabilityTracker={true}
                 onLoadEnd={_handleOnPostBodyLoad}
               />

--- a/yarn.lock
+++ b/yarn.lock
@@ -1192,10 +1192,10 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@ecency/render-helper@^2.5.15":
-  version "2.5.15"
-  resolved "https://registry.yarnpkg.com/@ecency/render-helper/-/render-helper-2.5.15.tgz#393ab93eb421a26b8e2d5255207c61a8b2be90c8"
-  integrity sha512-m5/fqC4R7s2+4vsO5YeBWOtl08fcnbqi/moJR7eV8b5MJPOJAxiVqzMBB2EAm2LwDTh7YLBAF2JO9JQDodpfoQ==
+"@ecency/render-helper@^2.5.16":
+  version "2.5.16"
+  resolved "https://registry.yarnpkg.com/@ecency/render-helper/-/render-helper-2.5.16.tgz#f5d95415e245edd76ca0cb62d0f6f8f46aad7121"
+  integrity sha512-zNqzftJIqt2Qun/C4SborZAK9DT0qALODvBcCTtXE49jxEgqpMLLbXJU/I53s+dJBmKAlB/rQOo7nGfWHth11A==
   dependencies:
     "@xmldom/xmldom" "^0.9.10"
     dom-serializer "^2.0.0"


### PR DESCRIPTION
## Why

Liketu "Speak" voice posts (now surfaced in the Waves feed via the SPEAKS source tab) had **no playable audio** in the app. Two reasons:
1. The audio is **Opus in a WebM container**, which iOS `AVPlayer` (`react-native-video`) cannot decode.
2. `@ecency/render-helper` turns the audio link into an `<audio>` element, but `react-native-render-html` has no `<audio>` renderer, so it is silently dropped on mobile.

## What

A native `SpeakAudioPlayer` driven by `json_metadata.speak` (`audio_url`, `duration_ms`, `waveform_peaks`):

- Plays the **transcoded AAC stream** via the new web `/api/speak-audio` endpoint, so iOS can decode it. The `Video` element is **mounted lazily on first play**, so a clip is only transcoded when actually listened to.
- Draws `waveform_peaks` as a tappable **SVG waveform** (played/unplayed colour split, tap-to-seek) with a play/pause button and duration. Falls back to a thin progress track when a post has no waveform data.
- Graceful failure: if the stream errors (e.g. endpoint not yet live), it resets to a tappable paused state instead of spinning.

`postHtmlRenderer` detects `metadata.speak.audio_url`, renders the player below the body, strips the body's own audio markup, and skips the trailing-video extraction so the `.webm` link isn't mistaken for a video.

No new dependencies (`react-native-video` + `react-native-svg` already present).

## Depends on

The transcode endpoint: **ecency/vision-next#1019** (`/api/speak-audio`). This player points at `https://ecency.com/api/speak-audio`, so that PR should be deployed to production before this ships. Until then the waveform renders and playback fails gracefully.

## Test

- Unit tests for the pure helpers (stream URL building, time formatting, waveform/progress math).
- Full unit suite green (456 passing).
- Needs on-device QA: play/pause, tap-to-seek on the waveform, silent-switch playback on iOS, and confirm the hidden (audio-only) Video initialises on both platforms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added native “Liketu Speak” audio playback inside posts, including play/pause controls, waveform, tap-to-seek, and formatted time/duration.
* **Bug Fixes**
  * Prevented duplicate or incorrect embeds by suppressing Speak-generated audio/video markup when a Speak post is detected.
* **Improvements**
  * Extended post and comment rendering to pass author/permlink through so Speak posts use the correct audio stream.
* **Tests**
  * Added unit tests for Speak audio URL building, duration formatting, waveform/playback progress calculations.
* **Chores**
  * Updated the `@ecency/render-helper` dependency patch version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->