### PR TITLE
Surface Translate CTA when reader and post languages differ

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "expo-local-authentication": "~16.0.5",
     "expo-speech": "^13.1.7",
     "expo-store-review": "~8.1.5",
+    "franc-min": "5.0.0",
     "he": "^1.2.0",
     "hive-auth-wrapper": "git+https://github.com/noumantahir/hive-auth-wrapper.git",
     "hive-uri": "^0.2.8",

--- a/src/components/post-translation-modal/postTranslationModal.tsx
+++ b/src/components/post-translation-modal/postTranslationModal.tsx
@@ -23,6 +23,8 @@ const targetLang = { name: 'English', code: 'en' };
 const PostTranslationModal = ({ payload }: SheetProps<'post_translation'>) => {
   const intl = useIntl();
   const content = payload?.content;
+  const initialTargetCode = payload?.initialTargetCode;
+  const initialSource = payload?.initialSource;
 
   const appLang = useAppSelector(selectLanguage);
 
@@ -44,6 +46,26 @@ const PostTranslationModal = ({ payload }: SheetProps<'post_translation'>) => {
   useEffect(() => {
     getSupportedLanguages();
   }, []);
+
+  // Sheets stay mounted; when (re)opened with a pre-selected target/source
+  // (from the inline banner or a chip) apply it once the language list is ready.
+  useEffect(() => {
+    if (!supportedLangsList.length) {
+      return;
+    }
+    if (initialTargetCode) {
+      const match = supportedLangsList.find((l) => l?.code === initialTargetCode);
+      if (match) {
+        setSelectedTargetLang(match);
+      }
+    }
+    if (initialSource) {
+      const match = supportedLangsList.find((l) => l?.code === initialSource);
+      if (match) {
+        setSelectedSourceLang(match);
+      }
+    }
+  }, [initialTargetCode, initialSource, supportedLangsList]);
 
   useEffect(() => {
     if (content && content.body) {

--- a/src/components/post-translation-modal/postTranslationModal.tsx
+++ b/src/components/post-translation-modal/postTranslationModal.tsx
@@ -47,8 +47,11 @@ const PostTranslationModal = ({ payload }: SheetProps<'post_translation'>) => {
     getSupportedLanguages();
   }, []);
 
-  // Sheets stay mounted; when (re)opened with a pre-selected target/source
-  // (from the inline banner or a chip) apply it once the language list is ready.
+  // Sheets stay mounted and _handleOnSheetClose resets the target on close, so
+  // re-apply the pre-selected target/source on EVERY open. Keying on `payload`
+  // (a fresh object per SheetManager.show) is what makes this re-fire when the
+  // sheet is reopened from the same chip/banner with unchanged initial codes —
+  // without it the pre-targeting would only work once per session.
   useEffect(() => {
     if (!supportedLangsList.length) {
       return;
@@ -65,7 +68,7 @@ const PostTranslationModal = ({ payload }: SheetProps<'post_translation'>) => {
         setSelectedSourceLang(match);
       }
     }
-  }, [initialTargetCode, initialSource, supportedLangsList]);
+  }, [payload, initialTargetCode, initialSource, supportedLangsList]);
 
   useEffect(() => {
     if (content && content.body) {

--- a/src/components/postCard/children/postCardActionsPanel.tsx
+++ b/src/components/postCard/children/postCardActionsPanel.tsx
@@ -9,6 +9,7 @@ import { TextWithIcon } from '../../basicUIElements';
 // Styles
 import styles from '../styles/postCard.styles';
 import { UpvoteButton } from './upvoteButton';
+import { TranslateChip } from './translateChip';
 import { PostTypes } from '../../../constants/postTypes';
 import { PostCardActionIds } from '../container/postCard';
 import ROUTES from '../../../constants/routeNames';
@@ -92,6 +93,7 @@ const PostCardActionsPanelComponent = ({ content, handleCardInteraction }: Props
         </TouchableOpacity>
       </View>
       <View style={styles.rightFooterWrapper}>
+        <TranslateChip content={content} />
         <TextWithIcon
           iconName="repeat"
           iconStyle={styles.commentIcon}

--- a/src/components/postCard/children/translateChip.tsx
+++ b/src/components/postCard/children/translateChip.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { useIntl } from 'react-intl';
+import { SheetManager } from 'react-native-actions-sheet';
+
+import { TextWithIcon } from '../../basicUIElements';
+import { useContentLanguageGate } from '../../../hooks/useContentLanguageGate';
+import { languageDisplayName } from '../../../utils/iso639';
+import { SheetNames } from '../../../navigation/sheets';
+import styles from '../styles/postCard.styles';
+
+interface Props {
+  content: any;
+}
+
+/**
+ * Compact Translate chip for feed cards, shown only when the detected content
+ * language differs from the reader's. Feed-safe: detection is franc-only (no
+ * server call), idle-scheduled and memoized per permlink by the gate hook.
+ * Tapping opens the existing translate sheet pre-targeted to the reader's
+ * language (source stays "auto" so the backend picks the real source).
+ */
+const TranslateChipComponent = ({ content }: Props) => {
+  const intl = useIntl();
+  const decision = useContentLanguageGate(content, { serverConfirm: false });
+
+  if (!decision?.show) {
+    return null;
+  }
+
+  const _onPress = () => {
+    SheetManager.show(SheetNames.POST_TRANSLATION, {
+      payload: { content, initialTargetCode: decision.target },
+    });
+  };
+
+  return (
+    <TextWithIcon
+      iconName="translate"
+      iconStyle={styles.commentIcon}
+      iconType="MaterialIcons"
+      isClickable
+      onPress={_onPress}
+      accessibilityLabel={intl.formatMessage(
+        { id: 'post_translate.translate_to' },
+        { lang: languageDisplayName(decision.target) },
+      )}
+    />
+  );
+};
+
+export const TranslateChip = React.memo(
+  TranslateChipComponent,
+  (prev, next) => prev.content === next.content,
+);

--- a/src/components/postView/children/postTranslateInline.tsx
+++ b/src/components/postView/children/postTranslateInline.tsx
@@ -1,0 +1,223 @@
+import React, { memo, useCallback, useEffect, useRef, useState } from 'react';
+import { View, Text, TouchableOpacity, ActivityIndicator, Platform } from 'react-native';
+import { useIntl } from 'react-intl';
+import EStyleSheet from 'react-native-extended-stylesheet';
+import { SheetManager } from 'react-native-actions-sheet';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { postBodySummary } from '@ecency/render-helper';
+import { Icon } from '../../icon';
+import { useContentLanguageGate } from '../../../hooks/useContentLanguageGate';
+import { isRtlLang, languageDisplayName, normLang } from '../../../utils/iso639';
+import { translateLongText } from '../../../providers/translation/translation';
+import { SheetNames } from '../../../navigation/sheets';
+
+const DISMISS_PREFIX = '@translate-dismissed:';
+
+interface Props {
+  post: any;
+  // Lifts the translated plain-text body to the parent (which renders it in
+  // place of <PostBody>). Called with null to restore the original.
+  onTranslate: (text: string | null, rtl?: boolean) => void;
+}
+
+const PostTranslateInlineComponent = ({ post, onTranslate }: Props) => {
+  const intl = useIntl();
+  const dismissKey = `${DISMISS_PREFIX}${post?.author}/${post?.permlink}`;
+
+  const [dismissed, setDismissed] = useState(false);
+  const [status, setStatus] = useState<'idle' | 'loading' | 'done'>('idle');
+  const [fromLang, setFromLang] = useState('');
+  const requestRef = useRef<{ canceled: boolean } | null>(null);
+
+  const decision = useContentLanguageGate(post, { serverConfirm: true });
+
+  useEffect(() => {
+    let active = true;
+    AsyncStorage.getItem(dismissKey).then((v) => {
+      if (active) {
+        setDismissed(!!v);
+      }
+    });
+    return () => {
+      active = false;
+    };
+  }, [dismissKey]);
+
+  // Abort any in-flight translation on unmount.
+  useEffect(
+    () => () => {
+      if (requestRef.current) {
+        requestRef.current.canceled = true;
+      }
+    },
+    [],
+  );
+
+  const handleTranslate = useCallback(async () => {
+    if (!decision) {
+      return;
+    }
+    setStatus('loading');
+    const token = { canceled: false };
+    requestRef.current = token;
+    try {
+      const text = postBodySummary(post.body, 0, Platform.OS as any);
+      const res = await translateLongText(text, 'auto', decision.target);
+      if (token.canceled) {
+        return;
+      }
+      const detected = res.detectedLanguage?.language
+        ? normLang(res.detectedLanguage.language)
+        : decision.source;
+      // Wrong instant guess — the body is actually the reader's language.
+      if (detected && detected === decision.target) {
+        AsyncStorage.setItem(dismissKey, '1');
+        setDismissed(true);
+        return;
+      }
+      setFromLang(detected || decision.source);
+      onTranslate(res.translatedText, isRtlLang(decision.target));
+      setStatus('done');
+    } catch {
+      if (!token.canceled) {
+        setStatus('idle');
+      }
+    }
+  }, [decision, post, dismissKey, onTranslate]);
+
+  const handleShowOriginal = useCallback(() => {
+    if (requestRef.current) {
+      requestRef.current.canceled = true;
+    }
+    onTranslate(null);
+    setStatus('idle');
+  }, [onTranslate]);
+
+  const handleDismiss = useCallback(() => {
+    if (requestRef.current) {
+      requestRef.current.canceled = true;
+    }
+    AsyncStorage.setItem(dismissKey, '1');
+    setDismissed(true);
+    onTranslate(null);
+  }, [dismissKey, onTranslate]);
+
+  const handleChangeLanguage = useCallback(() => {
+    if (!decision) {
+      return;
+    }
+    SheetManager.show(SheetNames.POST_TRANSLATION, {
+      payload: { content: post, initialTargetCode: decision.target },
+    });
+  }, [decision, post]);
+
+  if (dismissed || !decision?.show) {
+    return null;
+  }
+
+  const targetName = languageDisplayName(decision.target);
+  const sourceName = languageDisplayName(decision.source);
+
+  return (
+    <View style={styles.container}>
+      <Icon
+        iconType="MaterialIcons"
+        name="translate"
+        size={18}
+        color={EStyleSheet.value('$primaryBlue')}
+        style={styles.icon}
+      />
+      <Text style={styles.label} numberOfLines={2}>
+        {status === 'done'
+          ? intl.formatMessage(
+              { id: 'post_translate.translated_from' },
+              { lang: languageDisplayName(fromLang || decision.source) },
+            )
+          : intl.formatMessage(
+              { id: 'post_translate.banner_detected' },
+              { lang: sourceName, target: targetName },
+            )}
+      </Text>
+
+      {status === 'idle' && (
+        <TouchableOpacity onPress={handleTranslate} hitSlop={hitSlop}>
+          <Text style={styles.action}>
+            {intl.formatMessage({ id: 'post_translate.translate_to' }, { lang: targetName })}
+          </Text>
+        </TouchableOpacity>
+      )}
+      {status === 'loading' && <ActivityIndicator size="small" style={styles.spinner} />}
+      {status === 'done' && (
+        <TouchableOpacity onPress={handleShowOriginal} hitSlop={hitSlop}>
+          <Text style={styles.action}>
+            {intl.formatMessage({ id: 'post_translate.show_original' })}
+          </Text>
+        </TouchableOpacity>
+      )}
+
+      <TouchableOpacity onPress={handleChangeLanguage} hitSlop={hitSlop}>
+        <Text style={styles.action}>
+          {intl.formatMessage({ id: 'post_translate.change_language' })}
+        </Text>
+      </TouchableOpacity>
+
+      {status !== 'loading' && (
+        <TouchableOpacity onPress={handleDismiss} hitSlop={hitSlop} style={styles.dismiss}>
+          <Icon
+            iconType="MaterialIcons"
+            name="close"
+            size={16}
+            color={EStyleSheet.value('$iconColor')}
+          />
+        </TouchableOpacity>
+      )}
+    </View>
+  );
+};
+
+const hitSlop = { top: 8, bottom: 8, left: 8, right: 8 };
+
+const styles = EStyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    flexWrap: 'wrap',
+    marginHorizontal: 16,
+    marginVertical: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: '$primaryLightBackground',
+    backgroundColor: '$primaryLightBackground',
+  },
+  icon: {
+    marginRight: 8,
+  },
+  label: {
+    flex: 1,
+    minWidth: 120,
+    fontSize: 13,
+    color: '$primaryBlack',
+  },
+  action: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: '$primaryBlue',
+    marginLeft: 12,
+  },
+  spinner: {
+    marginLeft: 12,
+  },
+  dismiss: {
+    marginLeft: 8,
+  },
+});
+
+export const PostTranslateInline = memo(
+  PostTranslateInlineComponent,
+  (prev, next) =>
+    prev.post?.author === next.post?.author &&
+    prev.post?.permlink === next.post?.permlink &&
+    prev.onTranslate === next.onTranslate,
+);

--- a/src/components/postView/children/postTranslateInline.tsx
+++ b/src/components/postView/children/postTranslateInline.tsx
@@ -3,8 +3,8 @@ import { View, Text, TouchableOpacity, ActivityIndicator, Platform } from 'react
 import { useIntl } from 'react-intl';
 import EStyleSheet from 'react-native-extended-stylesheet';
 import { SheetManager } from 'react-native-actions-sheet';
-import AsyncStorage from '@react-native-async-storage/async-storage';
 import { postBodySummary } from '@ecency/render-helper';
+import { getItemFromStorage, setItemToStorage } from '../../../realm/realm';
 import { Icon } from '../../icon';
 import { useContentLanguageGate } from '../../../hooks/useContentLanguageGate';
 import { isRtlLang, languageDisplayName, normLang } from '../../../utils/iso639';
@@ -43,7 +43,7 @@ const PostTranslateInlineComponent = ({ post, onTranslate }: Props) => {
       requestRef.current.canceled = true;
     }
     let active = true;
-    AsyncStorage.getItem(dismissKey).then((v) => {
+    getItemFromStorage(dismissKey).then((v) => {
       if (active) {
         setDismissed(!!v);
       }
@@ -81,7 +81,7 @@ const PostTranslateInlineComponent = ({ post, onTranslate }: Props) => {
         : decision.source;
       // Wrong instant guess — the body is actually the reader's language.
       if (detected && detected === decision.target) {
-        AsyncStorage.setItem(dismissKey, '1');
+        setItemToStorage(dismissKey, true);
         setDismissed(true);
         return;
       }
@@ -107,7 +107,7 @@ const PostTranslateInlineComponent = ({ post, onTranslate }: Props) => {
     if (requestRef.current) {
       requestRef.current.canceled = true;
     }
-    AsyncStorage.setItem(dismissKey, '1');
+    setItemToStorage(dismissKey, true);
     setDismissed(true);
     onTranslate(null);
   }, [dismissKey, onTranslate]);

--- a/src/components/postView/children/postTranslateInline.tsx
+++ b/src/components/postView/children/postTranslateInline.tsx
@@ -32,6 +32,16 @@ const PostTranslateInlineComponent = ({ post, onTranslate }: Props) => {
   const decision = useContentLanguageGate(post, { serverConfirm: true });
 
   useEffect(() => {
+    // Reset per-post. postDisplayView reuses this component instance across posts
+    // (it resets its own translatedBody on permlink change), so without this a new
+    // post would inherit the previous post's "done"/fromLang and show a bogus
+    // "Translated from X" with no Translate prompt.
+    setStatus('idle');
+    setFromLang('');
+    setDismissed(false);
+    if (requestRef.current) {
+      requestRef.current.canceled = true;
+    }
     let active = true;
     AsyncStorage.getItem(dismissKey).then((v) => {
       if (active) {

--- a/src/components/postView/view/postDisplayStyles.ts
+++ b/src/components/postView/view/postDisplayStyles.ts
@@ -107,4 +107,15 @@ export default EStyleSheet.create({
     height: 200,
     width: 300,
   },
+  translatedBody: {
+    paddingHorizontal: 16,
+    marginTop: 8,
+    fontSize: 16,
+    lineHeight: 24,
+    color: '$primaryBlack',
+  },
+  translatedBodyRtl: {
+    writingDirection: 'rtl',
+    textAlign: 'right',
+  },
 });

--- a/src/components/postView/view/postDisplayView.tsx
+++ b/src/components/postView/view/postDisplayView.tsx
@@ -85,6 +85,12 @@ const PostDisplayView = ({
     setTranslatedBody(null);
   }, [permlink]);
 
+  // Stable reference so PostTranslateInline's memo isn't defeated every render.
+  const _handleTranslatedBody = useCallback(
+    (text: string | null, rtl?: boolean) => setTranslatedBody(text ? { text, rtl: !!rtl } : null),
+    [],
+  );
+
   // Component Life Cycles
   useEffect(() => {
     if (isLoggedIn && get(currentAccount, 'name') && !isNewPost) {
@@ -468,12 +474,7 @@ const PostDisplayView = ({
                 </View>
               </View>
               {post && <PostReadingMetadata post={post} />}
-              {post && (
-                <PostTranslateInline
-                  post={post}
-                  onTranslate={(text, rtl) => setTranslatedBody(text ? { text, rtl: !!rtl } : null)}
-                />
-              )}
+              <PostTranslateInline post={post} onTranslate={_handleTranslatedBody} />
               {translatedBody ? (
                 <Text
                   selectable
@@ -535,6 +536,7 @@ const PostDisplayView = ({
       formatedTime,
       tags,
       translatedBody,
+      _handleTranslatedBody,
       postBodyLoading,
       postStatsQuery.data?.visits,
       postStatsQuery.isLoading,

--- a/src/components/postView/view/postDisplayView.tsx
+++ b/src/components/postView/view/postDisplayView.tsx
@@ -17,6 +17,7 @@ import { PostHeaderDescription, PostBody, Tags } from '../../postElements';
 import { PostPlaceHolder, StickyBar, TextWithIcon, NoPost } from '../../basicUIElements';
 import { ParentPost } from '../../parentPost';
 import { PostReadingMetadata } from '../children/postReadingMetadata';
+import { PostTranslateInline } from '../children/postTranslateInline';
 
 // Styles
 import styles from './postDisplayStyles';
@@ -77,6 +78,12 @@ const PostDisplayView = ({
   const [refreshing, setRefreshing] = useState(false);
   const [postBodyLoading, setPostBodyLoading] = useState(true);
   const [tags, setTags] = useState([]);
+  // Full plain-text translation shown in place of the body; reset per post.
+  const [translatedBody, setTranslatedBody] = useState<{ text: string; rtl: boolean } | null>(null);
+
+  useEffect(() => {
+    setTranslatedBody(null);
+  }, [permlink]);
 
   // Component Life Cycles
   useEffect(() => {
@@ -461,14 +468,29 @@ const PostDisplayView = ({
                 </View>
               </View>
               {post && <PostReadingMetadata post={post} />}
-              <PostBody
-                body={post.body}
-                metadata={post.json_metadata}
-                author={post.author}
-                permlink={post.permlink}
-                enableViewabilityTracker={true}
-                onLoadEnd={_handleOnPostBodyLoad}
-              />
+              {post && (
+                <PostTranslateInline
+                  post={post}
+                  onTranslate={(text, rtl) => setTranslatedBody(text ? { text, rtl: !!rtl } : null)}
+                />
+              )}
+              {translatedBody ? (
+                <Text
+                  selectable
+                  style={[styles.translatedBody, translatedBody.rtl && styles.translatedBodyRtl]}
+                >
+                  {translatedBody.text}
+                </Text>
+              ) : (
+                <PostBody
+                  body={post.body}
+                  metadata={post.json_metadata}
+                  author={post.author}
+                  permlink={post.permlink}
+                  enableViewabilityTracker={true}
+                  onLoadEnd={_handleOnPostBodyLoad}
+                />
+              )}
 
               <PostPoll author={author} permlink={permlink} metadata={post.json_metadata} />
 
@@ -512,6 +534,7 @@ const PostDisplayView = ({
       name,
       formatedTime,
       tags,
+      translatedBody,
       postBodyLoading,
       postStatsQuery.data?.visits,
       postStatsQuery.isLoading,

--- a/src/config/locales/en-US.json
+++ b/src/config/locales/en-US.json
@@ -207,6 +207,13 @@
     "pin-reply": "Pin comment",
     "unpin-reply": "Unpin comment"
   },
+  "post_translate": {
+    "banner_detected": "This post is in {lang}. Translate to {target}?",
+    "translate_to": "Translate to {lang}",
+    "show_original": "Show original",
+    "translated_from": "Translated from {lang}",
+    "change_language": "Change language"
+  },
   "side_menu": {
     "profile": "Profile",
     "add_account": "Add Account",

--- a/src/hooks/useContentLanguageGate.ts
+++ b/src/hooks/useContentLanguageGate.ts
@@ -25,7 +25,19 @@ interface CacheEntry {
 // Module-scoped, keyed by `${author}/${permlink}`. Survives component remounts
 // (FlashList header/row churn) so detection and any /detect call happen at most
 // once per post for the whole session.
+const MAX_CACHE_ENTRIES = 500;
 const contentLangCache = new Map<string, CacheEntry>();
+
+// Bound memory over long feed-scroll sessions with simple FIFO eviction.
+function cacheDetection(key: string, entry: CacheEntry): void {
+  if (!contentLangCache.has(key) && contentLangCache.size >= MAX_CACHE_ENTRIES) {
+    const oldest = contentLangCache.keys().next().value;
+    if (oldest !== undefined) {
+      contentLangCache.delete(oldest);
+    }
+  }
+  contentLangCache.set(key, entry);
+}
 
 function resolveReaderLang(appLang: string): string {
   const candidates = [appLang, getLocale()];
@@ -103,7 +115,7 @@ export function useContentLanguageGate(
         ).slice(0, SAMPLE_CHARS);
         const textLength = sample.trim().length;
         if (textLength < MIN_DETECT_CHARS) {
-          contentLangCache.set(key, { lang: null, confirmed: true });
+          cacheDetection(key, { lang: null, confirmed: true });
           return;
         }
 
@@ -135,7 +147,7 @@ export function useContentLanguageGate(
           }
         }
 
-        contentLangCache.set(key, { lang, confirmed });
+        cacheDetection(key, { lang, confirmed });
         if (!cancelled) {
           setDecision(resolveTranslateCta({ detected: lang, reader, textLength }));
         }

--- a/src/hooks/useContentLanguageGate.ts
+++ b/src/hooks/useContentLanguageGate.ts
@@ -1,0 +1,156 @@
+import { useEffect, useState } from 'react';
+import { Platform, InteractionManager } from 'react-native';
+import { useSelector } from 'react-redux';
+import { postBodySummary } from '@ecency/render-helper';
+import { detectLanguage } from '../providers/translation/translation';
+import getLocale from '../utils/getLocale';
+import { selectLanguage } from '../redux/selectors';
+import {
+  francToIso1,
+  LIBRETRANSLATE_TARGETS,
+  MIN_DETECT_CHARS,
+  normLang,
+  resolveTranslateCta,
+  TranslateCtaDecision,
+} from '../utils/iso639';
+
+const SAMPLE_CHARS = 600;
+const RAW_SAMPLE_CHARS = 2000;
+
+interface CacheEntry {
+  lang: string | null;
+  confirmed: boolean;
+}
+
+// Module-scoped, keyed by `${author}/${permlink}`. Survives component remounts
+// (FlashList header/row churn) so detection and any /detect call happen at most
+// once per post for the whole session.
+const contentLangCache = new Map<string, CacheEntry>();
+
+function resolveReaderLang(appLang: string): string {
+  const candidates = [appLang, getLocale()];
+  // eslint-disable-next-line no-restricted-syntax
+  for (const candidate of candidates) {
+    const norm = normLang(candidate);
+    if (norm && LIBRETRANSLATE_TARGETS.has(norm)) {
+      return norm;
+    }
+  }
+  return 'en';
+}
+
+interface GatePost {
+  author?: string;
+  permlink?: string;
+  body?: string;
+}
+
+interface GateOptions {
+  // Full-post view only: confirm the on-device guess with the server /detect
+  // endpoint. NEVER enable for feed/wave chips (would fan out a call per item).
+  serverConfirm?: boolean;
+}
+
+/**
+ * Decide whether to offer a "Translate to <reader>" CTA for a post, comparing
+ * the reader's language (app language, then device locale) to the detected
+ * content language. Returns null until resolved; fails closed on any error.
+ *
+ * Feed-safe: only a cheap length check + Map lookup run synchronously. The
+ * markdown render + franc detection run once per permlink, after interactions,
+ * on a cache miss. franc-min@5 is CommonJS so it is required synchronously (no
+ * dynamic import / ESM concerns on Hermes).
+ */
+export function useContentLanguageGate(
+  post: GatePost | null | undefined,
+  { serverConfirm = false }: GateOptions = {},
+): TranslateCtaDecision | null {
+  const appLang = useSelector(selectLanguage);
+  const [decision, setDecision] = useState<TranslateCtaDecision | null>(null);
+
+  const author = post?.author;
+  const permlink = post?.permlink;
+  const body = post?.body;
+
+  useEffect(() => {
+    setDecision(null);
+
+    if (!author || !permlink || !body || body.trim().length < MIN_DETECT_CHARS) {
+      return undefined;
+    }
+
+    let cancelled = false;
+    const key = `${author}/${permlink}`;
+    const reader = resolveReaderLang(appLang);
+
+    const cached = contentLangCache.get(key);
+    if (cached && (cached.confirmed || !serverConfirm)) {
+      setDecision(
+        resolveTranslateCta({ detected: cached.lang, reader, textLength: MIN_DETECT_CHARS }),
+      );
+      return undefined;
+    }
+
+    const task = InteractionManager.runAfterInteractions(async () => {
+      if (cancelled) {
+        return;
+      }
+      try {
+        const sample = postBodySummary(
+          body.slice(0, RAW_SAMPLE_CHARS),
+          0,
+          Platform.OS as any,
+        ).slice(0, SAMPLE_CHARS);
+        const textLength = sample.trim().length;
+        if (textLength < MIN_DETECT_CHARS) {
+          contentLangCache.set(key, { lang: null, confirmed: true });
+          return;
+        }
+
+        let lang: string | null = cached?.lang ?? null;
+        let confirmed = cached?.confirmed ?? false;
+
+        if (!cached) {
+          // franc-min@5 is CommonJS; its default export is the detector function.
+          // eslint-disable-next-line @typescript-eslint/no-var-requires
+          const franc = require('franc-min');
+          lang = francToIso1(franc(sample));
+        }
+
+        if (lang && lang === reader) {
+          confirmed = true;
+        } else if (serverConfirm) {
+          try {
+            const detected = await detectLanguage(sample);
+            if (cancelled) {
+              return;
+            }
+            const top = detected[0];
+            if (top && typeof top.language === 'string') {
+              lang = normLang(top.language);
+              confirmed = true;
+            }
+          } catch {
+            // /detect unreachable — keep the franc guess.
+          }
+        }
+
+        contentLangCache.set(key, { lang, confirmed });
+        if (!cancelled) {
+          setDecision(resolveTranslateCta({ detected: lang, reader, textLength }));
+        }
+      } catch {
+        if (!cancelled) {
+          setDecision(null);
+        }
+      }
+    });
+
+    return () => {
+      cancelled = true;
+      task?.cancel?.();
+    };
+  }, [author, permlink, body, serverConfirm, appLang]);
+
+  return decision;
+}

--- a/src/navigation/sheets.tsx
+++ b/src/navigation/sheets.tsx
@@ -78,6 +78,9 @@ declare module 'react-native-actions-sheet' {
     [SheetNames.POST_TRANSLATION]: SheetDefinition<{
       payload: {
         content: any;
+        // Pre-select the target language (from the inline banner / a chip).
+        initialTargetCode?: string;
+        initialSource?: string;
       };
     }>;
     [SheetNames.QUICK_PROFILE]: SheetDefinition<{

--- a/src/providers/translation/translation.ts
+++ b/src/providers/translation/translation.ts
@@ -42,3 +42,67 @@ export const fetchSupportedLangs = async () => {
     throw error;
   }
 };
+
+// Ask the backend to detect the language of a text. Returns confidence-ranked
+// ISO-639-1 candidates ([{ confidence, language }]). Used only on the full-post
+// view to confirm/refine the instant on-device guess (never per feed item).
+export const detectLanguage = async (text: string) => {
+  try {
+    const { clean } = stripEmojis(text);
+    if (!clean) {
+      return [];
+    }
+    const res = await translationApi.post('/detect', {
+      q: clean.slice(0, 800),
+      api_key: '',
+    });
+    return Array.isArray(res?.data) ? res.data : [];
+  } catch (error) {
+    console.log('error : ', error);
+    Sentry.captureException(error);
+    throw error;
+  }
+};
+
+const MAX_TRANSLATE_CHARS = 1800;
+
+const chunkText = (text: string, max: number): string[] => {
+  if (text.length <= max) {
+    return [text];
+  }
+  const chunks: string[] = [];
+  let buf = '';
+  text.split(/\s+/).forEach((word) => {
+    if (buf && buf.length + 1 + word.length > max) {
+      chunks.push(buf);
+      buf = word;
+    } else {
+      buf = buf ? `${buf} ${word}` : word;
+    }
+  });
+  if (buf) {
+    chunks.push(buf);
+  }
+  return chunks.filter(Boolean);
+};
+
+// Translate a full (possibly long) plain-text body, chunking to stay under the
+// endpoint's request limit. Returns the joined translation plus the language the
+// backend auto-detected on the first chunk (authoritative — used to relabel).
+export const translateLongText = async (text: string, source: string, target: string) => {
+  const chunks = chunkText(text, MAX_TRANSLATE_CHARS);
+  const parts: string[] = [];
+  let detectedLanguage;
+  // Sequential on purpose: a deliberate user action, keeps us under the rate limit.
+  // eslint-disable-next-line no-restricted-syntax
+  for (const chunk of chunks) {
+    // eslint-disable-next-line no-await-in-loop
+    const res = await getTranslation(chunk, source, target);
+    parts.push(res.translatedText);
+    if (!detectedLanguage && res.detectedLanguage) {
+      // eslint-disable-next-line prefer-destructuring
+      detectedLanguage = res.detectedLanguage;
+    }
+  }
+  return { translatedText: parts.join(' '), detectedLanguage };
+};

--- a/src/providers/translation/translation.ts
+++ b/src/providers/translation/translation.ts
@@ -58,9 +58,10 @@ export const detectLanguage = async (text: string) => {
     });
     return Array.isArray(res?.data) ? res.data : [];
   } catch (error) {
-    console.log('error : ', error);
-    Sentry.captureException(error);
-    throw error;
+    // Best-effort: detection only refines the on-device guess, so a failure
+    // (offline / rate limit) should fail open quietly, not spam Sentry per post.
+    console.log('detectLanguage error : ', error);
+    return [];
   }
 };
 
@@ -72,17 +73,29 @@ const chunkText = (text: string, max: number): string[] => {
   }
   const chunks: string[] = [];
   let buf = '';
-  text.split(/\s+/).forEach((word) => {
-    if (buf && buf.length + 1 + word.length > max) {
+  const flush = () => {
+    if (buf) {
       chunks.push(buf);
+      buf = '';
+    }
+  };
+  text.split(/\s+/).forEach((word) => {
+    // A single "word" longer than the limit — e.g. space-less CJK text, where the
+    // whole body is one token — must be hard-split, or it becomes one over-limit
+    // request that gets truncated/rejected.
+    if (word.length > max) {
+      flush();
+      for (let i = 0; i < word.length; i += max) {
+        chunks.push(word.slice(i, i + max));
+      }
+    } else if (buf && buf.length + 1 + word.length > max) {
+      flush();
       buf = word;
     } else {
       buf = buf ? `${buf} ${word}` : word;
     }
   });
-  if (buf) {
-    chunks.push(buf);
-  }
+  flush();
   return chunks.filter(Boolean);
 };
 

--- a/src/utils/iso639.test.ts
+++ b/src/utils/iso639.test.ts
@@ -1,0 +1,110 @@
+import {
+  francToIso1,
+  isRtlLang,
+  ISO_639_3_TO_1,
+  languageDisplayName,
+  LIBRETRANSLATE_SOURCES,
+  normLang,
+  resolveTranslateCta,
+} from './iso639';
+
+describe('normLang', () => {
+  it('reduces locale tags to a 2-letter code', () => {
+    expect(normLang('en-US')).toBe('en');
+    expect(normLang('pt_BR')).toBe('pt');
+    expect(normLang('ES')).toBe('es');
+  });
+
+  it('maps Traditional Chinese variants to LibreTranslate zt', () => {
+    expect(normLang('zh-Hant')).toBe('zt');
+    expect(normLang('zh-TW')).toBe('zt');
+    expect(normLang('zh-HK')).toBe('zt');
+  });
+
+  it('keeps Simplified Chinese as zh', () => {
+    expect(normLang('zh')).toBe('zh');
+    expect(normLang('zh-CN')).toBe('zh');
+  });
+
+  it('returns empty string for missing input', () => {
+    expect(normLang('')).toBe('');
+    expect(normLang(null)).toBe('');
+    expect(normLang(undefined)).toBe('');
+  });
+});
+
+describe('francToIso1', () => {
+  it('maps franc ISO-639-3 codes (both fas and pes) to ISO-639-1', () => {
+    expect(francToIso1('fas')).toBe('fa'); // franc-min@5 (mobile)
+    expect(francToIso1('pes')).toBe('fa'); // franc-min@6 (web parity)
+    expect(francToIso1('arb')).toBe('ar');
+    expect(francToIso1('cmn')).toBe('zh');
+    expect(francToIso1('zlm')).toBe('ms');
+    expect(francToIso1('spa')).toBe('es');
+  });
+
+  it('returns null for und / unknown codes', () => {
+    expect(francToIso1('und')).toBeNull();
+    expect(francToIso1('')).toBeNull();
+    expect(francToIso1(null)).toBeNull();
+    expect(francToIso1('dan')).toBeNull();
+  });
+
+  it('every mapped target is a supported LibreTranslate source', () => {
+    Object.values(ISO_639_3_TO_1).forEach((code1) => {
+      expect(LIBRETRANSLATE_SOURCES.has(code1)).toBe(true);
+    });
+  });
+});
+
+describe('resolveTranslateCta', () => {
+  const long = 200;
+
+  it('shows when content and reader differ', () => {
+    expect(resolveTranslateCta({ detected: 'es', reader: 'en', textLength: long })).toEqual({
+      show: true,
+      source: 'es',
+      target: 'en',
+    });
+  });
+
+  it('hides when content is the reader language', () => {
+    expect(resolveTranslateCta({ detected: 'en', reader: 'en', textLength: long }).show).toBe(
+      false,
+    );
+  });
+
+  it('hides for short text', () => {
+    expect(resolveTranslateCta({ detected: 'es', reader: 'en', textLength: 10 }).show).toBe(false);
+  });
+
+  it('hides for undetected / unsupported source', () => {
+    expect(resolveTranslateCta({ detected: null, reader: 'en', textLength: long }).show).toBe(
+      false,
+    );
+    expect(resolveTranslateCta({ detected: 'xx', reader: 'en', textLength: long }).show).toBe(
+      false,
+    );
+  });
+
+  it('falls back to English target when reader language unsupported', () => {
+    const d = resolveTranslateCta({ detected: 'es', reader: 'xx', textLength: long });
+    expect(d.target).toBe('en');
+    expect(d.show).toBe(true);
+  });
+});
+
+describe('isRtlLang', () => {
+  it('flags RTL languages', () => {
+    expect(isRtlLang('ar')).toBe(true);
+    expect(isRtlLang('fa')).toBe(true);
+    expect(isRtlLang('en')).toBe(false);
+  });
+});
+
+describe('languageDisplayName', () => {
+  it('produces readable names', () => {
+    expect(languageDisplayName('es')).toBe('Spanish');
+    expect(languageDisplayName('zt').toLowerCase()).toContain('traditional');
+  });
+});

--- a/src/utils/iso639.test.ts
+++ b/src/utils/iso639.test.ts
@@ -26,6 +26,13 @@ describe('normLang', () => {
     expect(normLang('zh-CN')).toBe('zh');
   });
 
+  it('maps generic Norwegian / Nynorsk to Bokmål (nb)', () => {
+    expect(normLang('no')).toBe('nb');
+    expect(normLang('nn')).toBe('nb');
+    expect(normLang('no-NO')).toBe('nb');
+    expect(normLang('nb-NO')).toBe('nb');
+  });
+
   it('returns empty string for missing input', () => {
     expect(normLang('')).toBe('');
     expect(normLang(null)).toBe('');

--- a/src/utils/iso639.ts
+++ b/src/utils/iso639.ts
@@ -119,6 +119,11 @@ export function normLang(input: string | null | undefined): string {
   ) {
     return 'zt';
   }
+  // Norwegian macrolanguage ('no') and Nynorsk ('nn') -> LibreTranslate's
+  // Bokmål ('nb'); device/app locales often report the generic 'no'.
+  if (lower === 'no' || lower.startsWith('no-') || lower === 'nn' || lower.startsWith('nn-')) {
+    return 'nb';
+  }
   return lower.split('-')[0];
 }
 

--- a/src/utils/iso639.ts
+++ b/src/utils/iso639.ts
@@ -1,0 +1,230 @@
+/**
+ * Pure language helpers for the "translate when the reader's language differs
+ * from the content" feature. No React Native imports — unit-testable.
+ *
+ * franc-min (the client-side detector) emits ISO-639-3 codes; LibreTranslate
+ * (translate.ecency.com) speaks ISO-639-1. Our instance exposes 43 languages
+ * and every source can translate to every target (all-to-all), so a CTA is
+ * valid whenever the detected source and the reader target are both supported
+ * and differ.
+ *
+ * Mirrors the web app's features/shared/entry-translate/iso639.ts. NOTE: mobile
+ * uses franc-min@5 (CommonJS — safe for Metro/Hermes/jest), which emits "fas"
+ * for Persian, whereas web's franc-min@6 emits "pes". Both are mapped here.
+ */
+
+export const LIBRETRANSLATE_CODES = [
+  'ar',
+  'az',
+  'bg',
+  'bn',
+  'ca',
+  'cs',
+  'da',
+  'de',
+  'el',
+  'en',
+  'eo',
+  'es',
+  'et',
+  'fa',
+  'fi',
+  'fr',
+  'ga',
+  'he',
+  'hi',
+  'hu',
+  'id',
+  'it',
+  'ja',
+  'ko',
+  'lt',
+  'lv',
+  'ms',
+  'nb',
+  'nl',
+  'pl',
+  'pt',
+  'ro',
+  'ru',
+  'sk',
+  'sl',
+  'sq',
+  'sv',
+  'th',
+  'tl',
+  'tr',
+  'uk',
+  'zh',
+  'zt',
+];
+
+export const LIBRETRANSLATE_SOURCES = new Set<string>(LIBRETRANSLATE_CODES);
+export const LIBRETRANSLATE_TARGETS = new Set<string>(LIBRETRANSLATE_CODES);
+
+// ISO-639-3 (franc-min output) -> ISO-639-1 (LibreTranslate). Verified against
+// the installed franc-min@5 data. Both "pes" (v6) and "fas" (v5) map to fa so
+// this table is correct regardless of the installed franc-min major.
+export const ISO_639_3_TO_1: Record<string, string> = {
+  arb: 'ar',
+  azj: 'az',
+  bul: 'bg',
+  ben: 'bn',
+  cmn: 'zh',
+  ces: 'cs',
+  deu: 'de',
+  ell: 'el',
+  eng: 'en',
+  spa: 'es',
+  pes: 'fa',
+  fas: 'fa',
+  fra: 'fr',
+  hin: 'hi',
+  hun: 'hu',
+  ind: 'id',
+  ita: 'it',
+  jpn: 'ja',
+  kor: 'ko',
+  nld: 'nl',
+  pol: 'pl',
+  por: 'pt',
+  ron: 'ro',
+  rus: 'ru',
+  swe: 'sv',
+  tgl: 'tl',
+  tha: 'th',
+  tur: 'tr',
+  ukr: 'uk',
+  zlm: 'ms',
+};
+
+export function francToIso1(code3: string | null | undefined): string | null {
+  if (!code3 || code3 === 'und') {
+    return null;
+  }
+  return ISO_639_3_TO_1[code3] ?? null;
+}
+
+export function normLang(input: string | null | undefined): string {
+  if (!input) {
+    return '';
+  }
+  const lower = input.toLowerCase().replace(/_/g, '-');
+  if (
+    lower === 'zh-hant' ||
+    lower.startsWith('zh-hant-') ||
+    lower === 'zh-tw' ||
+    lower === 'zh-hk' ||
+    lower === 'zh-mo'
+  ) {
+    return 'zt';
+  }
+  return lower.split('-')[0];
+}
+
+const RTL_LANGS = new Set(['ar', 'he', 'fa', 'ur', 'ps', 'dv', 'yi']);
+
+export function isRtlLang(code: string | null | undefined): boolean {
+  return RTL_LANGS.has(normLang(code));
+}
+
+export const MIN_DETECT_CHARS = 40;
+
+export interface TranslateCtaDecision {
+  show: boolean;
+  source: string;
+  target: string;
+}
+
+export function resolveTranslateCta({
+  detected,
+  reader,
+  textLength,
+}: {
+  detected: string | null | undefined;
+  reader: string;
+  textLength: number;
+}): TranslateCtaDecision {
+  const normDetected = detected ? normLang(detected) : null;
+  const target = LIBRETRANSLATE_TARGETS.has(reader) ? reader : 'en';
+
+  const show =
+    textLength >= MIN_DETECT_CHARS &&
+    !!normDetected &&
+    normDetected !== 'und' &&
+    LIBRETRANSLATE_SOURCES.has(normDetected) &&
+    LIBRETRANSLATE_TARGETS.has(target) &&
+    normDetected !== target;
+
+  return { show, source: normDetected ?? '', target };
+}
+
+const DISPLAY_NAME_FALLBACK: Record<string, string> = {
+  ar: 'Arabic',
+  az: 'Azerbaijani',
+  bg: 'Bulgarian',
+  bn: 'Bengali',
+  ca: 'Catalan',
+  cs: 'Czech',
+  da: 'Danish',
+  de: 'German',
+  el: 'Greek',
+  en: 'English',
+  eo: 'Esperanto',
+  es: 'Spanish',
+  et: 'Estonian',
+  fa: 'Persian',
+  fi: 'Finnish',
+  fr: 'French',
+  ga: 'Irish',
+  he: 'Hebrew',
+  hi: 'Hindi',
+  hu: 'Hungarian',
+  id: 'Indonesian',
+  it: 'Italian',
+  ja: 'Japanese',
+  ko: 'Korean',
+  lt: 'Lithuanian',
+  lv: 'Latvian',
+  ms: 'Malay',
+  nb: 'Norwegian',
+  nl: 'Dutch',
+  pl: 'Polish',
+  pt: 'Portuguese',
+  ro: 'Romanian',
+  ru: 'Russian',
+  sk: 'Slovak',
+  sl: 'Slovenian',
+  sq: 'Albanian',
+  sv: 'Swedish',
+  th: 'Thai',
+  tl: 'Tagalog',
+  tr: 'Turkish',
+  uk: 'Ukrainian',
+  zh: 'Chinese',
+  zt: 'Chinese (Traditional)',
+};
+
+/**
+ * Human-readable language name. Prefers a static English label (Hermes lacks
+ * reliable Intl.DisplayNames); falls back to Intl only when the map misses.
+ */
+export function languageDisplayName(code: string): string {
+  const norm = normLang(code);
+  if (DISPLAY_NAME_FALLBACK[norm]) {
+    return DISPLAY_NAME_FALLBACK[norm];
+  }
+  try {
+    const AnyIntl = Intl as any;
+    if (AnyIntl && typeof AnyIntl.DisplayNames === 'function') {
+      const dn = new AnyIntl.DisplayNames(['en'], { type: 'language' });
+      const name = dn.of(norm === 'zt' ? 'zh-Hant' : norm);
+      if (name && name.toLowerCase() !== norm) {
+        return name;
+      }
+    }
+  } catch {
+    // ignore
+  }
+  return code;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5011,6 +5011,11 @@ code-point-at@^1.0.0:
   resolved "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz"
   integrity sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA==
 
+collapse-white-space@^1.0.0:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/collapse-white-space/-/collapse-white-space-1.0.6.tgz#e63629c0016665792060dbbeb79c42239d2c5287"
+  integrity sha512-jEovNnrhMuqyCcjfEJA56v0Xq8SkIoPKDyaHahwo3POf4qcSXqMYuwNcOTzp74vTsR9Tn08z4MxWqAhcekogkQ==
+
 collect-v8-coverage@^1.0.0:
   version "1.0.2"
   resolved "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.2.tgz"
@@ -7066,6 +7071,13 @@ fragment-cache@^0.2.1:
   integrity sha512-GMBAbW9antB8iZRHLoGw0b3HANt57diZYFO/HL1JGIC1MjKrdmhxvrJbupnVvpys0zsz7yBApXdQyfepKly2kA==
   dependencies:
     map-cache "^0.2.2"
+
+franc-min@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/franc-min/-/franc-min-5.0.0.tgz#5625d0570a18564dcbbfa8330254d23549294d9a"
+  integrity sha512-xy7Iq7uNflbvNU+bkyYWtP+BOHWZle7kT9GM84gEV14b7/7sgq7M7Flf6v1XRflHAuHoshBMveWA6Q+kEXYeHQ==
+  dependencies:
+    trigram-utils "^1.0.0"
 
 freeport-async@^2.0.0:
   version "2.0.0"
@@ -9845,6 +9857,11 @@ mz@^2.7.0:
     any-promise "^1.0.0"
     object-assign "^4.0.1"
     thenify-all "^1.0.0"
+
+n-gram@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/n-gram/-/n-gram-1.1.2.tgz#69c609a5c83bb32f82774c9e297f8494c7326798"
+  integrity sha512-mBTpWKp0NHdujHmxrskPg2jc108mjyMmVxHN1rZGK/ogTLi9O0debDIXlQPqotNELdNmVGtL4jr7SCig+4OWvQ==
 
 nanoid@^3.1.23, nanoid@^3.3.7:
   version "3.3.8"
@@ -13142,6 +13159,20 @@ tr46@~0.0.3:
   version "0.0.3"
   resolved "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz"
   integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
+
+trigram-utils@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/trigram-utils/-/trigram-utils-1.0.3.tgz#535da37a414dae249c4b023512cf2b3dc65c8ea4"
+  integrity sha512-UAhS1Ll21FtClVIzIN0I/SmGnJ+D08BOxX7Dl1penV8raC0ksf2dJkhNI6kU1Mj3uT86Bul12iMvxXquXSYSng==
+  dependencies:
+    collapse-white-space "^1.0.0"
+    n-gram "^1.0.0"
+    trim "0.0.1"
+
+trim@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.1.tgz#5858547f6b290757ee95cccc666fb50084c460dd"
+  integrity sha512-YzQV+TZg4AxpKxaTHK3c3D+kRDCGVEE7LemdlQZoQXn0iennk10RsIoY6ikzAqJTc9Xjl9C1/waHom/J86ziAQ==
 
 ts-api-utils@^1.3.0:
   version "1.4.3"


### PR DESCRIPTION
## What

Mirrors the vision-next change: surfaces the existing post translation feature prominently when the reader's language differs from the language a post is written in, instead of only in the 3-dot menu.

- **Full post:** when the detected content language differs from the reader's language, a "This post is in X. Translate to Y?" banner appears between the reading metadata and the body. One tap translates the full body in place (plain text, RTL-aware) with **Show original** and **Change language**. The source language is confirmed via the backend `/detect`, and the translation call relabels the banner to "Translated from X".
- **Feed cards:** a compact **Translate** chip in the actions row for the same mismatch case, opening the existing translate sheet pre-targeted to the reader's language.
- The existing 3-dot Translate stays as a fallback everywhere (and covers waves).

## How

- **Reader language** = app language (redux) → device locale (`getLocale`), normalized to a LibreTranslate code.
- **Content language** is detected on-device with `franc-min@5` (CommonJS — no ESM/Metro/Hermes/jest issues; required synchronously). On the full-post view an ambiguous/unsupported result is confirmed with `/detect`; feed chips are franc-only (no per-item network).
- **Feed-safe:** detection is deferred via `InteractionManager`, bounded to the first ~2k chars of the body, and memoized per `author/permlink` at module scope (survives FlashList remounts). The gate returns null until resolved and fails closed.
- Pure logic in `src/utils/iso639.ts` (unit-tested): franc ISO-639-3 → LibreTranslate ISO-639-1 map (both `fas` and `pes` for Persian), all-to-all gate, Traditional-Chinese → `zt`, RTL set.
- `providers/translation`: adds `detectLanguage()` and chunked `translateLongText()`; the `POST_TRANSLATION` sheet payload accepts `initialTargetCode`.

## Files

- New: `src/utils/iso639.ts` (+ `iso639.test.ts`), `src/hooks/useContentLanguageGate.ts`, `src/components/postView/children/postTranslateInline.tsx`, `src/components/postCard/children/translateChip.tsx`
- Edited: `providers/translation/translation.ts`, `postDisplayView.tsx` (+ styles), `postCardActionsPanel.tsx`, `post-translation-modal/postTranslationModal.tsx`, `navigation/sheets.tsx`, `config/locales/en-US.json`, `package.json` (franc-min@5)

## Testing

- `yarn test:ci`: 500 passed (includes 14 new `iso639` tests; existing `translation.test.ts` still green)
- `eslint src/`: no errors on changed files

## Needs on-device verification before merge

This could not be bundled/run on the build host. Before merge, please verify on a real device/emulator: a foreign-language post shows the banner and translates in place; Show original / Change language work; the feed chip appears and opens the sheet pre-targeted; and a release bundle resolves `franc-min` (CJS, so expected to just work, but confirm). Per the usual order this ships after the web release.

## Follow-ups

- Full-body translation is plain text (paragraph breaks collapsed); a follow-up can preserve structure.
- A dedicated Translate chip in the waves reels view (waves currently use the 3-dot fallback).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Translate” actions on post cards and post pages, including inline translation with language switching.
  * Preselects initial source/target languages when opening the translation sheet.
  * Translation CTA and UI now account for supported languages and right-to-left text.

* **Bug Fixes**
  * Improved language detection gating, caching, and fallback behavior to keep translation prompts consistent.
  * Ensures dismissed/“show original” states correctly cancel in-flight translation and restore original content.

* **Chores**
  * Added translation language utilities, test coverage, and UI copy for the new translation flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->