### PR TITLE
Show Ecency source badge on post feed cards

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -102,7 +102,7 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode versionMajor * 10000 + versionMinor * 100 + versionPatch
-        versionName "3.5.7"
+        versionName "3.5.8"
         resValue "string", "build_config_package", "app.esteem.mobile.android"
         multiDexEnabled true
         // react-native-image-crop-picker

--- a/ios/Ecency.xcodeproj/project.pbxproj
+++ b/ios/Ecency.xcodeproj/project.pbxproj
@@ -1448,7 +1448,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 32;
+				CURRENT_PROJECT_VERSION = 33;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 75B6RXTKGT;
@@ -1494,7 +1494,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 32;
+				CURRENT_PROJECT_VERSION = 33;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 75B6RXTKGT;
@@ -1535,7 +1535,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 32;
+				CURRENT_PROJECT_VERSION = 33;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 75B6RXTKGT;
@@ -1618,7 +1618,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 32;
+				CURRENT_PROJECT_VERSION = 33;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 75B6RXTKGT;

--- a/ios/Ecency/Info.plist
+++ b/ios/Ecency/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.5.7</string>
+	<string>3.5.8</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/ios/EcencyTests/Info.plist
+++ b/ios/EcencyTests/Info.plist
@@ -15,10 +15,10 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.5.7</string>
+	<string>3.5.8</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>32</string>
+	<string>33</string>
 </dict>
 </plist>

--- a/ios/eshare/Info.plist
+++ b/ios/eshare/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.5.7</string>
+	<string>3.5.8</string>
 	<key>CFBundleVersion</key>
-	<string>32</string>
+	<string>33</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ecency",
-  "version": "3.5.7",
+  "version": "3.5.8",
   "displayName": "Ecency",
   "private": true,
   "rnpm": {

--- a/src/components/postCard/children/postCardHeader.tsx
+++ b/src/components/postCard/children/postCardHeader.tsx
@@ -41,6 +41,18 @@ const PostCardHeaderComponent = ({
   const _isPollPost =
     content?.json_metadata?.content_type === ContentType.POLL && !!content?.json_metadata?.question;
 
+  // Show the Ecency source badge when the post was published from an Ecency
+  // client (e.g. ecency/x-vision, ecency-mobile). Mirrors the comment/wave
+  // badge; only an explicit "ecency" app matches (not a missing app).
+  const _isFromEcency = useMemo(
+    () =>
+      String(content?.json_metadata?.app || '')
+        .split('/')[0]
+        .toLowerCase()
+        .includes('ecency'),
+    [content],
+  );
+
   const _handleOnTagPress = (navParams) => {
     handleCardInteraction(PostCardActionIds.NAVIGATE, navParams);
   };
@@ -85,6 +97,7 @@ const PostCardHeaderComponent = ({
           content={content}
           rebloggedBy={rebloggedBy}
           isPromoted={get(content, 'is_promoted')}
+          isFromEcency={_isFromEcency}
         />
 
         <View style={styles.headerIconsWrapper}>

--- a/src/components/postCard/children/postCardHeader.tsx
+++ b/src/components/postCard/children/postCardHeader.tsx
@@ -43,13 +43,14 @@ const PostCardHeaderComponent = ({
 
   // Show the Ecency source badge when the post was published from an Ecency
   // client (e.g. ecency/x-vision, ecency-mobile). Mirrors the comment/wave
-  // badge; only an explicit "ecency" app matches (not a missing app).
+  // badge; only an explicit "ecency" app matches (not a missing app). Anchor to
+  // the start so lookalikes like "notecency/..." don't falsely match.
   const _isFromEcency = useMemo(
     () =>
       String(content?.json_metadata?.app || '')
         .split('/')[0]
         .toLowerCase()
-        .includes('ecency'),
+        .startsWith('ecency'),
     [content],
   );
 

--- a/src/components/postElements/headerDescription/view/postHeaderDescription.tsx
+++ b/src/components/postElements/headerDescription/view/postHeaderDescription.tsx
@@ -222,6 +222,10 @@ class PostHeaderDescription extends PureComponent {
               )}
 
               {!inlineTime && <Text style={styles.date}>{date}</Text>}
+
+              {!inlineTime && isFromEcency && (
+                <Image source={ECENCY_LOGO} style={styles.ecencySourceBadge} />
+              )}
             </View>
           </View>
         </View>


### PR DESCRIPTION
## What

The Ecency "published via" badge already appears on waves, comments and the single-post view. This surfaces it on the post feed cards too, so it's clear at a glance which feed content was published with Ecency.

## Changes

- `postCardHeader` detects an explicit Ecency client (`ecency/x-vision`, `ecency-mobile`) from `json_metadata.app` and passes `isFromEcency` to the shared `PostHeaderDescription`.
- `PostHeaderDescription` now renders the existing Ecency logo badge next to the date in its non-inline (feed) layout as well, mirroring the inline (comment) layout that already showed it.

Only an explicit "ecency" app matches; a missing app does not show the badge. Reuses the existing `ecency-logo-round.png` asset and `ecencySourceBadge` style, so no new assets.

Pairs with the web change (ecency/vision-next#1051).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Posts published from Ecency now show the Ecency badge in more post header layouts, making the source easier to recognize.
  * Header details more consistently detect Ecency-origin posts based on available post metadata.
* **Bug Fixes**
  * Fixed cases where the Ecency badge could be missing in certain post header views despite the post being from Ecency.
* **Chores**
  * Bumped app/package version to **3.5.8** for Android and iOS.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->