### PR TITLE
fix(waves): reliable iOS sound + single active Speak player

### DIFF
--- a/src/components/postHtmlRenderer/speakAudioPlayer.tsx
+++ b/src/components/postHtmlRenderer/speakAudioPlayer.tsx
@@ -3,6 +3,7 @@ import {
   ActivityIndicator,
   GestureResponderEvent,
   LayoutChangeEvent,
+  Platform,
   Pressable,
   Text,
   View,
@@ -221,13 +222,17 @@ const SpeakAudioPlayer = ({
           onEnd={_onEnd}
           onError={_onError}
           ignoreSilentSwitch="ignore"
-          // Registers with the now-playing center, which is the only path in
-          // react-native-video that calls AVAudioSession.setActive(true). Without
-          // it, configureAudio only sets the .playback category (never activates
-          // the session), so after app restarts/interruptions iOS can leave the
-          // session inactive and the clip plays silently (position advances, no
-          // sound). Side benefit: lock-screen / control-center play-pause.
-          showNotificationControls={true}
+          // iOS-only, and ONLY while this player is actively playing. On iOS,
+          // registering with the now-playing center is the one path that calls
+          // AVAudioSession.setActive(true) (configureAudio otherwise just sets the
+          // .playback category, never activates it — so after restarts/interruptions
+          // the clip plays silently). Gating to `started && !paused` means it
+          // registers on each play (re-activating the session) and DEREGISTERS on
+          // pause, so paused players don't linger in the now-playing controls.
+          // Excluded on Android: the prop there starts a foreground playback
+          // service that needs extra manifest config, and Android plays fine
+          // without it.
+          showNotificationControls={Platform.OS === 'ios' && started && !paused}
           playInBackground={false}
           progressUpdateInterval={250}
           style={styles.hiddenVideo}

--- a/src/components/postHtmlRenderer/speakAudioPlayer.tsx
+++ b/src/components/postHtmlRenderer/speakAudioPlayer.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   ActivityIndicator,
   GestureResponderEvent,
@@ -17,6 +17,7 @@ import {
   playbackProgress,
   playedBarCount,
 } from './speakAudioPlayer.utils';
+import { speakPlayback } from './speakPlaybackCoordinator';
 import styles from './speakAudioPlayerStyles';
 
 export interface SpeakMeta {
@@ -70,6 +71,19 @@ const SpeakAudioPlayer = ({
   const progress = playbackProgress(currentTime, duration);
   const playedColor = EStyleSheet.value('$primaryBlue');
   const unplayedColor = EStyleSheet.value('$borderColor');
+
+  // Single-active-player: a post and its voice comments each render a player, so
+  // while this one is playing, pause any other that was playing. Cleared on
+  // pause/end and on unmount.
+  const _stop = useCallback(() => setPaused(true), []);
+  useEffect(() => {
+    if (started && !paused) {
+      speakPlayback.activate(_stop);
+    } else {
+      speakPlayback.deactivate(_stop);
+    }
+  }, [started, paused, _stop]);
+  useEffect(() => () => speakPlayback.deactivate(_stop), [_stop]);
 
   const _togglePlay = () => {
     if (!started) {
@@ -207,6 +221,13 @@ const SpeakAudioPlayer = ({
           onEnd={_onEnd}
           onError={_onError}
           ignoreSilentSwitch="ignore"
+          // Registers with the now-playing center, which is the only path in
+          // react-native-video that calls AVAudioSession.setActive(true). Without
+          // it, configureAudio only sets the .playback category (never activates
+          // the session), so after app restarts/interruptions iOS can leave the
+          // session inactive and the clip plays silently (position advances, no
+          // sound). Side benefit: lock-screen / control-center play-pause.
+          showNotificationControls={true}
           playInBackground={false}
           progressUpdateInterval={250}
           style={styles.hiddenVideo}

--- a/src/components/postHtmlRenderer/speakPlaybackCoordinator.test.ts
+++ b/src/components/postHtmlRenderer/speakPlaybackCoordinator.test.ts
@@ -1,0 +1,45 @@
+import { speakPlayback } from './speakPlaybackCoordinator';
+
+describe('speakPlayback coordinator', () => {
+  beforeEach(() => {
+    // Reset the module-level active player between tests.
+    const noop = () => {};
+    speakPlayback.activate(noop);
+    speakPlayback.deactivate(noop);
+  });
+
+  it('pauses the previously-active player when another one starts', () => {
+    const a = jest.fn();
+    const b = jest.fn();
+    speakPlayback.activate(a);
+    expect(a).not.toHaveBeenCalled();
+    speakPlayback.activate(b); // b starts -> a must be paused
+    expect(a).toHaveBeenCalledTimes(1);
+    expect(b).not.toHaveBeenCalled();
+  });
+
+  it('does not pause itself when the same player re-activates', () => {
+    const a = jest.fn();
+    speakPlayback.activate(a);
+    speakPlayback.activate(a);
+    expect(a).not.toHaveBeenCalled();
+  });
+
+  it('deactivate only clears the active slot when it owns it', () => {
+    const a = jest.fn();
+    const b = jest.fn();
+    speakPlayback.activate(a);
+    speakPlayback.deactivate(b); // b is not active -> a stays active
+    speakPlayback.activate(b); // so a still gets paused now
+    expect(a).toHaveBeenCalledTimes(1);
+  });
+
+  it('after the active player deactivates, the next start pauses nobody', () => {
+    const a = jest.fn();
+    const b = jest.fn();
+    speakPlayback.activate(a);
+    speakPlayback.deactivate(a); // a stops on its own
+    speakPlayback.activate(b);
+    expect(a).not.toHaveBeenCalled(); // a was already cleared, not re-paused
+  });
+});

--- a/src/components/postHtmlRenderer/speakPlaybackCoordinator.ts
+++ b/src/components/postHtmlRenderer/speakPlaybackCoordinator.ts
@@ -1,0 +1,26 @@
+// Ensures only ONE Speak voice player is audible at a time. A post and its
+// comments can each render a SpeakAudioPlayer; without coordination, tapping a
+// second one leaves the first playing (overlapping audio) and confuses the iOS
+// now-playing/lock-screen controls. Each player registers a `stop` callback when
+// it starts; activating a new one pauses the previously-active player.
+
+type Stopper = () => void;
+
+let activeStopper: Stopper | null = null;
+
+export const speakPlayback = {
+  /** A player started playing: pause whichever player was playing before. */
+  activate(stopper: Stopper) {
+    if (activeStopper && activeStopper !== stopper) {
+      activeStopper();
+    }
+    activeStopper = stopper;
+  },
+
+  /** A player paused / ended / unmounted: clear it if it was the active one. */
+  deactivate(stopper: Stopper) {
+    if (activeStopper === stopper) {
+      activeStopper = null;
+    }
+  },
+};


### PR DESCRIPTION
Two follow-up fixes for the Liketu Speak voice player on iOS (the 0×0→1×1 fix in #3305 was necessary but not sufficient).

## 1. No sound after app restarts

react-native-video's `configureAudio` (run on every play) only sets the `.playback` **category** — it never calls `AVAudioSession.setActive(true)`. On a fresh launch AVPlayer activates the session implicitly, but after restarts/interruptions iOS can leave the session inactive, so the clip decodes and the position advances but **no audio is output** (and it's not the mute switch).

The only code path in react-native-video that calls `setActive(true)` is the now-playing center registration, gated on `showNotificationControls`. Setting **`showNotificationControls={true}`** therefore supplies the missing activation (verified in the library source: `registerPlayer` → `receivingRemoteControlEvents = true` → `setCategory(.playback)` + `setActive(true)`). Bonus: lock-screen / control-center play-pause for the voice clip.

## 2. Overlapping audio across a post + its comments

A post and each of its voice comments render their own `SpeakAudioPlayer`. They were fully independent, so tapping play on one then another left **both playing at once** (and the two now-playing registrations fight). Added a tiny module-level **single-active-player coordinator**: when one player starts, the previously-active one is paused. Cleared on pause/end/unmount.

## Test

- `speakPlaybackCoordinator` unit-tested (activate pauses previous, same-player re-activate is a no-op, deactivate only clears its own slot).
- Full suite green (461 passing).
- Needs on-device iOS confirmation: sound plays reliably across restarts, and starting a second clip pauses the first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Speak audio playback now coordinates across multiple rendered players, ensuring only one is audible at a time.

* **Bug Fixes**
  * Improved stop and unmount behavior so deactivated players no longer linger as the active/controllable playback source.
  * On iOS, play/pause controls are enabled only when playback is actively started (and not paused), preventing paused instances from remaining in now-playing controls.

* **Tests**
  * Added automated coverage for playback handoff, re-activation behavior, and correct deactivation/ownership handling between players.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->