### PR TITLE
Bump @ecency/render-helper to 2.5.17

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@babel/preset-typescript": "^7.26.0",
     "@babel/runtime": "^7.26.7",
-    "@ecency/render-helper": "^2.5.16",
+    "@ecency/render-helper": "^2.5.17",
     "@ecency/sdk": "^2.3.27",
     "@esteemapp/react-native-autocomplete-input": "^4.2.1",
     "@esteemapp/react-native-multi-slider": "^1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1192,10 +1192,10 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@ecency/render-helper@^2.5.16":
-  version "2.5.16"
-  resolved "https://registry.yarnpkg.com/@ecency/render-helper/-/render-helper-2.5.16.tgz#f5d95415e245edd76ca0cb62d0f6f8f46aad7121"
-  integrity sha512-zNqzftJIqt2Qun/C4SborZAK9DT0qALODvBcCTtXE49jxEgqpMLLbXJU/I53s+dJBmKAlB/rQOo7nGfWHth11A==
+"@ecency/render-helper@^2.5.17":
+  version "2.5.17"
+  resolved "https://registry.yarnpkg.com/@ecency/render-helper/-/render-helper-2.5.17.tgz#4ccc36c3045a33110e674dda62f1f873b80d445a"
+  integrity sha512-kBfeme113RSFjIstD8DUvoewCn/Vj0SbkLIQO8WIzVUh4mlwSr6n6SX6rSPVGdcQFt9mvJoj2LgZUFysOVbijQ==
   dependencies:
     "@xmldom/xmldom" "^0.9.10"
     dom-serializer "^2.0.0"


### PR DESCRIPTION
Bumps `@ecency/render-helper` from 2.5.16 to 2.5.17.

Picks up the latest published render-helper. The notable change in 2.5.17 is the removal of the web-only "Hive account" label on `@username` mention chips (the `forApp=false` render branch). Mobile renders mentions through the `forApp=true` `markdown-author-link` path, which is unchanged, so this is a routine dependency freshening with **no behavioral change** for the app.

### Changes
- `package.json` - `@ecency/render-helper` `^2.5.16` -> `^2.5.17`
- `yarn.lock` - updated resolution (deps unchanged between versions; lockfile integrity/shasum verified against the published tarball)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a core rendering library to the latest patch version, helping keep the app current and stable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->