### PR TITLE
fix(waves): make the Speak audio player audible on iOS

### DIFF
--- a/src/components/postHtmlRenderer/speakAudioPlayerStyles.ts
+++ b/src/components/postHtmlRenderer/speakAudioPlayerStyles.ts
@@ -55,9 +55,15 @@ export default EStyleSheet.create({
     fontWeight: '600',
   } as TextStyle,
 
-  // Audio-only: the Video element is mounted but not shown.
+  // Audio-only: the Video is mounted but visually hidden. It must have REAL
+  // (non-zero) bounds: iOS won't activate the AVAudioSession for a 0x0 layer, so
+  // a 0x0 audio player decodes/advances but outputs no sound (even with
+  // ignoreSilentSwitch). 1x1 + opacity 0, absolutely positioned so it doesn't
+  // affect layout or intercept taps.
   hiddenVideo: {
-    width: 0,
-    height: 0,
+    position: 'absolute',
+    width: 1,
+    height: 1,
+    opacity: 0,
   } as ViewStyle,
 });


### PR DESCRIPTION
## Problem

Liketu Speak voice posts play (the waveform/position advances) but produce **no sound on iOS** — not a mute/volume issue.

## Cause

The audio-only `<Video>` in `SpeakAudioPlayer` was styled `width: 0, height: 0`. On iOS, `AVPlayer` does not activate its audio session for a zero-size layer, so the clip decodes and the timeline advances but no audio is output — even with `ignoreSilentSwitch="ignore"` set. (Android/ExoPlayer is unaffected, which is why it can differ by platform.)

Verified the bytes are fine: the `/api/speak-audio` transcode carries full audio across multiple clips (e.g. -16 to -25 dB mean), so this is purely the iOS audio-session activation, not the media.

## Fix

Give the hidden Video real but invisible bounds — `position: absolute`, `1x1`, `opacity: 0` — so iOS activates the audio session while it stays out of layout and off the tap targets. `ignoreSilentSwitch="ignore"` is retained so it also plays with the ring switch silenced.

## Test

- Confirmed via the API that transcoded output is audible across clips (ffprobe + volumedetect).
- Needs on-device iOS confirmation that sound now plays (can't be exercised in CI/jest).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio playback behavior for audio-only content, especially on iOS.
  * Fixed an issue where hidden media could prevent audio from decoding or advancing correctly.
  * Audio now stays invisible without affecting layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->