### PR TITLE
fix(waves): stop shorts reel playback when its tab isn't focused

### DIFF
--- a/src/screens/waves/children/wavesReelsView.tsx
+++ b/src/screens/waves/children/wavesReelsView.tsx
@@ -27,6 +27,10 @@ interface Props {
   // Shared with wavesScreen's active-list ref so re-tapping the Shorts tab
   // scrolls the reels back to the top, like the other feed tabs.
   listRef?: React.RefObject<FlatList<ShortsFeedEntry> | null>;
+  // True only while the Shorts tab is the active, on-screen tab. When false
+  // (switched to another waves tab or off the Waves screen) no reel is active,
+  // so the video player unmounts and stops playing instead of running hidden.
+  focused?: boolean;
 }
 
 // A reel counts as "the one in view" once it covers most of the viewport, so the
@@ -35,7 +39,7 @@ const VIEWABILITY_CONFIG = { itemVisiblePercentThreshold: 80 };
 
 const keyOf = (item: ShortsFeedEntry) => `${item.author}/${item.permlink}`;
 
-const WavesReelsView = ({ observer, isDarkTheme, listRef }: Props) => {
+const WavesReelsView = ({ observer, isDarkTheme, listRef, focused = true }: Props) => {
   const intl = useIntl();
   const shortsQuery = shortsQueries.useShortsQuery(observer);
   const upvotePopoverRef = useRef<any>(null);
@@ -98,13 +102,13 @@ const WavesReelsView = ({ observer, isDarkTheme, listRef }: Props) => {
       <WavesReelItem
         item={item}
         height={viewHeight}
-        active={activeKey === keyOf(item)}
+        active={focused && activeKey === keyOf(item)}
         onUpvotePress={_onUpvotePress}
         onReplyPress={_onReplyPress}
         onTipPress={_onTipPress}
       />
     ),
-    [viewHeight, activeKey, _onUpvotePress, _onReplyPress, _onTipPress],
+    [focused, viewHeight, activeKey, _onUpvotePress, _onReplyPress, _onTipPress],
   );
 
   const _getItemLayout = useCallback(
@@ -168,6 +172,9 @@ const WavesReelsView = ({ observer, isDarkTheme, listRef }: Props) => {
         data={data}
         keyExtractor={keyOf}
         renderItem={_renderItem}
+        // Re-render cells when the active reel or tab-focus changes so the
+        // previously-active reel actually tears its player down.
+        extraData={`${focused}:${activeKey}`}
         pagingEnabled
         showsVerticalScrollIndicator={false}
         getItemLayout={_getItemLayout}

--- a/src/screens/waves/screen/wavesScreen.tsx
+++ b/src/screens/waves/screen/wavesScreen.tsx
@@ -15,6 +15,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { SheetManager } from 'react-native-actions-sheet';
 import { useIntl } from 'react-intl';
 import { getWavesFeedQueryOptions } from '@ecency/sdk';
+import { useIsFocused } from '@react-navigation/native';
 import {
   Comments,
   EmptyScreen,
@@ -216,6 +217,11 @@ const WavesScreen = () => {
     }
   }, []);
 
+  // Whether the Waves screen itself is the focused route (not behind another
+  // bottom tab / pushed screen). Combined with the active waves tab below to
+  // decide if the Shorts reels should actually be playing.
+  const isScreenFocused = useIsFocused();
+
   const isLoggedIn = useAppSelector(selectIsLoggedIn);
   const currentAccount = useAppSelector(selectCurrentAccount);
   const isDarkTheme = useAppSelector(selectIsDarkTheme);
@@ -384,12 +390,17 @@ const WavesScreen = () => {
     // Shorts is a source like any other in the picker, but it's cross-container
     // and gets the full-screen vertical reels viewer instead of the waves list.
     if (route.key === `container:${SHORTS_SOURCE}`) {
+      // TabView keeps visited scenes mounted, so gate playback on the Shorts tab
+      // actually being the active, on-screen tab — otherwise the reel keeps
+      // playing (and holding the player) after switching away.
+      const shortsFocused = isScreenFocused && feedType === `container:${SHORTS_SOURCE}`;
       return (
         <View style={styles.tabScene}>
           <WavesReelsView
             observer={observer}
             isDarkTheme={isDarkTheme}
             listRef={_getDynamicTabRef(route.key)}
+            focused={shortsFocused}
           />
         </View>
       );


### PR DESCRIPTION
## Problem

Switching from the **Shorts** tab to **For you**/**Following** (or leaving the Waves screen) left the reel video playing — audio kept going in the background and the player stayed alive (memory + bad UX).

## Cause

`TabView` keeps visited scenes mounted (just hidden), so the Shorts scene's `<Video>` kept running. The reel's `active` state was driven only by in-list viewability, which stays true when the tab is hidden.

## Fix

Gate reel activity on the Shorts tab actually being the focused, on-screen tab — `useIsFocused()` (Waves screen is the active route) **and** `feedType === container:shorts` (Shorts is the active waves tab). When false, no reel is `active`, so `WavesReelItem` renders the poster and **`WavesReelVideo` unmounts** — stopping playback and releasing the player. `extraData` ensures the previously-active cell re-renders to tear down.

## Test plan
- [ ] Play a short, switch to For you/Following → audio stops immediately.
- [ ] Switch back to Shorts → the in-view reel resumes.
- [ ] Navigate away from Waves entirely → audio stops.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reels now stop staying active when the Waves screen or Shorts feed is not currently focused.
  * Improved list updates so reel playback state refreshes correctly when focus changes or a different reel becomes active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->