### PR TITLE
feat(waves): Shorts (reels) tab

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@babel/preset-typescript": "^7.26.0",
     "@babel/runtime": "^7.26.7",
     "@ecency/render-helper": "^2.5.16",
-    "@ecency/sdk": "^2.3.27",
+    "@ecency/sdk": "^2.3.28",
     "@esteemapp/react-native-autocomplete-input": "^4.2.1",
     "@esteemapp/react-native-multi-slider": "^1.1.0",
     "@native-html/iframe-plugin": "^2.6.1",

--- a/src/config/locales/en-US.json
+++ b/src/config/locales/en-US.json
@@ -40,7 +40,9 @@
     "sources": "Sources",
     "your_feeds": "Your feeds",
     "trending_tags": "Trending tags",
-    "shorts_empty": "No shorts to show yet"
+    "shorts_empty": "No shorts to show yet",
+    "mute": "Mute",
+    "unmute": "Unmute"
   },
   "profile": {
     "havent_commented": "haven't commented anything yet",

--- a/src/config/locales/en-US.json
+++ b/src/config/locales/en-US.json
@@ -39,7 +39,8 @@
     "add_tag_placeholder": "Add a tag",
     "sources": "Sources",
     "your_feeds": "Your feeds",
-    "trending_tags": "Trending tags"
+    "trending_tags": "Trending tags",
+    "shorts_empty": "No shorts to show yet"
   },
   "profile": {
     "havent_commented": "haven't commented anything yet",

--- a/src/constants/waves.ts
+++ b/src/constants/waves.ts
@@ -42,23 +42,38 @@ export const WAVES_CONTAINER_HOSTS: readonly string[] = [
 export const isWavesHost = (account?: string | null): boolean =>
   !!account && WAVES_CONTAINER_HOSTS.includes(account);
 
+/**
+ * Pseudo-source for the cross-container Shorts (reels) feed. Unlike the other
+ * sources it isn't a single container account: it's every wave that embeds a
+ * 3Speak video, across all containers, backed by `getShortsFeedQueryOptions`
+ * and shown in a vertical full-screen reels viewer instead of the comments
+ * list. Pinning it adds a `container:shorts` tab that wavesScreen renders with
+ * the reels view (see its reels branch).
+ */
+export const SHORTS_SOURCE = 'shorts';
+
 export interface WaveSourceOption {
-  /** Container host account the source feed filters to. */
+  /** Container host account the source feed filters to (or SHORTS_SOURCE). */
   host: string;
   /** Product label shown on the picker chip and the pinned tab. */
   label: string;
 }
 
 /**
- * Source containers offered as one-tap pinned feed tabs in the waves picker.
- * Each maps a single container account to its product label; pinning one adds a
+ * Sources offered as one-tap pinned feed tabs in the waves picker. Most map a
+ * single container account to its product label; pinning one adds a
  * `container:<host>` tab backed by `getWavesFeedQueryOptions({ containers: [host] })`.
+ *
+ * `Shorts` (SHORTS_SOURCE) is the one exception: it's the cross-container reels
+ * feed, so its `container:shorts` tab is rendered with the reels viewer and a
+ * different SDK query instead of the standard waves list.
  *
  * Deliberately a curated subset of WAVES_CONTAINER_HOSTS: `hive.flow` (the
  * still-inert unified account) is omitted, so "Waves" surfaces only the legacy
  * `ecency.waves` source for now. Order is the order chips/tabs appear in.
  */
 export const WAVES_SOURCE_OPTIONS: readonly WaveSourceOption[] = [
+  { host: SHORTS_SOURCE, label: 'Shorts' },
   { host: 'ecency.waves', label: 'Waves' },
   { host: 'leothreads', label: 'Threads' },
   { host: 'peak.snaps', label: 'Snaps' },

--- a/src/providers/queries/postQueries/index.ts
+++ b/src/providers/queries/postQueries/index.ts
@@ -1,8 +1,17 @@
 import * as postQueries from './postQueries';
 import * as wavesQueries from './wavesQueries';
+import * as shortsQueries from './shortsQueries';
 import * as pollQueries from './pollQueries';
 import * as repostQueries from './repostQueries';
 import * as feedQueries from './feedQueries';
 import * as tipsQueries from './tipsQueries';
 
-export { postQueries, wavesQueries, pollQueries, repostQueries, feedQueries, tipsQueries };
+export {
+  postQueries,
+  wavesQueries,
+  shortsQueries,
+  pollQueries,
+  repostQueries,
+  feedQueries,
+  tipsQueries,
+};

--- a/src/providers/queries/postQueries/shortsQueries.ts
+++ b/src/providers/queries/postQueries/shortsQueries.ts
@@ -1,0 +1,97 @@
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { useCallback, useMemo, useState } from 'react';
+
+import { isArray } from 'lodash';
+import { getShortsFeedQueryOptions, ShortsFeedEntry } from '@ecency/sdk';
+
+import { parsePost } from '../../../utils/postParser';
+import { useAppSelector } from '../../../hooks';
+import { useBotAuthorsQuery } from './postQueries';
+import { selectCurrentAccount, selectCurrentAccountMutes } from '../../../redux/selectors';
+
+/**
+ * Drives the cross-container Shorts (reels) feed from the esync
+ * `/api/waves/shorts` endpoint via `getShortsFeedQueryOptions`. Same keyset
+ * pagination and observer-mute model as the waves feed, but each entry carries
+ * a `video` block for the vertical reels player and there's no promoted
+ * interleaving or following filter (v1). Visibility filtering mirrors
+ * `useWavesQuery` so muted/gray/bot authors stay hidden, plus a guard that only
+ * shorts actually carrying a playable video reach the viewer.
+ */
+export const useShortsQuery = (observer?: string) => {
+  const mutes = useAppSelector(selectCurrentAccountMutes);
+  const currentAccount = useAppSelector(selectCurrentAccount);
+  const botAuthorsQuery = useBotAuthorsQuery();
+
+  const [isRefreshing, setIsRefreshing] = useState(false);
+
+  const shortsQuery = useInfiniteQuery({
+    ...getShortsFeedQueryOptions({ observer }),
+    refetchInterval: 60000,
+  });
+
+  const data = useMemo(() => {
+    const flat = (shortsQuery.data?.pages?.flat() ?? []) as ShortsFeedEntry[];
+    const botAuthors = botAuthorsQuery.data ?? [];
+
+    const isVisible = (post: any) => {
+      if (!post) {
+        return false;
+      }
+      // discard wave if author is muted
+      if (isArray(mutes) && mutes.indexOf(post.author) >= 0) {
+        return false;
+      }
+      // discard if wave is downvoted or marked gray
+      if (post.isMuted) {
+        return false;
+      }
+      // discard bot authors
+      if (botAuthors.includes(post.author)) {
+        return false;
+      }
+      // only shorts that actually carry a playable video belong in the reels viewer
+      if (!post.video) {
+        return false;
+      }
+      return true;
+    };
+
+    return (
+      flat
+        // Shallow-copy before parsing: parsePost mutates its argument, and `flat`
+        // holds the SDK query cache objects. parsePost preserves the `video` field.
+        .map((item) => parsePost({ ...item }, currentAccount?.name, false) as ShortsFeedEntry)
+        .filter(isVisible)
+    );
+  }, [shortsQuery.data, mutes, botAuthorsQuery.data, currentAccount?.name]);
+
+  const hasNextPage = !!shortsQuery.hasNextPage;
+  const { isFetchingNextPage, isLoading } = shortsQuery;
+
+  const fetchNextPage = useCallback(() => {
+    if (shortsQuery.hasNextPage && !shortsQuery.isFetchingNextPage) {
+      return shortsQuery.fetchNextPage();
+    }
+    return undefined;
+  }, [shortsQuery.hasNextPage, shortsQuery.isFetchingNextPage, shortsQuery.fetchNextPage]);
+
+  const refresh = async () => {
+    setIsRefreshing(true);
+    try {
+      await shortsQuery.refetch();
+    } finally {
+      setIsRefreshing(false);
+    }
+  };
+
+  return {
+    data,
+    isRefreshing,
+    isLoading,
+    isFetchingNextPage,
+    hasNextPage,
+    fetchNextPage,
+    refresh,
+  };
+};

--- a/src/screens/waves/children/wavesReelItem.tsx
+++ b/src/screens/waves/children/wavesReelItem.tsx
@@ -1,10 +1,10 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Image, Text, TouchableOpacity, View } from 'react-native';
-import WebView from 'react-native-webview';
 import { useIntl } from 'react-intl';
 import { ShortsFeedEntry } from '@ecency/sdk';
 
 import { FormattedCurrency, Icon, UserAvatar } from '../../../components';
+import WavesReelVideo from './wavesReelVideo';
 import styles from '../styles/wavesReels.styles';
 
 interface Props {
@@ -71,12 +71,6 @@ const WavesReelItem = ({
 
   const caption = useMemo(() => buildReelCaption(item), [item]);
 
-  const reelUrl = video
-    ? `https://play.3speak.tv/watch?v=${encodeURIComponent(video.author)}/${encodeURIComponent(
-        video.permlink,
-      )}&mode=iframe&autoplay=true`
-    : null;
-
   const _onUpvote = () => {
     onUpvotePress({
       content: item,
@@ -90,28 +84,8 @@ const WavesReelItem = ({
   return (
     <View style={[styles.reel, { height }]}>
       <View style={styles.videoLayer}>
-        {active && reelUrl ? (
-          <WebView
-            source={{ uri: reelUrl }}
-            style={styles.webview}
-            javaScriptEnabled
-            domStorageEnabled
-            bounces={false}
-            // Let vertical swipes fall through to the paging FlatList instead of
-            // being eaten by the player page, so users can move between reels.
-            scrollEnabled={false}
-            startInLoadingState
-            allowsInlineMediaPlayback
-            mediaPlaybackRequiresUserAction={false}
-            allowsFullscreenVideo
-            allowsProtectedMedia
-            thirdPartyCookiesEnabled
-            sharedCookiesEnabled
-            mixedContentMode="compatibility"
-            // Fixed-origin player: keep navigations inside 3Speak; anything else
-            // is handed to the OS browser rather than loaded in-page.
-            originWhitelist={['https://*.3speak.tv']}
-          />
+        {active && video ? (
+          <WavesReelVideo video={video} active={active} />
         ) : (
           <View style={styles.poster}>
             {video?.thumbnail_url ? (

--- a/src/screens/waves/children/wavesReelItem.tsx
+++ b/src/screens/waves/children/wavesReelItem.tsx
@@ -97,6 +97,9 @@ const WavesReelItem = ({
             javaScriptEnabled
             domStorageEnabled
             bounces={false}
+            // Let vertical swipes fall through to the paging FlatList instead of
+            // being eaten by the player page, so users can move between reels.
+            scrollEnabled={false}
             startInLoadingState
             allowsInlineMediaPlayback
             mediaPlaybackRequiresUserAction={false}
@@ -105,7 +108,9 @@ const WavesReelItem = ({
             thirdPartyCookiesEnabled
             sharedCookiesEnabled
             mixedContentMode="compatibility"
-            originWhitelist={['*']}
+            // Fixed-origin player: keep navigations inside 3Speak; anything else
+            // is handed to the OS browser rather than loaded in-page.
+            originWhitelist={['https://*.3speak.tv']}
           />
         ) : (
           <View style={styles.poster}>

--- a/src/screens/waves/children/wavesReelItem.tsx
+++ b/src/screens/waves/children/wavesReelItem.tsx
@@ -1,0 +1,186 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { Image, Text, TouchableOpacity, View } from 'react-native';
+import WebView from 'react-native-webview';
+import { useIntl } from 'react-intl';
+import { ShortsFeedEntry } from '@ecency/sdk';
+
+import { FormattedCurrency, Icon, UserAvatar } from '../../../components';
+import styles from '../styles/wavesReels.styles';
+
+interface Props {
+  item: ShortsFeedEntry;
+  height: number;
+  active: boolean;
+  onUpvotePress: (args: {
+    content: any;
+    sourceRef: React.RefObject<any>;
+    onVotingStart: (status: number) => void;
+  }) => void;
+  onReplyPress: (content: any) => void;
+  onTipPress: (content: any) => void;
+}
+
+// The reel already plays the video, so the caption is just the human text:
+// drop markdown images, the 3Speak "watch" footer link, other markdown links
+// (kept as their label), HTML tags (the composer appends videos as `text<br>url`)
+// and bare URLs (e.g. the play.3speak.tv embed link the body carries).
+function sanitizeCaptionText(value: string): string {
+  return value
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, ' ')
+    .replace(/\[[^\]]*\]\((?:https?:\/\/)?(?:play\.)?3speak[^)]*\)/gi, ' ')
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/https?:\/\/\S+/gi, ' ')
+    .replace(/▶️?/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+// Clean title and body independently so a title that's only a URL/markdown
+// (collapses to empty) falls back to the body text instead of a blank caption.
+function buildReelCaption(item: ShortsFeedEntry): string {
+  const caption = sanitizeCaptionText(item.title ?? '') || sanitizeCaptionText(item.body ?? '');
+  return caption.slice(0, 140);
+}
+
+/**
+ * One full-height reel: the 3Speak video plays only while the item is the one
+ * in view (mounting every WebView at once would autoplay/load dozens of
+ * videos), with the same upvote/reply/tip engagement as a wave card overlaid on
+ * top. Inactive reels show the poster thumbnail with a play badge.
+ */
+const WavesReelItem = ({
+  item,
+  height,
+  active,
+  onUpvotePress,
+  onReplyPress,
+  onTipPress,
+}: Props) => {
+  const intl = useIntl();
+  const upvoteRef = useRef<any>(null);
+  const { video } = item;
+  const itemIsUpVoted = !!(item as any).isUpVoted;
+
+  // Local vote state for immediate feedback (the feed query only reconciles the
+  // real vote on the 60s refetch), seeded from the parsed entry.
+  const [isVoted, setIsVoted] = useState(itemIsUpVoted);
+  useEffect(() => {
+    setIsVoted(itemIsUpVoted);
+  }, [itemIsUpVoted]);
+
+  const caption = useMemo(() => buildReelCaption(item), [item]);
+
+  const reelUrl = video
+    ? `https://play.3speak.tv/watch?v=${encodeURIComponent(video.author)}/${encodeURIComponent(
+        video.permlink,
+      )}&mode=iframe&autoplay=true`
+    : null;
+
+  const _onUpvote = () => {
+    onUpvotePress({
+      content: item,
+      sourceRef: upvoteRef,
+      onVotingStart: (status: number) => setIsVoted(status > 0),
+    });
+  };
+
+  const payoutValue = Number((item as any).total_payout) || 0;
+
+  return (
+    <View style={[styles.reel, { height }]}>
+      <View style={styles.videoLayer}>
+        {active && reelUrl ? (
+          <WebView
+            source={{ uri: reelUrl }}
+            style={styles.webview}
+            javaScriptEnabled
+            domStorageEnabled
+            bounces={false}
+            startInLoadingState
+            allowsInlineMediaPlayback
+            mediaPlaybackRequiresUserAction={false}
+            allowsFullscreenVideo
+            allowsProtectedMedia
+            thirdPartyCookiesEnabled
+            sharedCookiesEnabled
+            mixedContentMode="compatibility"
+            originWhitelist={['*']}
+          />
+        ) : (
+          <View style={styles.poster}>
+            {video?.thumbnail_url ? (
+              <Image source={{ uri: video.thumbnail_url }} style={styles.posterImage} />
+            ) : (
+              <View style={styles.posterFallback} />
+            )}
+            <View style={styles.playBadge}>
+              <Icon iconType="AntDesign" name="playcircleo" style={styles.playIcon} />
+            </View>
+          </View>
+        )}
+      </View>
+
+      {/* Author + caption (bottom-left). box-none so taps reach the video/rail
+          except on the avatar/name themselves. */}
+      <View style={styles.bottomOverlay} pointerEvents="box-none">
+        <View style={styles.authorRow}>
+          <UserAvatar username={item.author} />
+          <Text style={styles.authorName}>@{item.author}</Text>
+        </View>
+        {!!caption && (
+          <Text style={styles.caption} numberOfLines={2}>
+            {caption}
+          </Text>
+        )}
+      </View>
+
+      {/* Engagement rail (bottom-right) */}
+      <View style={styles.rail}>
+        <TouchableOpacity
+          ref={upvoteRef}
+          onPress={_onUpvote}
+          style={styles.railBtn}
+          accessibilityRole="button"
+          accessibilityLabel={intl.formatMessage({ id: 'post.upvote', defaultMessage: 'Upvote' })}
+        >
+          <Icon
+            iconType="AntDesign"
+            name={isVoted ? 'upcircle' : 'upcircleo'}
+            style={isVoted ? styles.railIconVoted : styles.railIcon}
+          />
+          <Text style={styles.railText}>
+            <FormattedCurrency value={payoutValue} />
+          </Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          onPress={() => onReplyPress(item)}
+          style={styles.railBtn}
+          accessibilityRole="button"
+          accessibilityLabel={intl.formatMessage({
+            id: 'post.a11y_reply_hint',
+            defaultMessage: 'Reply',
+          })}
+        >
+          <Icon iconType="MaterialCommunityIcons" name="comment-outline" style={styles.railIcon} />
+          <Text style={styles.railText}>{(item as any).children || 0}</Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          onPress={() => onTipPress(item)}
+          style={styles.railBtn}
+          accessibilityRole="button"
+          accessibilityLabel={intl.formatMessage({
+            id: 'post.a11y_tip',
+            defaultMessage: 'Send tip',
+          })}
+        >
+          <Icon iconType="MaterialCommunityIcons" name="gift-outline" style={styles.railIcon} />
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+};
+
+export default React.memo(WavesReelItem);

--- a/src/screens/waves/children/wavesReelVideo.tsx
+++ b/src/screens/waves/children/wavesReelVideo.tsx
@@ -1,0 +1,155 @@
+import React, { useEffect, useState } from 'react';
+import { Image, TouchableOpacity, View } from 'react-native';
+import Video from 'react-native-video';
+import WebView from 'react-native-webview';
+import { useIntl } from 'react-intl';
+import { ShortVideo } from '@ecency/sdk';
+
+import { Icon } from '../../../components';
+import styles from '../styles/wavesReels.styles';
+
+// Resolve a 3Speak video's HLS stream (manifest.m3u8) from its embed API, so the
+// reel can play it natively (react-native-video) and fill the frame via
+// resizeMode instead of being letterboxed inside an opaque WebView player. The
+// feed only carries the embed iframe URL. Returns the primary URL (or a CDN
+// fallback), or null when it can't be resolved.
+async function resolveThreeSpeakHls(
+  author: string,
+  permlink: string,
+  signal: AbortSignal,
+): Promise<string | null> {
+  try {
+    const res = await fetch(
+      `https://play.3speak.tv/api/embed?v=${encodeURIComponent(author)}/${encodeURIComponent(
+        permlink,
+      )}`,
+      { signal },
+    );
+    if (!res.ok) {
+      return null;
+    }
+    const data = await res.json();
+    const url = [data?.videoUrl, data?.videoUrlFallback1, data?.videoUrlFallback2].find(
+      (u: unknown): u is string => typeof u === 'string' && u.length > 0,
+    );
+    return url ?? null;
+  } catch {
+    return null;
+  }
+}
+
+interface Props {
+  video: ShortVideo;
+  active: boolean;
+}
+
+/**
+ * Native HLS reel player. Streams the 3Speak manifest into react-native-video so
+ * the clip fills the reel aspect-aware: portrait/square clips fill (cover) and
+ * landscape clips are letterboxed (contain) so nothing is cropped. While the
+ * stream resolves it shows the poster (no black flash), and it falls back to the
+ * 3Speak iframe (WebView) if the stream can't be resolved or played.
+ */
+const WavesReelVideo = ({ video, active }: Props) => {
+  const intl = useIntl();
+  const [src, setSrc] = useState<string | null>(null);
+  const [resizeMode, setResizeMode] = useState<'cover' | 'contain'>('contain');
+  const [muted, setMuted] = useState(false);
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    if (!active) {
+      return undefined;
+    }
+    const ac = new AbortController();
+    let cancelled = false;
+    (async () => {
+      const url = await resolveThreeSpeakHls(video.author, video.permlink, ac.signal);
+      if (cancelled) {
+        return;
+      }
+      if (url) {
+        setSrc(url);
+      } else {
+        setFailed(true);
+      }
+    })();
+    return () => {
+      cancelled = true;
+      ac.abort();
+    };
+  }, [active, video.author, video.permlink]);
+
+  if (failed) {
+    const reelUrl = `https://play.3speak.tv/watch?v=${encodeURIComponent(
+      video.author,
+    )}/${encodeURIComponent(video.permlink)}&mode=iframe&autoplay=true`;
+    return (
+      <WebView
+        source={{ uri: reelUrl }}
+        style={styles.webview}
+        javaScriptEnabled
+        domStorageEnabled
+        bounces={false}
+        scrollEnabled={false}
+        startInLoadingState
+        allowsInlineMediaPlayback
+        mediaPlaybackRequiresUserAction={false}
+        allowsFullscreenVideo
+        allowsProtectedMedia
+        thirdPartyCookiesEnabled
+        sharedCookiesEnabled
+        mixedContentMode="compatibility"
+        originWhitelist={['https://*.3speak.tv']}
+      />
+    );
+  }
+
+  if (!src) {
+    return (
+      <View style={styles.poster}>
+        {video.thumbnail_url ? (
+          <Image source={{ uri: video.thumbnail_url }} style={styles.posterImage} />
+        ) : (
+          <View style={styles.posterFallback} />
+        )}
+      </View>
+    );
+  }
+
+  return (
+    <>
+      <Video
+        source={{ uri: src }}
+        style={styles.webview}
+        paused={!active}
+        muted={muted}
+        repeat
+        resizeMode={resizeMode}
+        poster={video.thumbnail_url ?? undefined}
+        onLoad={(data: { naturalSize?: { orientation?: string } }) =>
+          setResizeMode(data?.naturalSize?.orientation === 'portrait' ? 'cover' : 'contain')
+        }
+        onError={() => setFailed(true)}
+      />
+      <TouchableOpacity
+        onPress={() => setMuted((m) => !m)}
+        style={styles.muteBtn}
+        accessibilityRole="button"
+        accessibilityLabel={
+          muted
+            ? intl.formatMessage({ id: 'waves.unmute', defaultMessage: 'Unmute' })
+            : intl.formatMessage({ id: 'waves.mute', defaultMessage: 'Mute' })
+        }
+      >
+        <Icon
+          iconType="MaterialCommunityIcons"
+          name={muted ? 'volume-off' : 'volume-high'}
+          style={styles.muteIcon}
+        />
+      </TouchableOpacity>
+    </>
+  );
+};
+
+export default WavesReelVideo;

--- a/src/screens/waves/children/wavesReelsView.tsx
+++ b/src/screens/waves/children/wavesReelsView.tsx
@@ -1,0 +1,186 @@
+import React, { useCallback, useMemo, useRef, useState } from 'react';
+import {
+  ActivityIndicator,
+  Dimensions,
+  FlatList,
+  LayoutChangeEvent,
+  ListRenderItem,
+  RefreshControl,
+  Text,
+  View,
+  ViewToken,
+} from 'react-native';
+import { useIntl } from 'react-intl';
+import { SheetManager } from 'react-native-actions-sheet';
+import { ShortsFeedEntry } from '@ecency/sdk';
+
+import { UpvotePopover } from '../../../components';
+import { PostTypes } from '../../../constants/postTypes';
+import { SheetNames } from '../../../navigation/sheets';
+import { shortsQueries } from '../../../providers/queries';
+import WavesReelItem from './wavesReelItem';
+import styles from '../styles/wavesReels.styles';
+
+interface Props {
+  observer?: string;
+  isDarkTheme: boolean;
+}
+
+// A reel counts as "the one in view" once it covers most of the viewport, so the
+// active video (and its autoplay) tracks the page the user has snapped to.
+const VIEWABILITY_CONFIG = { itemVisiblePercentThreshold: 80 };
+
+const keyOf = (item: ShortsFeedEntry) => `${item.author}/${item.permlink}`;
+
+const WavesReelsView = ({ observer, isDarkTheme }: Props) => {
+  const intl = useIntl();
+  const shortsQuery = shortsQueries.useShortsQuery(observer);
+  const upvotePopoverRef = useRef<any>(null);
+
+  const [activeKey, setActiveKey] = useState<string | null>(null);
+  const [viewHeight, setViewHeight] = useState(() => Dimensions.get('window').height);
+
+  const { data } = shortsQuery;
+
+  const _onLayout = (event: LayoutChangeEvent) => {
+    const { height } = event.nativeEvent.layout;
+    if (height > 0 && height !== viewHeight) {
+      setViewHeight(height);
+    }
+  };
+
+  // Kept in a ref because FlatList forbids changing onViewableItemsChanged on
+  // the fly; setActiveKey is stable so the callback never needs to change.
+  const _onViewableItemsChanged = useRef(({ viewableItems }: { viewableItems: ViewToken[] }) => {
+    const first = viewableItems[0]?.item as ShortsFeedEntry | undefined;
+    if (first) {
+      setActiveKey(keyOf(first));
+    }
+  }).current;
+
+  const _onUpvotePress = useCallback(
+    ({
+      content,
+      sourceRef,
+      onVotingStart,
+    }: {
+      content: any;
+      sourceRef: React.RefObject<any>;
+      onVotingStart: (status: number) => void;
+    }) => {
+      upvotePopoverRef.current?.showPopover({
+        sourceRef,
+        content,
+        postType: PostTypes.WAVE,
+        onVotingStart,
+      });
+    },
+    [],
+  );
+
+  const _onReplyPress = useCallback((content: any) => {
+    SheetManager.show(SheetNames.QUICK_POST, {
+      payload: { mode: 'comment', parentPost: content },
+    });
+  }, []);
+
+  const _onTipPress = useCallback((content: any) => {
+    SheetManager.show(SheetNames.TIPPING_DIALOG, {
+      payload: { post: content },
+    });
+  }, []);
+
+  const _renderItem = useCallback<ListRenderItem<ShortsFeedEntry>>(
+    ({ item }) => (
+      <WavesReelItem
+        item={item}
+        height={viewHeight}
+        active={activeKey === keyOf(item)}
+        onUpvotePress={_onUpvotePress}
+        onReplyPress={_onReplyPress}
+        onTipPress={_onTipPress}
+      />
+    ),
+    [viewHeight, activeKey, _onUpvotePress, _onReplyPress, _onTipPress],
+  );
+
+  const _getItemLayout = useCallback(
+    (_: unknown, index: number) => ({
+      length: viewHeight,
+      offset: viewHeight * index,
+      index,
+    }),
+    [viewHeight],
+  );
+
+  const _onEndReached = () => {
+    if (shortsQuery.hasNextPage && !shortsQuery.isFetchingNextPage) {
+      shortsQuery.fetchNextPage();
+    }
+  };
+
+  const _renderFooter = () =>
+    shortsQuery.isFetchingNextPage && !shortsQuery.isRefreshing ? (
+      <View style={styles.footer}>
+        <ActivityIndicator color="#fff" />
+      </View>
+    ) : null;
+
+  const _renderEmpty = () => {
+    if (shortsQuery.isLoading || shortsQuery.isRefreshing) {
+      return (
+        <View style={[styles.emptyWrapper, { height: viewHeight }]}>
+          <ActivityIndicator color="#fff" />
+        </View>
+      );
+    }
+    return (
+      <View style={[styles.emptyWrapper, { height: viewHeight }]}>
+        <Text style={styles.emptyText}>
+          {intl.formatMessage({
+            id: 'waves.shorts_empty',
+            defaultMessage: 'No shorts to show yet',
+          })}
+        </Text>
+      </View>
+    );
+  };
+
+  const refreshControl = useMemo(
+    () => (
+      <RefreshControl
+        refreshing={shortsQuery.isRefreshing}
+        onRefresh={shortsQuery.refresh}
+        tintColor={!isDarkTheme ? '#357ce6' : '#96c0ff'}
+        colors={['#fff']}
+      />
+    ),
+    [shortsQuery.isRefreshing, shortsQuery.refresh, isDarkTheme],
+  );
+
+  return (
+    <View style={styles.container} onLayout={_onLayout}>
+      <FlatList
+        data={data}
+        keyExtractor={keyOf}
+        renderItem={_renderItem}
+        pagingEnabled
+        showsVerticalScrollIndicator={false}
+        getItemLayout={_getItemLayout}
+        onViewableItemsChanged={_onViewableItemsChanged}
+        viewabilityConfig={VIEWABILITY_CONFIG}
+        onEndReached={_onEndReached}
+        onEndReachedThreshold={1.5}
+        windowSize={3}
+        maxToRenderPerBatch={2}
+        initialNumToRender={1}
+        refreshControl={refreshControl}
+        ListEmptyComponent={_renderEmpty}
+        ListFooterComponent={_renderFooter}
+      />
+      <UpvotePopover ref={upvotePopoverRef} />
+    </View>
+  );
+};
+
+export default WavesReelsView;

--- a/src/screens/waves/children/wavesReelsView.tsx
+++ b/src/screens/waves/children/wavesReelsView.tsx
@@ -24,6 +24,9 @@ import styles from '../styles/wavesReels.styles';
 interface Props {
   observer?: string;
   isDarkTheme: boolean;
+  // Shared with wavesScreen's active-list ref so re-tapping the Shorts tab
+  // scrolls the reels back to the top, like the other feed tabs.
+  listRef?: React.RefObject<FlatList<ShortsFeedEntry> | null>;
 }
 
 // A reel counts as "the one in view" once it covers most of the viewport, so the
@@ -32,7 +35,7 @@ const VIEWABILITY_CONFIG = { itemVisiblePercentThreshold: 80 };
 
 const keyOf = (item: ShortsFeedEntry) => `${item.author}/${item.permlink}`;
 
-const WavesReelsView = ({ observer, isDarkTheme }: Props) => {
+const WavesReelsView = ({ observer, isDarkTheme, listRef }: Props) => {
   const intl = useIntl();
   const shortsQuery = shortsQueries.useShortsQuery(observer);
   const upvotePopoverRef = useRef<any>(null);
@@ -161,6 +164,7 @@ const WavesReelsView = ({ observer, isDarkTheme }: Props) => {
   return (
     <View style={styles.container} onLayout={_onLayout}>
       <FlatList
+        ref={listRef}
         data={data}
         keyExtractor={keyOf}
         renderItem={_renderItem}

--- a/src/screens/waves/screen/wavesScreen.tsx
+++ b/src/screens/waves/screen/wavesScreen.tsx
@@ -28,8 +28,9 @@ import styles from '../styles/wavesScreen.styles';
 import { wavesQueries } from '../../../providers/queries';
 import { useAppSelector } from '../../../hooks';
 import { WavesHeader } from '../children/wavesHeader';
+import WavesReelsView from '../children/wavesReelsView';
 import { PostTypes } from '../../../constants/postTypes';
-import { waveSourceLabel } from '../../../constants/waves';
+import { SHORTS_SOURCE, waveSourceLabel } from '../../../constants/waves';
 import { ScrollTopPopup } from '../../../components/atoms';
 import { SheetNames } from '../../../navigation/sheets';
 import {
@@ -252,6 +253,11 @@ const WavesScreen = () => {
   const containerTabQueryOptions = useMemo(() => {
     const map: Record<string, ReturnType<typeof getWavesFeedQueryOptions>> = {};
     waveContainers.forEach((host) => {
+      // Shorts isn't a single container: it's the cross-container reels feed,
+      // rendered by WavesReelsView with its own SDK query, so skip it here.
+      if (host === SHORTS_SOURCE) {
+        return;
+      }
       map[`container:${host}`] = getWavesFeedQueryOptions({ containers: [host], observer });
     });
     return map;
@@ -375,6 +381,16 @@ const WavesScreen = () => {
   ) : null;
 
   const _renderWavesScene = ({ route }: { route: { key: string } }) => {
+    // Shorts is a source like any other in the picker, but it's cross-container
+    // and gets the full-screen vertical reels viewer instead of the waves list.
+    if (route.key === `container:${SHORTS_SOURCE}`) {
+      return (
+        <View style={styles.tabScene}>
+          <WavesReelsView observer={observer} isDarkTheme={isDarkTheme} />
+        </View>
+      );
+    }
+
     if (route.key === 'following') {
       if (!currentAccount?.name) {
         return <View style={styles.tabScene} />;

--- a/src/screens/waves/screen/wavesScreen.tsx
+++ b/src/screens/waves/screen/wavesScreen.tsx
@@ -386,7 +386,11 @@ const WavesScreen = () => {
     if (route.key === `container:${SHORTS_SOURCE}`) {
       return (
         <View style={styles.tabScene}>
-          <WavesReelsView observer={observer} isDarkTheme={isDarkTheme} />
+          <WavesReelsView
+            observer={observer}
+            isDarkTheme={isDarkTheme}
+            listRef={_getDynamicTabRef(route.key)}
+          />
         </View>
       );
     }
@@ -559,7 +563,11 @@ const WavesScreen = () => {
           Alert.alert(intl.formatMessage({ id: 'alert.fail' }));
         }}
       />
-      <FabButton bottomOffset={fabBottomOffset} onPress={_onCreatePress} />
+      {/* No compose-wave FAB on the Shorts reels tab: you don't post into
+          shorts, and the FAB would sit on top of the reel's tip button. */}
+      {feedType !== `container:${SHORTS_SOURCE}` && (
+        <FabButton bottomOffset={fabBottomOffset} onPress={_onCreatePress} />
+      )}
     </View>
   );
 };

--- a/src/screens/waves/styles/wavesReels.styles.ts
+++ b/src/screens/waves/styles/wavesReels.styles.ts
@@ -90,6 +90,19 @@ export default EStyleSheet.create({
     color: '#fff',
     fontSize: 12,
   } as TextStyle,
+  muteBtn: {
+    ...({ position: 'absolute', top: 12, right: 12 } as ViewStyle),
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'rgba(0, 0, 0, 0.4)',
+  } as ViewStyle,
+  muteIcon: {
+    color: '#fff',
+    fontSize: 18,
+  } as TextStyle,
   footer: {
     paddingVertical: 24,
     alignItems: 'center',

--- a/src/screens/waves/styles/wavesReels.styles.ts
+++ b/src/screens/waves/styles/wavesReels.styles.ts
@@ -1,0 +1,109 @@
+import { ImageStyle, TextStyle, ViewStyle } from 'react-native';
+import EStyleSheet from 'react-native-extended-stylesheet';
+
+export default EStyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#000',
+  } as ViewStyle,
+  reel: {
+    width: '100%',
+    backgroundColor: '#000',
+    justifyContent: 'center',
+  } as ViewStyle,
+  videoLayer: {
+    ...({ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0 } as ViewStyle),
+    alignItems: 'center',
+    justifyContent: 'center',
+  } as ViewStyle,
+  webview: {
+    flex: 1,
+    width: '100%',
+    backgroundColor: '#000',
+  } as ViewStyle,
+  poster: {
+    flex: 1,
+    width: '100%',
+    alignItems: 'center',
+    justifyContent: 'center',
+  } as ViewStyle,
+  posterImage: {
+    ...({ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0 } as ImageStyle),
+    width: '100%',
+    height: '100%',
+    opacity: 0.9,
+  } as ImageStyle,
+  posterFallback: {
+    ...({ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0 } as ViewStyle),
+    backgroundColor: '#1a1a1a',
+  } as ViewStyle,
+  playBadge: {
+    width: 64,
+    height: 64,
+    borderRadius: 32,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'rgba(0, 0, 0, 0.45)',
+  } as ViewStyle,
+  playIcon: {
+    color: '#fff',
+    fontSize: 38,
+  } as TextStyle,
+  bottomOverlay: {
+    ...({ position: 'absolute', left: 0, right: 64, bottom: 0 } as ViewStyle),
+    padding: 16,
+    paddingBottom: 24,
+  } as ViewStyle,
+  authorRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  } as ViewStyle,
+  authorName: {
+    marginLeft: 8,
+    color: '#fff',
+    fontWeight: '600',
+    fontSize: 15,
+  } as TextStyle,
+  caption: {
+    marginTop: 8,
+    color: 'rgba(255, 255, 255, 0.9)',
+    fontSize: 14,
+  } as TextStyle,
+  rail: {
+    ...({ position: 'absolute', right: 8, bottom: 24 } as ViewStyle),
+    alignItems: 'center',
+  } as ViewStyle,
+  railBtn: {
+    alignItems: 'center',
+    marginBottom: 18,
+  } as ViewStyle,
+  railIcon: {
+    color: '#fff',
+    fontSize: 30,
+  } as TextStyle,
+  railIconVoted: {
+    color: '#357ce6',
+    fontSize: 30,
+  } as TextStyle,
+  railText: {
+    marginTop: 2,
+    color: '#fff',
+    fontSize: 12,
+  } as TextStyle,
+  footer: {
+    paddingVertical: 24,
+    alignItems: 'center',
+    justifyContent: 'center',
+  } as ViewStyle,
+  emptyWrapper: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 32,
+  } as ViewStyle,
+  emptyText: {
+    color: 'rgba(255, 255, 255, 0.8)',
+    fontSize: 15,
+    textAlign: 'center',
+  } as TextStyle,
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1211,10 +1211,10 @@
     url "^0.11.0"
     xss "^1.0.9"
 
-"@ecency/sdk@^2.3.27":
-  version "2.3.27"
-  resolved "https://registry.yarnpkg.com/@ecency/sdk/-/sdk-2.3.27.tgz#4e4d9918d00272e4411bae9330f6a01c5d967498"
-  integrity sha512-NpQ5kEsaae1cwU6q8aYuC4LyWhoQdb7p5R3qmcNCOFA5NooHbW0QDdWhzGUx8wnf7M7se7Oc5GEiGUOSwX6qCw==
+"@ecency/sdk@^2.3.28":
+  version "2.3.28"
+  resolved "https://registry.yarnpkg.com/@ecency/sdk/-/sdk-2.3.28.tgz#9564bc9183310e7cc9c5f78a52ee566a6017628d"
+  integrity sha512-GbE/ReVBOqYOxv34Yx3P2SKjP1hNem66lqn/BzRo6dR8G8hvTdSbgP3hajB5X8eaQIPaieylv2Yy3zplpRlkRg==
   dependencies:
     "@noble/ciphers" "^2.1.1"
     "@noble/curves" "^2.0.1"


### PR DESCRIPTION
## What

Adds a **Shorts (reels)** experience to the mobile waves screen, mirroring the web Shorts tab (vision-next #1039). Shorts is an opt-in source in the waves picker; selecting it shows a full-screen vertical reels viewer instead of the comments list.

## How

- **SDK bump 2.3.27 → 2.3.28** — adds `getShortsFeedQueryOptions` / `ShortsFeedEntry` (cross-container shorts feed backed by esync `/api/waves/shorts`). The only other change since 2.3.27 is additive; the null-account behaviour was already handled in #3314.
- **`SHORTS_SOURCE`** added to `WAVES_SOURCE_OPTIONS`, so it appears as a one-tap chip in the existing source picker and pins a `container:shorts` tab through the existing tab machinery.
- **`useShortsQuery`** (`shortsQueries.ts`) wraps the SDK infinite query with the same mute/bot visibility filter as `useWavesQuery`, plus a guard that only entries carrying a playable video reach the viewer.
- **`WavesReelsView`** — paging `FlatList` (full-height items, viewability-driven active page) + pull-to-refresh + infinite scroll, with a single `UpvotePopover`.
- **`WavesReelItem`** — the active reel autoplays the 3Speak video in a `WebView` (`play.3speak.tv/watch?v=…&mode=iframe&autoplay=true`); inactive reels show the poster thumbnail. Author + caption overlay (markdown/URL-stripped) and an upvote / reply / tip rail wired to the same handlers the waves list uses (`UpvotePopover`, quick-post comment sheet, tipping dialog).

Shorts is cross-container, so its `container:shorts` route is rendered with the reels view and its own query; it is excluded from the standard waves-feed `containerTabQueryOptions`.

## Scope

v1 is cross-container with no sub-filter, matching the web. No promoted interleaving or following filter on shorts.

## Test plan

- [x] `yarn lint` clean on changed files
- [x] `yarn test:ci` green (470 passing)
- [ ] Device: open Waves → picker → pin **Shorts** → tab shows a vertical reels feed; swiping plays only the in-view video; upvote/reply/tip work; pull-to-refresh and infinite scroll work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Shorts/reels experience in Waves with vertical paging, autoplay playback, and reel engagement actions (upvote, reply, tip).
  * Introduced a dedicated Shorts tab/route plus an “empty” message when no shorts are available.
* **Bug Fixes**
  * Improved reel caption cleanup for cleaner text by removing markup/links and truncating to a shorter display length.
  * Enhanced shorts feed visibility by filtering muted/graylisted items and only showing playable video posts.
* **Chores**
  * Updated the ecency SDK dependency to the latest patch version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->