### PR TITLE
chore(deps): bump @ecency/sdk to 2.3.27

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@babel/preset-typescript": "^7.26.0",
     "@babel/runtime": "^7.26.7",
     "@ecency/render-helper": "^2.5.16",
-    "@ecency/sdk": "^2.3.26",
+    "@ecency/sdk": "^2.3.27",
     "@esteemapp/react-native-autocomplete-input": "^4.2.1",
     "@esteemapp/react-native-multi-slider": "^1.1.0",
     "@native-html/iframe-plugin": "^2.6.1",

--- a/src/containers/profileContainer.tsx
+++ b/src/containers/profileContainer.tsx
@@ -402,6 +402,14 @@ class ProfileContainer extends Component {
       const queryClient = getQueryClient();
       const rawAccount = await queryClient.fetchQuery(getAccountFullQueryOptions(username));
 
+      // SDK now resolves null for a missing/unresolved account instead of
+      // throwing; treat it the same as a failed load to preserve the
+      // "profile not found" UX.
+      if (!rawAccount) {
+        this._profileActionDone({ error: new Error('Account not found') });
+        return;
+      }
+
       // SDK returns profile directly as .profile field
       user = {
         ...rawAccount,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1211,10 +1211,10 @@
     url "^0.11.0"
     xss "^1.0.9"
 
-"@ecency/sdk@^2.3.26":
-  version "2.3.26"
-  resolved "https://registry.yarnpkg.com/@ecency/sdk/-/sdk-2.3.26.tgz#c576272f83d53e2494c73338af3b6938c4524469"
-  integrity sha512-uZXesVPLhSiLf9nZhUKURvOFsl8J/KIIEcnuRHcqXc11beXXV/lDAKc7+154vtG767RCKer3r6yUERIKRWkyiA==
+"@ecency/sdk@^2.3.27":
+  version "2.3.27"
+  resolved "https://registry.yarnpkg.com/@ecency/sdk/-/sdk-2.3.27.tgz#4e4d9918d00272e4411bae9330f6a01c5d967498"
+  integrity sha512-NpQ5kEsaae1cwU6q8aYuC4LyWhoQdb7p5R3qmcNCOFA5NooHbW0QDdWhzGUx8wnf7M7se7Oc5GEiGUOSwX6qCw==
   dependencies:
     "@noble/ciphers" "^2.1.1"
     "@noble/curves" "^2.0.1"


### PR DESCRIPTION
Bumps `@ecency/sdk` 2.3.26 → 2.3.27.

The only change in that release is `getAccountFullQueryOptions` resolving `null` for a missing or not-yet-finalized account instead of throwing, which removes a source of unhandled promise rejections.

Audited every mobile consumer of `getAccountFullQueryOptions`; all handle a null result safely (null checks / optional chaining) except `profileContainer._loadProfile`, which previously relied on the throw to reach its error path. It now treats a null account as a failed load, preserving the existing "profile not found" UX. No other behavior changes are in this SDK release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved profile loading to handle missing accounts more gracefully, showing a clear “profile not found” error instead of failing silently.
  * Updated a core SDK dependency to the latest patch version for general stability improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->