### PR TITLE
fix(waves): recover when ecency.app posting authority is missing

### DIFF
--- a/src/components/quickPostModal/usePostSubmitter.ts
+++ b/src/components/quickPostModal/usePostSubmitter.ts
@@ -57,17 +57,19 @@ export const usePostSubmitter = () => {
   // A HiveSigner token broadcast failed with `unauthorized_client` because
   // ecency.app is not authorised to post for this account. Open the grant /
   // re-authorise sheet (grants directly with the local key for key logins, or
-  // routes through HiveSigner for token-only logins) and run `onGranted` once
-  // the authority exists, instead of surfacing the raw JSON error.
-  const _promptPostingAuthorityRecovery = (onGranted?: () => void) => {
-    SheetManager.show(SheetNames.POSTING_AUTHORITY_PROMPT, {
-      payload: {
-        onGranted: () => onGranted?.(),
-        onSkipped: () => {},
-        onError: () => {},
-      },
+  // routes through HiveSigner for token-only logins) instead of surfacing the
+  // raw JSON error. Resolves `true` once the authority is granted, `false` if
+  // the user skips, and rejects if the grant itself errors.
+  const _promptPostingAuthorityRecovery = (): Promise<boolean> =>
+    new Promise<boolean>((resolve, reject) => {
+      SheetManager.show(SheetNames.POSTING_AUTHORITY_PROMPT, {
+        payload: {
+          onGranted: () => resolve(true),
+          onSkipped: () => resolve(false),
+          onError: (error) => reject(error),
+        },
+      });
     });
-  };
 
   // handle submit reply
   const _submitReply = async (
@@ -95,8 +97,12 @@ export const usePostSubmitter = () => {
         return false;
       }
 
-      // Check if we should prompt for posting authority (HiveAuth users without authority)
-      if (shouldPromptPostingAuthority(currentAccount)) {
+      // Check if we should prompt for posting authority (token-broadcast /
+      // HiveAuth users without authority). Skipped on the authority-recovery
+      // retry: the grant already happened, and `currentAccount` in this hook
+      // render may still be the pre-grant snapshot, which would re-open the
+      // prompt or trip the recursion guard.
+      if (!isAuthorityRetry && shouldPromptPostingAuthority(currentAccount)) {
         // Guard against infinite recursion - use ref getter to read latest value
         if (getPostingAuthorityPromptShown()) {
           console.warn('Posting authority prompt already shown, preventing recursion');
@@ -322,22 +328,32 @@ export const usePostSubmitter = () => {
         console.log(error);
 
         // Missing ecency.app posting authority: offer the grant/re-authorise
-        // sheet and retry once, rather than dumping the raw unauthorized_client
-        // JSON at the user. Guarded by `isAuthorityRetry` so a still-missing
-        // authority after granting can't loop.
+        // sheet and, once granted, retry once and return the retry's result so
+        // the caller's success handling (e.g. `_submitWave`'s feed prepend)
+        // still runs — rather than dumping the raw unauthorized_client JSON.
+        // Guarded by `isAuthorityRetry` so a still-missing authority can't loop.
         if (isMissingEcencyPostingAuthorityError(error) && !isAuthorityRetry) {
-          _promptPostingAuthorityRecovery(() => {
-            _submitReply(
-              commentBody,
-              parentPost,
-              postType,
-              pollDraft,
-              manageSubmittingState,
-              videoThumbUrls,
-              true,
-            );
-          });
-          return false;
+          // A grant failure surfaces its own toast from the sheet, so treat a
+          // rejection as "not granted" here.
+          const granted = await _promptPostingAuthorityRecovery().catch(() => false);
+          if (!granted) {
+            return false;
+          }
+          // Release the submit lock before retrying: the retry re-arms it via
+          // its own `if (manageSubmittingState) setIsSubmitting(true)`, and
+          // leaving it armed would trip the retry's entry guard.
+          if (manageSubmittingState) {
+            setIsSubmitting(false);
+          }
+          return await _submitReply(
+            commentBody,
+            parentPost,
+            postType,
+            pollDraft,
+            manageSubmittingState,
+            videoThumbUrls,
+            true,
+          );
         }
 
         let errMsg = error?.message || '';
@@ -360,18 +376,22 @@ export const usePostSubmitter = () => {
       }
     } catch (error: any) {
       if (isMissingEcencyPostingAuthorityError(error) && !isAuthorityRetry) {
-        _promptPostingAuthorityRecovery(() => {
-          _submitReply(
-            commentBody,
-            parentPost,
-            postType,
-            pollDraft,
-            manageSubmittingState,
-            videoThumbUrls,
-            true,
-          );
-        });
-        return false;
+        const granted = await _promptPostingAuthorityRecovery().catch(() => false);
+        if (!granted) {
+          return false;
+        }
+        if (manageSubmittingState) {
+          setIsSubmitting(false);
+        }
+        return await _submitReply(
+          commentBody,
+          parentPost,
+          postType,
+          pollDraft,
+          manageSubmittingState,
+          videoThumbUrls,
+          true,
+        );
       }
       let errMsg = error?.message || '';
       if (!errMsg) {

--- a/src/components/quickPostModal/usePostSubmitter.ts
+++ b/src/components/quickPostModal/usePostSubmitter.ts
@@ -4,7 +4,11 @@ import { useIntl } from 'react-intl';
 import { useComment } from '@ecency/sdk';
 import { SheetManager } from 'react-native-actions-sheet';
 import { useAppSelector, useStateWithRef } from '../../hooks';
-import { shouldPromptPostingAuthority, getDigitPinCode } from '../../providers/hive/hive';
+import {
+  shouldPromptPostingAuthority,
+  getDigitPinCode,
+  isMissingEcencyPostingAuthorityError,
+} from '../../providers/hive/hive';
 import {
   extractMetadata,
   generateContentBasedPermlink,
@@ -50,6 +54,21 @@ export const usePostSubmitter = () => {
     getPostingAuthorityPromptShown,
   ] = useStateWithRef(false);
 
+  // A HiveSigner token broadcast failed with `unauthorized_client` because
+  // ecency.app is not authorised to post for this account. Open the grant /
+  // re-authorise sheet (grants directly with the local key for key logins, or
+  // routes through HiveSigner for token-only logins) and run `onGranted` once
+  // the authority exists, instead of surfacing the raw JSON error.
+  const _promptPostingAuthorityRecovery = (onGranted?: () => void) => {
+    SheetManager.show(SheetNames.POSTING_AUTHORITY_PROMPT, {
+      payload: {
+        onGranted: () => onGranted?.(),
+        onSkipped: () => {},
+        onError: () => {},
+      },
+    });
+  };
+
   // handle submit reply
   const _submitReply = async (
     commentBody: string,
@@ -58,6 +77,7 @@ export const usePostSubmitter = () => {
     pollDraft?: PollDraft,
     manageSubmittingState = true,
     videoThumbUrls?: string[],
+    isAuthorityRetry = false,
   ) => {
     if (!commentBody) {
       return false;
@@ -126,6 +146,7 @@ export const usePostSubmitter = () => {
             pollDraft,
             manageSubmittingState,
             videoThumbUrls,
+            isAuthorityRetry,
           );
         } catch (error) {
           // Error granting posting authority - surface through outer handler.
@@ -300,6 +321,25 @@ export const usePostSubmitter = () => {
 
         console.log(error);
 
+        // Missing ecency.app posting authority: offer the grant/re-authorise
+        // sheet and retry once, rather than dumping the raw unauthorized_client
+        // JSON at the user. Guarded by `isAuthorityRetry` so a still-missing
+        // authority after granting can't loop.
+        if (isMissingEcencyPostingAuthorityError(error) && !isAuthorityRetry) {
+          _promptPostingAuthorityRecovery(() => {
+            _submitReply(
+              commentBody,
+              parentPost,
+              postType,
+              pollDraft,
+              manageSubmittingState,
+              videoThumbUrls,
+              true,
+            );
+          });
+          return false;
+        }
+
         let errMsg = error?.message || '';
         if (!errMsg) {
           try {
@@ -319,6 +359,20 @@ export const usePostSubmitter = () => {
         return false;
       }
     } catch (error: any) {
+      if (isMissingEcencyPostingAuthorityError(error) && !isAuthorityRetry) {
+        _promptPostingAuthorityRecovery(() => {
+          _submitReply(
+            commentBody,
+            parentPost,
+            postType,
+            pollDraft,
+            manageSubmittingState,
+            videoThumbUrls,
+            true,
+          );
+        });
+        return false;
+      }
       let errMsg = error?.message || '';
       if (!errMsg) {
         try {

--- a/src/components/quickPostModal/usePostSubmitter.ts
+++ b/src/components/quickPostModal/usePostSubmitter.ts
@@ -333,17 +333,24 @@ export const usePostSubmitter = () => {
         // still runs — rather than dumping the raw unauthorized_client JSON.
         // Guarded by `isAuthorityRetry` so a still-missing authority can't loop.
         if (isMissingEcencyPostingAuthorityError(error) && !isAuthorityRetry) {
+          // Release the submit lock BEFORE awaiting the sheet. If the user
+          // dismisses it without firing onGranted/onSkipped/onError (swipe,
+          // app backgrounded, system kill), the promise never settles, this
+          // await hangs and the outer `finally` never runs — so without this
+          // `isSubmitting` would stay true and permanently wedge publish.
+          // Mirrors the pre-flight guard above.
+          setIsSubmitting(false);
           // A grant failure surfaces its own toast from the sheet, so treat a
           // rejection as "not granted" here.
           const granted = await _promptPostingAuthorityRecovery().catch(() => false);
           if (!granted) {
             return false;
           }
-          // Release the submit lock before retrying: the retry re-arms it via
-          // its own `if (manageSubmittingState) setIsSubmitting(true)`, and
-          // leaving it armed would trip the retry's entry guard.
-          if (manageSubmittingState) {
-            setIsSubmitting(false);
+          // Re-arm only for the wave path: the quick-post retry re-arms via its
+          // own `if (manageSubmittingState) setIsSubmitting(true)`, and re-arming
+          // here would trip that retry's entry guard.
+          if (!manageSubmittingState) {
+            setIsSubmitting(true);
           }
           return await _submitReply(
             commentBody,
@@ -376,12 +383,15 @@ export const usePostSubmitter = () => {
       }
     } catch (error: any) {
       if (isMissingEcencyPostingAuthorityError(error) && !isAuthorityRetry) {
+        // Release before the await so a dismissed sheet can't wedge
+        // `isSubmitting` (see inner catch for the full rationale).
+        setIsSubmitting(false);
         const granted = await _promptPostingAuthorityRecovery().catch(() => false);
         if (!granted) {
           return false;
         }
-        if (manageSubmittingState) {
-          setIsSubmitting(false);
+        if (!manageSubmittingState) {
+          setIsSubmitting(true);
         }
         return await _submitReply(
           commentBody,

--- a/src/providers/hive/hive.ts
+++ b/src/providers/hive/hive.ts
@@ -582,7 +582,7 @@ export const votingPower = (account) => {
   return percentage / 100;
 };
 
-const hasEcencyPostingAuthority = (account: any): boolean => {
+export const hasEcencyPostingAuthority = (account: any): boolean => {
   const postingAccountAuths = account?.posting?.account_auths;
   if (!Array.isArray(postingAccountAuths)) {
     return false;
@@ -590,8 +590,79 @@ const hasEcencyPostingAuthority = (account: any): boolean => {
   return postingAccountAuths.some((auth: any) => auth[0] === 'ecency.app');
 };
 
+/**
+ * True when this account's posting operations are broadcast through the
+ * HiveSigner token API (`ecency.app` signs on the user's behalf) rather than
+ * signed locally. Those broadcasts REQUIRE `ecency.app` to be present in the
+ * account's posting `account_auths`, otherwise HiveSigner rejects them with
+ * `unauthorized_client` ("The app @ecency.app doesn't have permission to
+ * broadcast for @user").
+ *
+ * This mirrors the routing in `mobilePlatformAdapter.getLoginType`:
+ * - HiveSigner (steemConnect) logins always use the token path for posting.
+ * - Key logins that lack a stored posting key but hold an access token
+ *   (active-key-only logins) also fall back to the token path.
+ *
+ * Key logins WITH a posting key sign directly and never need the authority.
+ */
+export const usesHivesignerTokenBroadcast = (account: any): boolean => {
+  const local = account?.local;
+  if (!local?.authType) {
+    return false;
+  }
+  if (local.authType === AUTH_TYPE.STEEM_CONNECT) {
+    return true;
+  }
+  const isKeyLogin =
+    local.authType === AUTH_TYPE.MASTER_KEY ||
+    local.authType === AUTH_TYPE.ACTIVE_KEY ||
+    local.authType === AUTH_TYPE.MEMO_KEY ||
+    local.authType === AUTH_TYPE.POSTING_KEY ||
+    local.authType === AUTH_TYPE.OWNER_KEY;
+  return isKeyLogin && !local.postingKey && !!local.accessToken;
+};
+
+/**
+ * Recognises the HiveSigner rejection that means `ecency.app` is not (or no
+ * longer) authorised to post for the account. Matches both the structured
+ * error and the stringified/wrapped forms the SDK may surface.
+ *
+ * Example payload:
+ *   {"error":"unauthorized_client","error_description":
+ *    "The app @ecency.app doesn't have permission to broadcast for @user"}
+ */
+export const isMissingEcencyPostingAuthorityError = (error: any): boolean => {
+  if (!error) {
+    return false;
+  }
+  const code = String(error.error || '');
+  if (code === 'unauthorized_client') {
+    return true;
+  }
+  const haystack = `${error.error_description || ''} ${error.message || ''} ${
+    typeof error === 'string' ? error : ''
+  }`.toLowerCase();
+  return (
+    haystack.includes("doesn't have permission to broadcast") ||
+    haystack.includes('does not have permission to broadcast') ||
+    (haystack.includes('unauthorized_client') && haystack.includes('broadcast'))
+  );
+};
+
+/**
+ * Whether to prompt the user to grant `ecency.app` posting authority before
+ * (or after a failed) broadcast.
+ *
+ * - HiveAuth users: an optimisation — granting lets posts use the fast token
+ *   path instead of a Keychain round-trip on every action.
+ * - Token-broadcast users (HiveSigner, active-key-only): a REQUIREMENT — their
+ *   posts fail with `unauthorized_client` until the authority exists.
+ *
+ * In both cases we skip the prompt once the authority is present.
+ */
 export const shouldPromptPostingAuthority = (account: any): boolean => {
-  if (account?.local?.authType !== AUTH_TYPE.HIVE_AUTH) {
+  const isHiveAuth = account?.local?.authType === AUTH_TYPE.HIVE_AUTH;
+  if (!isHiveAuth && !usesHivesignerTokenBroadcast(account)) {
     return false;
   }
 

--- a/src/providers/hive/hive.ts
+++ b/src/providers/hive/hive.ts
@@ -635,18 +635,16 @@ export const isMissingEcencyPostingAuthorityError = (error: any): boolean => {
   if (!error) {
     return false;
   }
-  const code = String(error.error || '');
-  if (code === 'unauthorized_client') {
-    return true;
-  }
   const haystack = `${error.error_description || ''} ${error.message || ''} ${
     typeof error === 'string' ? error : ''
   }`.toLowerCase();
-  return (
-    haystack.includes("doesn't have permission to broadcast") ||
-    haystack.includes('does not have permission to broadcast') ||
-    (haystack.includes('unauthorized_client') && haystack.includes('broadcast'))
-  );
+  // Require the specific missing-authority context, not the bare
+  // `unauthorized_client` code — HiveSigner (or another OAuth service) returns
+  // that same code for unrelated reasons (expired token, wrong scope, revoked
+  // grant), which should surface a real error rather than the grant sheet. The
+  // "@ecency.app doesn't have permission to broadcast for @user" rejection
+  // always carries one of these signals.
+  return haystack.includes('permission to broadcast') || haystack.includes('ecency.app');
 };
 
 /**

--- a/src/providers/hive/hive.ts
+++ b/src/providers/hive/hive.ts
@@ -635,16 +635,22 @@ export const isMissingEcencyPostingAuthorityError = (error: any): boolean => {
   if (!error) {
     return false;
   }
+  const code = String(error.error || '');
   const haystack = `${error.error_description || ''} ${error.message || ''} ${
     typeof error === 'string' ? error : ''
   }`.toLowerCase();
-  // Require the specific missing-authority context, not the bare
-  // `unauthorized_client` code — HiveSigner (or another OAuth service) returns
-  // that same code for unrelated reasons (expired token, wrong scope, revoked
-  // grant), which should surface a real error rather than the grant sheet. The
-  // "@ecency.app doesn't have permission to broadcast for @user" rejection
-  // always carries one of these signals.
-  return haystack.includes('permission to broadcast') || haystack.includes('ecency.app');
+  // The "@ecency.app doesn't have permission to broadcast for @user" phrase is
+  // unique to this rejection, so match it directly. Fall back to the
+  // `unauthorized_client` code plus an ecency.app mention for wrapped/truncated
+  // forms — but gate the domain match behind the code so unrelated errors that
+  // merely reference ecency.app (network timeout, server error) aren't routed
+  // into the grant sheet instead of surfacing the real error. The bare
+  // `unauthorized_client` code is deliberately NOT enough: HiveSigner returns
+  // it for expired tokens and wrong scope too.
+  return (
+    haystack.includes('permission to broadcast') ||
+    (code === 'unauthorized_client' && haystack.includes('ecency.app'))
+  );
 };
 
 /**

--- a/src/providers/hive/postingAuthority.test.ts
+++ b/src/providers/hive/postingAuthority.test.ts
@@ -79,6 +79,22 @@ describe('posting authority helpers', () => {
         }),
       ).toBe(false);
     });
+    it('does not match unrelated errors that merely mention the ecency.app domain', () => {
+      expect(
+        isMissingEcencyPostingAuthorityError({ message: 'Network timeout contacting ecency.app' }),
+      ).toBe(false);
+      expect(
+        isMissingEcencyPostingAuthorityError({ error: 'server_error', message: 'ecency.app 500' }),
+      ).toBe(false);
+    });
+    it('matches unauthorized_client + ecency.app even without the exact phrase', () => {
+      expect(
+        isMissingEcencyPostingAuthorityError({
+          error: 'unauthorized_client',
+          error_description: 'ecency.app not authorized',
+        }),
+      ).toBe(true);
+    });
   });
 
   describe('shouldPromptPostingAuthority', () => {

--- a/src/providers/hive/postingAuthority.test.ts
+++ b/src/providers/hive/postingAuthority.test.ts
@@ -70,6 +70,15 @@ describe('posting authority helpers', () => {
       expect(isMissingEcencyPostingAuthorityError(new Error('Insufficient RC'))).toBe(false);
       expect(isMissingEcencyPostingAuthorityError(null)).toBe(false);
     });
+    it('does not match a bare unauthorized_client without the broadcast context', () => {
+      expect(isMissingEcencyPostingAuthorityError({ error: 'unauthorized_client' })).toBe(false);
+      expect(
+        isMissingEcencyPostingAuthorityError({
+          error: 'unauthorized_client',
+          error_description: 'The token has expired',
+        }),
+      ).toBe(false);
+    });
   });
 
   describe('shouldPromptPostingAuthority', () => {

--- a/src/providers/hive/postingAuthority.test.ts
+++ b/src/providers/hive/postingAuthority.test.ts
@@ -1,0 +1,109 @@
+import {
+  hasEcencyPostingAuthority,
+  usesHivesignerTokenBroadcast,
+  isMissingEcencyPostingAuthorityError,
+  shouldPromptPostingAuthority,
+} from './hive';
+import AUTH_TYPE from '../../constants/authType';
+
+const withAuths = (auths: any[]) => ({ posting: { account_auths: auths, weight_threshold: 1 } });
+
+describe('posting authority helpers', () => {
+  describe('hasEcencyPostingAuthority', () => {
+    it('is true when ecency.app is present', () => {
+      expect(hasEcencyPostingAuthority(withAuths([['ecency.app', 1]]))).toBe(true);
+    });
+    it('is false when absent or malformed', () => {
+      expect(hasEcencyPostingAuthority(withAuths([['peakd.app', 1]]))).toBe(false);
+      expect(hasEcencyPostingAuthority(withAuths([]))).toBe(false);
+      expect(hasEcencyPostingAuthority({})).toBe(false);
+      expect(hasEcencyPostingAuthority(null)).toBe(false);
+    });
+  });
+
+  describe('usesHivesignerTokenBroadcast', () => {
+    it('is true for HiveSigner (steemConnect) logins', () => {
+      expect(usesHivesignerTokenBroadcast({ local: { authType: AUTH_TYPE.STEEM_CONNECT } })).toBe(
+        true,
+      );
+    });
+    it('is true for active-key-only logins that fall back to the token', () => {
+      expect(
+        usesHivesignerTokenBroadcast({
+          local: { authType: AUTH_TYPE.ACTIVE_KEY, activeKey: 'enc', accessToken: 'tok' },
+        }),
+      ).toBe(true);
+    });
+    it('is false for key logins that hold a posting key (sign directly)', () => {
+      expect(
+        usesHivesignerTokenBroadcast({
+          local: { authType: AUTH_TYPE.MASTER_KEY, postingKey: 'enc', accessToken: 'tok' },
+        }),
+      ).toBe(false);
+    });
+    it('is false for HiveAuth and unknown logins', () => {
+      expect(usesHivesignerTokenBroadcast({ local: { authType: AUTH_TYPE.HIVE_AUTH } })).toBe(
+        false,
+      );
+      expect(usesHivesignerTokenBroadcast({})).toBe(false);
+    });
+  });
+
+  describe('isMissingEcencyPostingAuthorityError', () => {
+    it('matches the HiveSigner unauthorized_client rejection', () => {
+      expect(
+        isMissingEcencyPostingAuthorityError({
+          error: 'unauthorized_client',
+          error_description: "The app @ecency.app doesn't have permission to broadcast for @user",
+        }),
+      ).toBe(true);
+    });
+    it('matches when only a stringified/wrapped message is available', () => {
+      expect(
+        isMissingEcencyPostingAuthorityError({
+          message: "The app @ecency.app doesn't have permission to broadcast for @user",
+        }),
+      ).toBe(true);
+    });
+    it('does not match unrelated errors', () => {
+      expect(isMissingEcencyPostingAuthorityError({ error: 'invalid_grant' })).toBe(false);
+      expect(isMissingEcencyPostingAuthorityError(new Error('Insufficient RC'))).toBe(false);
+      expect(isMissingEcencyPostingAuthorityError(null)).toBe(false);
+    });
+  });
+
+  describe('shouldPromptPostingAuthority', () => {
+    it('prompts token-broadcast users lacking the authority', () => {
+      expect(
+        shouldPromptPostingAuthority({
+          local: { authType: AUTH_TYPE.STEEM_CONNECT },
+          ...withAuths([]),
+        }),
+      ).toBe(true);
+    });
+    it('prompts HiveAuth users lacking the authority', () => {
+      expect(
+        shouldPromptPostingAuthority({
+          local: { authType: AUTH_TYPE.HIVE_AUTH },
+          ...withAuths([]),
+        }),
+      ).toBe(true);
+    });
+    it('does not prompt once the authority exists', () => {
+      expect(
+        shouldPromptPostingAuthority({
+          local: { authType: AUTH_TYPE.STEEM_CONNECT },
+          ...withAuths([['ecency.app', 1]]),
+        }),
+      ).toBe(false);
+    });
+    it('does not prompt direct-signing key users', () => {
+      expect(
+        shouldPromptPostingAuthority({
+          local: { authType: AUTH_TYPE.POSTING_KEY, postingKey: 'enc' },
+          ...withAuths([]),
+        }),
+      ).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
Posting through the HiveSigner token path requires `ecency.app` to be present in the account's posting authorities. When it is absent, HiveSigner rejects the broadcast with `unauthorized_client` ("The app @ecency.app doesn't have permission to broadcast for @user") and the raw JSON was shown to the user with no way to recover.

## Changes
- Broaden `shouldPromptPostingAuthority` to cover token-broadcast logins (HiveSigner and active-key-only), not just HiveAuth, so the grant prompt fires pre-flight for any user whose posts would otherwise fail. Key logins grant directly with the local key; token-only logins are routed through HiveSigner by the platform adapter.
- Detect the `unauthorized_client` rejection in the quick-post/wave submitter and open the grant / re-authorise sheet with a single guarded retry, instead of surfacing the raw error.
- Add unit tests for the posting-authority helpers.

## Testing
- `yarn test:ci` — full suite passes (adds 13 tests for the posting-authority helpers).
- Lint + typecheck clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing posting authority by retrying the submission once after the user grants or skips permission in the posting-authority prompt.
  * Updated prompt eligibility so the permission prompt is skipped when access already exists, and restricted to the applicable signing/broadcasting scenarios.
* **Tests**
  * Added Jest coverage for posting-authority detection, prompt eligibility rules, and correct interpretation of broadcast-permission rejection errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->