### PR TITLE
feat(waves): show tip count + already-tipped state on waves feed cards

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@babel/preset-typescript": "^7.26.0",
     "@babel/runtime": "^7.26.7",
     "@ecency/render-helper": "^2.5.16",
-    "@ecency/sdk": "^2.3.25",
+    "@ecency/sdk": "^2.3.26",
     "@esteemapp/react-native-autocomplete-input": "^4.2.1",
     "@esteemapp/react-native-multi-slider": "^1.1.0",
     "@native-html/iframe-plugin": "^2.6.1",

--- a/src/components/comment/view/commentView.tsx
+++ b/src/components/comment/view/commentView.tsx
@@ -256,29 +256,47 @@ const CommentView = ({
           })}
         />
 
-        {isLoggedIn && (
-          <TextWithIcon
-            iconName={comment.tipped_by_viewer ? 'gift' : 'gift-outline'}
-            iconSize={20}
-            wrapperStyle={styles.leftButton}
-            iconType="MaterialCommunityIcons"
-            isClickable
-            onPress={_handleOnTipPress}
-            text={comment.tip_count || 0}
-            textStyle={styles.voteCountText}
-            accessibilityLabel={intl.formatMessage(
-              {
-                id: 'post.a11y_tips',
-                defaultMessage: '{count, plural, one {# tip} other {# tips}}',
-              },
-              { count: comment.tip_count || 0 },
-            )}
-            accessibilityHint={intl.formatMessage({
-              id: 'post.a11y_tip',
-              defaultMessage: 'Send tip',
-            })}
-          />
-        )}
+        {isLoggedIn &&
+          // Only the waves feed carries a tip_count; show the count + an
+          // already-tipped (solid gift) state there. Elsewhere (regular comment
+          // threads, where the field is absent) keep the plain icon-only action
+          // instead of rendering a misleading "0".
+          (typeof comment.tip_count === 'number' ? (
+            <TextWithIcon
+              iconName={comment.tipped_by_viewer ? 'gift' : 'gift-outline'}
+              iconSize={20}
+              wrapperStyle={styles.leftButton}
+              iconType="MaterialCommunityIcons"
+              isClickable
+              onPress={_handleOnTipPress}
+              text={comment.tip_count}
+              textStyle={styles.voteCountText}
+              accessibilityLabel={intl.formatMessage(
+                {
+                  id: 'post.a11y_tips',
+                  defaultMessage: '{count, plural, one {# tip} other {# tips}}',
+                },
+                { count: comment.tip_count },
+              )}
+              accessibilityHint={intl.formatMessage({
+                id: 'post.a11y_tip',
+                defaultMessage: 'Send tip',
+              })}
+            />
+          ) : (
+            <IconButton
+              size={20}
+              iconStyle={styles.leftIcon}
+              style={styles.leftButton}
+              name="gift-outline"
+              onPress={_handleOnTipPress}
+              iconType="MaterialCommunityIcons"
+              accessibilityLabel={intl.formatMessage({
+                id: 'post.a11y_tip',
+                defaultMessage: 'Send tip',
+              })}
+            />
+          ))}
 
         {_currentUsername === comment.author && (
           <Fragment>

--- a/src/components/comment/view/commentView.tsx
+++ b/src/components/comment/view/commentView.tsx
@@ -257,14 +257,23 @@ const CommentView = ({
         />
 
         {isLoggedIn && (
-          <IconButton
-            size={20}
-            iconStyle={styles.leftIcon}
-            style={styles.leftButton}
-            name="gift-outline"
-            onPress={_handleOnTipPress}
+          <TextWithIcon
+            iconName={comment.tipped_by_viewer ? 'gift' : 'gift-outline'}
+            iconSize={20}
+            wrapperStyle={styles.leftButton}
             iconType="MaterialCommunityIcons"
-            accessibilityLabel={intl.formatMessage({
+            isClickable
+            onPress={_handleOnTipPress}
+            text={comment.tip_count || 0}
+            textStyle={styles.voteCountText}
+            accessibilityLabel={intl.formatMessage(
+              {
+                id: 'post.a11y_tips',
+                defaultMessage: '{count, plural, one {# tip} other {# tips}}',
+              },
+              { count: comment.tip_count || 0 },
+            )}
+            accessibilityHint={intl.formatMessage({
               id: 'post.a11y_tip',
               defaultMessage: 'Send tip',
             })}

--- a/src/providers/queries/postQueries/tipsQueries.ts
+++ b/src/providers/queries/postQueries/tipsQueries.ts
@@ -131,6 +131,14 @@ export const useSendTipMutation = () => {
         queryKey: tipsQueryKey,
       });
 
+      // Refresh the waves feed so a tip sent from a feed card updates its
+      // tip_count / tipped_by_viewer, which come from the feed payload (not the
+      // post-tips query above). Prefix-matches every feed variant (for-you /
+      // following / tag / account).
+      queryClient.invalidateQueries({
+        queryKey: ['posts', 'waves', 'feed'],
+      });
+
       // Invalidate wallet/portfolio query so balances refresh after tip
       queryClient.invalidateQueries({
         queryKey: ['wallet', 'portfolio', 'v2', currentAccount?.name],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1211,10 +1211,10 @@
     url "^0.11.0"
     xss "^1.0.9"
 
-"@ecency/sdk@^2.3.25":
-  version "2.3.25"
-  resolved "https://registry.yarnpkg.com/@ecency/sdk/-/sdk-2.3.25.tgz#13440efa19b4b4587cac44b6d47556dda8872ab6"
-  integrity sha512-cQ3mtxWEWkRzhDH2fDoPcKsVDP8teZgBwTgM0gngIhk6ecoMeL0CdHuH0nygDJHSODoSyEYPHtzn3awWzW1vpQ==
+"@ecency/sdk@^2.3.26":
+  version "2.3.26"
+  resolved "https://registry.yarnpkg.com/@ecency/sdk/-/sdk-2.3.26.tgz#c576272f83d53e2494c73338af3b6938c4524469"
+  integrity sha512-uZXesVPLhSiLf9nZhUKURvOFsl8J/KIIEcnuRHcqXc11beXXV/lDAKc7+154vtG767RCKer3r6yUERIKRWkyiA==
   dependencies:
     "@noble/ciphers" "^2.1.1"
     "@noble/curves" "^2.0.1"


### PR DESCRIPTION
## What

Show a wave's **tip count** on the waves feed cards, and mark waves the viewer has **already tipped** — matching the web waves feed.

## Why

Tip counts were only visible on the single-post view. In the waves feed the gift action showed no count, so a tipped wave looked untipped and you couldn't tell whether you'd already tipped it while scrolling.

## How

Backed by esync + `@ecency/sdk` 2.3.26, which add `tip_count` and `tipped_by_viewer` to each waves feed item (`tipped_by_viewer` is computed from the `observer` the feed already sends — the logged-in user).

- Bump `@ecency/sdk` `^2.3.25` → `^2.3.26` (adds the tip fields to the `Entry` type; the values already flow through the feed response and `parsePost` at runtime).
- `commentView`: the gift action becomes a `TextWithIcon` showing `tip_count`, and swaps to a solid `gift` icon (from `gift-outline`) when `tipped_by_viewer` is true — the at-a-glance already-tipped signal, mirroring web.

## Notes

- Reuses the existing `post.a11y_tips` / `post.a11y_tip` strings (no new i18n).
- Backward compatible; the single-post view already shows the count.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced the comment action area for tips: when a tip count is available, the UI now displays the current count and a clearer, count-based accessibility label; otherwise it remains icon-only.
  * The tip icon and presentation update based on whether the viewer has already tipped.
* **Bug Fixes**
  * After sending a tip from feed cards, related Waves feed tip counters refresh to reflect the latest state.
* **Chores**
  * Bumped the app’s `@ecency/sdk` dependency to the latest patch version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->