### PR TITLE
fix(gif-badge): shrink GIF label so it covers less of the media

### DIFF
--- a/src/components/autoHeightImage/autoHeightImage.tsx
+++ b/src/components/autoHeightImage/autoHeightImage.tsx
@@ -187,16 +187,16 @@ export const AutoHeightImage = ({
 const styles = EStyleSheet.create({
   gifBadge: {
     position: 'absolute',
-    left: 8,
-    bottom: 8,
-    backgroundColor: 'rgba(0,0,0,0.6)',
-    borderRadius: 4,
-    paddingHorizontal: 4,
-    paddingVertical: 2,
+    left: 6,
+    bottom: 6,
+    backgroundColor: 'rgba(0,0,0,0.5)',
+    borderRadius: 3,
+    paddingHorizontal: 3,
+    paddingVertical: 1,
   },
   gifBadgeText: {
     color: '$pureWhite',
-    fontSize: 12,
+    fontSize: 9,
     fontWeight: 'bold',
   },
 });

--- a/src/components/postCard/styles/postCard.styles.ts
+++ b/src/components/postCard/styles/postCard.styles.ts
@@ -55,16 +55,16 @@ export default EStyleSheet.create({
   },
   gifBadge: {
     position: 'absolute',
-    left: 8,
-    bottom: 8,
-    backgroundColor: 'rgba(0,0,0,0.6)',
-    borderRadius: 4,
-    paddingHorizontal: 4,
-    paddingVertical: 2,
+    left: 6,
+    bottom: 6,
+    backgroundColor: 'rgba(0,0,0,0.5)',
+    borderRadius: 3,
+    paddingHorizontal: 3,
+    paddingVertical: 1,
   },
   gifBadgeText: {
     color: '$pureWhite',
-    fontSize: 12,
+    fontSize: 9,
     fontWeight: 'bold',
   },
   bodyFooter: {


### PR DESCRIPTION
## What

Shrinks the **"GIF"** overlay badge shown on rendered post images so it no longer covers a meaningful portion of the GIF it marks.

Reported by users: *"The gif symbol often covers a portion of the gif being used."*

## Changes

The badge went from a 12px-bold label in a chunky pill to a smaller, tighter pill tucked closer to the corner:

| | before | after |
|---|---|---|
| font size | 12 | 9 |
| h-padding | 4 | 3 |
| v-padding | 2 | 1 |
| border radius | 4 | 3 |
| left / bottom | 8 | 6 |
| bg opacity | 0.6 | 0.5 |

Applied to both badge locations for visual consistency:
- `src/components/autoHeightImage/autoHeightImage.tsx` — post-body image rendering (the case in the report)
- `src/components/postCard/styles/postCard.styles.ts` — feed post-card thumbnails

The in-editor media-picker badge (`uploadsGalleryModal`) is intentionally left unchanged.