### PR TITLE
feat: outline (non-filled) bottom-tab icons

### DIFF
--- a/src/components/bottomTabBar/view/bottomTabBarView.tsx
+++ b/src/components/bottomTabBar/view/bottomTabBarView.tsx
@@ -46,7 +46,9 @@ const BottomTabBarView = ({
     const iconColor = isFocused ? tabBarActiveTintColor : tabBarInactiveTintColor;
 
     const _iconProps = {
-      iconType: 'MaterialIcons',
+      // MaterialCommunityIcons so every tab can use its outline (non-filled)
+      // glyph; the icon names are the `*-outline` variants set in the navigator.
+      iconType: 'MaterialCommunityIcons',
       style: { paddingTop: 15 },
       name: route.params.iconName,
       color: iconColor,
@@ -59,7 +61,6 @@ const BottomTabBarView = ({
         _tabBarIcon = <IconContainer isBadge badgeType="notification" {..._iconProps} />;
         break;
       case ROUTES.TABBAR.CHATS:
-        _iconProps.iconType = 'MaterialCommunityIcons';
         _tabBarIcon = <IconContainer isBadge badgeType="chat" {..._iconProps} />;
         break;
       case ROUTES.TABBAR.WAVES:

--- a/src/navigation/botomTabNavigator.tsx
+++ b/src/navigation/botomTabNavigator.tsx
@@ -29,7 +29,7 @@ export const BottomTabNavigator = () => {
         name={ROUTES.TABBAR.FEED}
         component={Feed}
         initialParams={{
-          iconName: 'home', // read in bottomTabBarView
+          iconName: 'home-outline', // read in bottomTabBarView (MaterialCommunityIcons)
         }}
       />
 
@@ -38,7 +38,7 @@ export const BottomTabNavigator = () => {
         component={Waves}
         initialParams={{
           // WAVES renders a custom wavy-dash (〰️) SVG in bottomTabBarView; this
-          // name is only a MaterialIcons fallback if that override is removed.
+          // name is only a MaterialCommunityIcons fallback if that override is removed.
           iconName: 'waves', // read in bottomTabBarView
         }}
       />
@@ -47,7 +47,7 @@ export const BottomTabNavigator = () => {
         name={ROUTES.TABBAR.CHATS}
         component={Chats}
         initialParams={{
-          iconName: 'message-text', // read in bottomTabBarView
+          iconName: 'chat-outline', // read in bottomTabBarView (MaterialCommunityIcons)
         }}
       />
 
@@ -55,7 +55,7 @@ export const BottomTabNavigator = () => {
         name={ROUTES.TABBAR.WALLET}
         component={Wallet}
         initialParams={{
-          iconName: 'account-balance-wallet', // read in bottomTabBarView
+          iconName: 'wallet-outline', // read in bottomTabBarView (MaterialCommunityIcons)
         }}
       />
 
@@ -63,7 +63,7 @@ export const BottomTabNavigator = () => {
         name={ROUTES.TABBAR.NOTIFICATION}
         component={Notification}
         initialParams={{
-          iconName: 'notifications', // read in bottomTabBarView
+          iconName: 'bell-outline', // read in bottomTabBarView (MaterialCommunityIcons)
         }}
       />
     </Tab.Navigator>


### PR DESCRIPTION
Follow-up to the Waves wavy-dash icon — switch the rest of the bottom-tab icons to outline (non-filled) variants so the whole tab bar is consistent.

## Changes
- Default the tab icon set to **MaterialCommunityIcons** and use the `*-outline` glyphs:
  - Home → `home-outline`
  - Chat → `chat-outline` (rounder bubble, replacing the squared `message-text`)
  - Wallet → `wallet-outline`
  - Notifications → `bell-outline`
- Waves keeps its custom wavy-dash SVG.
- Removed the now-redundant per-tab MaterialCommunityIcons override for the chat tab.

## Notes
- Active/inactive tinting is unchanged — the active tab just shows the outline glyph in the active color.
- Verified on the iOS simulator (iPhone 16 Pro): all icons render and sit level in the tab bar.