### PR TITLE
fix(waves): only one live Speak audio player at a time

### DIFF
--- a/src/components/postHtmlRenderer/speakAudioPlayer.tsx
+++ b/src/components/postHtmlRenderer/speakAudioPlayer.tsx
@@ -123,7 +123,9 @@ const SpeakAudioPlayer = ({
     }
     const pending = seekOnLoadRef.current;
     seekOnLoadRef.current = null;
-    playerRef.current?.seek(pending ?? 0);
+    // Resume from where we paused: the <Video> is unmounted while paused (see the
+    // render gate), so on re-mount seek back to the retained currentTime.
+    playerRef.current?.seek(pending ?? currentTime);
     setLoading(false);
   };
 
@@ -210,7 +212,14 @@ const SpeakAudioPlayer = ({
 
       <Text style={styles.time}>{formatDuration(started ? currentTime : duration)}</Text>
 
-      {started && !!uri && (
+      {/* Mount the <Video> only while THIS player is actively playing, so at most
+          ONE AVPlayer is alive across every player on the screen (a post + its
+          voice comments). Multiple live AVPlayers contend for the iOS audio
+          session: audio routes to one while the play/pause button targets another
+          component — so pause "doesn't work", orphaned players keep playing after
+          you navigate, and only one clip is audible. Unmounting on pause releases
+          the player; resuming re-mounts and seeks back to currentTime. */}
+      {started && !paused && !!uri && (
         <Video
           ref={playerRef}
           source={{ uri }}

--- a/src/components/postHtmlRenderer/speakAudioPlayer.tsx
+++ b/src/components/postHtmlRenderer/speakAudioPlayer.tsx
@@ -85,6 +85,14 @@ const SpeakAudioPlayer = ({
     }
   }, [started, paused, _stop]);
   useEffect(() => () => speakPlayback.deactivate(_stop), [_stop]);
+  // The <Video> unmounts on pause (render gate below) before onLoad/onBuffer/
+  // onError can clear a pending load, which would otherwise leave the spinner
+  // stuck instead of the play button. Clear loading whenever this player pauses.
+  useEffect(() => {
+    if (paused) {
+      setLoading(false);
+    }
+  }, [paused]);
 
   const _togglePlay = () => {
     if (!started) {

--- a/src/components/postHtmlRenderer/speakAudioPlayer.tsx
+++ b/src/components/postHtmlRenderer/speakAudioPlayer.tsx
@@ -85,14 +85,6 @@ const SpeakAudioPlayer = ({
     }
   }, [started, paused, _stop]);
   useEffect(() => () => speakPlayback.deactivate(_stop), [_stop]);
-  // The <Video> unmounts on pause (render gate below) before onLoad/onBuffer/
-  // onError can clear a pending load, which would otherwise leave the spinner
-  // stuck instead of the play button. Clear loading whenever this player pauses.
-  useEffect(() => {
-    if (paused) {
-      setLoading(false);
-    }
-  }, [paused]);
 
   const _togglePlay = () => {
     if (!started) {
@@ -202,7 +194,11 @@ const SpeakAudioPlayer = ({
         accessibilityRole="button"
         accessibilityLabel={paused ? 'Play voice' : 'Pause voice'}
       >
-        {loading ? (
+        {/* Only show the spinner while actually playing. The <Video> unmounts on
+            pause, so a late onLoadStart/onBuffer can leave `loading` true while
+            paused; gating on !paused makes the paused control always show the
+            play button regardless, with no state race. */}
+        {loading && !paused ? (
           <ActivityIndicator size="small" color={EStyleSheet.value('$pureWhite')} />
         ) : (
           <Icon


### PR DESCRIPTION
## Symptoms

On a screen with several voice clips (a post + its voice comments), after tapping a few:
- only one clip is audible (others' progress bar moves but no sound),
- tapping pause doesn't stop playback,
- a clip keeps playing after navigating away,
- navigating away and back "fixes" it,
- the play/pause icon can look out of sync.

## Cause

Each `SpeakAudioPlayer` mounted its hidden `<Video>` on first tap (`started`) and **never unmounted it** — `started` stays `true` even when paused. So several AVPlayers stay alive at once and contend for the single iOS audio session: audio routes to one instance while the play/pause button you tap belongs to a *different* component. Hence pause "not working", orphaned playback, and only one audible clip. A fresh remount (navigate away/back) resets to one player, which is why that temporarily works.

## Fix

Mount the `<Video>` only while that player is **actively playing** (`started && !paused`). Combined with the existing single-active-player coordinator (which pauses the previous clip when a new one starts), **at most one AVPlayer is alive at any moment**, so it's always the one the controls target. Unmounting on pause releases the native player (no orphans); resuming re-mounts and seeks back to the retained `currentTime` (the stream is CF-cached, so the re-fetch is fast).

## Test

- Coordinator unit tests + full suite green (lint/prettier clean).
- Needs on-device iOS: each tapped clip plays with sound, pause stops it, starting another pauses the first, and nothing keeps playing after navigating away.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Playback now resumes from the last saved position when reloading without an active seek.
  * The media player now unmounts while paused and remounts on resume to restore the correct playback state.
  * The loading indicator no longer remains visible when pausing interrupts the media load lifecycle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->