### PR TITLE
Streak Freeze: buy on quests card

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@babel/preset-typescript": "^7.26.0",
     "@babel/runtime": "^7.26.7",
     "@ecency/render-helper": "^2.5.17",
-    "@ecency/sdk": "^2.3.32",
+    "@ecency/sdk": "^2.3.35",
     "@esteemapp/react-native-autocomplete-input": "^4.2.1",
     "@esteemapp/react-native-multi-slider": "^1.1.0",
     "@native-html/iframe-plugin": "^2.6.1",

--- a/src/config/locales/en-US.json
+++ b/src/config/locales/en-US.json
@@ -29,7 +29,11 @@
     "account_boost": "Account boost",
     "account_boost_desc": "Boost any account",
     "rc_topup": "Top up RC",
-    "rc_topup_desc": "Keep posting when low on Resource Credits"
+    "rc_topup_desc": "Keep posting when low on Resource Credits",
+    "streak_freeze_owned": "{n} in reserve",
+    "streak_freeze_buy": "Protect streak ({price} Points)",
+    "streak_freeze_buying": "Protecting",
+    "streak_freeze_error": "Could not buy a streak freeze. Please try again."
   },
   "waves": {
     "for_you": "For you",

--- a/src/screens/perks/children/questsCard.tsx
+++ b/src/screens/perks/children/questsCard.tsx
@@ -1,13 +1,20 @@
 import React, { useState } from 'react';
-import { View, Text, TouchableOpacity } from 'react-native';
+import { View, Text, TouchableOpacity, Alert } from 'react-native';
 import { useIntl } from 'react-intl';
 import EStyleSheet from 'react-native-extended-stylesheet';
-import { QUEST_CATALOG } from '@ecency/sdk';
+import {
+  QUEST_CATALOG,
+  STREAK_FREEZE_MAX_OWNED,
+  STREAK_FREEZE_PRICE,
+  useBuyStreakFreeze,
+} from '@ecency/sdk';
 
 import { Icon } from '../../../components';
-import { useAppSelector } from '../../../hooks';
+import { useAppSelector, useAuth } from '../../../hooks';
 import { selectCurrentAccountName } from '../../../redux/selectors';
 import { useGetQuestsQuery } from '../../../providers/queries/pointQueries';
+import RootNavigation from '../../../navigation/rootNavigation';
+import ROUTES from '../../../constants/routeNames';
 import styles from '../styles/perksStyles';
 
 // Map the shared SDK catalog icon hints to MaterialCommunityIcons names.
@@ -26,8 +33,29 @@ const byId = (arr?: { id: string }[]) => Object.fromEntries((arr || []).map((q) 
 const QuestsCard = () => {
   const intl = useIntl();
   const username = useAppSelector(selectCurrentAccountName);
+  const { username: authUsername, code } = useAuth();
   const { data } = useGetQuestsQuery(username);
   const [tier, setTier] = useState<(typeof TIERS)[number]>('daily');
+
+  const { mutateAsync: buyFreeze, isPending: isBuyingFreeze } = useBuyStreakFreeze(
+    authUsername,
+    code,
+  );
+
+  const _handleBuyFreeze = async () => {
+    try {
+      await buyFreeze();
+    } catch (err) {
+      const status = (err as { status?: number })?.status;
+      if (status === 402) {
+        // Not enough Points -> send them to buy Points (the top-up funnel).
+        RootNavigation.navigate({ name: ROUTES.SCREENS.BOOST });
+      } else if (status !== 409) {
+        // 409 = already at max; the count refetches and the button hides.
+        Alert.alert(intl.formatMessage({ id: 'perks.streak_freeze_error' }));
+      }
+    }
+  };
 
   const progressByTier: Record<(typeof TIERS)[number], any> = {
     daily: byId(data?.daily),
@@ -86,6 +114,43 @@ const QuestsCard = () => {
           <Text style={styles.streakText}>
             {intl.formatMessage({ id: 'perks.streak' }, { n: streak.current })}
           </Text>
+        </View>
+      )}
+
+      {!!streak && streak.current > 0 && (
+        <View style={styles.freezeRow}>
+          {(streak.freezes_owned ?? 0) > 0 && (
+            <View style={styles.freezeCount}>
+              <Icon
+                iconType="MaterialCommunityIcons"
+                name="snowflake"
+                size={14}
+                color={EStyleSheet.value('$primaryBlue')}
+              />
+              <Text style={styles.freezeCountText}>
+                {intl.formatMessage(
+                  { id: 'perks.streak_freeze_owned' },
+                  { n: streak.freezes_owned },
+                )}
+              </Text>
+            </View>
+          )}
+          {(streak.freezes_owned ?? 0) < STREAK_FREEZE_MAX_OWNED && (
+            <TouchableOpacity
+              style={[styles.freezeBtn, isBuyingFreeze && styles.freezeBtnDisabled]}
+              onPress={_handleBuyFreeze}
+              disabled={isBuyingFreeze}
+            >
+              <Text style={styles.freezeBtnText}>
+                {isBuyingFreeze
+                  ? intl.formatMessage({ id: 'perks.streak_freeze_buying' })
+                  : intl.formatMessage(
+                      { id: 'perks.streak_freeze_buy' },
+                      { price: STREAK_FREEZE_PRICE },
+                    )}
+              </Text>
+            </TouchableOpacity>
+          )}
         </View>
       )}
 

--- a/src/screens/perks/children/questsCard.tsx
+++ b/src/screens/perks/children/questsCard.tsx
@@ -10,8 +10,7 @@ import {
 } from '@ecency/sdk';
 
 import { Icon } from '../../../components';
-import { useAppSelector, useAuth } from '../../../hooks';
-import { selectCurrentAccountName } from '../../../redux/selectors';
+import { useAuth } from '../../../hooks';
 import { useGetQuestsQuery } from '../../../providers/queries/pointQueries';
 import RootNavigation from '../../../navigation/rootNavigation';
 import ROUTES from '../../../constants/routeNames';
@@ -32,15 +31,11 @@ const byId = (arr?: { id: string }[]) => Object.fromEntries((arr || []).map((q) 
 
 const QuestsCard = () => {
   const intl = useIntl();
-  const username = useAppSelector(selectCurrentAccountName);
-  const { username: authUsername, code } = useAuth();
+  const { username, code } = useAuth();
   const { data } = useGetQuestsQuery(username);
   const [tier, setTier] = useState<(typeof TIERS)[number]>('daily');
 
-  const { mutateAsync: buyFreeze, isPending: isBuyingFreeze } = useBuyStreakFreeze(
-    authUsername,
-    code,
-  );
+  const { mutateAsync: buyFreeze, isPending: isBuyingFreeze } = useBuyStreakFreeze(username, code);
 
   const _handleBuyFreeze = async () => {
     try {
@@ -48,8 +43,9 @@ const QuestsCard = () => {
     } catch (err) {
       const status = (err as { status?: number })?.status;
       if (status === 402) {
-        // Not enough Points -> send them to buy Points (the top-up funnel).
-        RootNavigation.navigate({ name: ROUTES.SCREENS.BOOST });
+        // Not enough Points -> send them to buy Points (the top-up funnel). Pass
+        // username so the Boost screen shows the user-context ribbon like other callers.
+        RootNavigation.navigate({ name: ROUTES.SCREENS.BOOST, params: { username } });
       } else if (status !== 409) {
         // 409 = already at max; the count refetches and the button hides.
         Alert.alert(intl.formatMessage({ id: 'perks.streak_freeze_error' }));

--- a/src/screens/perks/styles/perksStyles.ts
+++ b/src/screens/perks/styles/perksStyles.ts
@@ -158,4 +158,37 @@ export default EStyleSheet.create({
     color: '$primaryDarkGray',
     fontFamily: '$primaryFont',
   },
+  freezeRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    flexWrap: 'wrap',
+    marginTop: 8,
+  },
+  freezeCount: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginRight: 10,
+  },
+  freezeCountText: {
+    fontSize: 12,
+    color: '$primaryDarkGray',
+    marginLeft: 4,
+    fontFamily: '$primaryFont',
+  },
+  freezeBtn: {
+    borderWidth: 1,
+    borderColor: '$primaryBlue',
+    borderRadius: 20,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+  },
+  freezeBtnDisabled: {
+    opacity: 0.6,
+  },
+  freezeBtnText: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: '$primaryBlue',
+    fontFamily: '$primaryFont',
+  },
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1211,10 +1211,10 @@
     url "^0.11.0"
     xss "^1.0.9"
 
-"@ecency/sdk@^2.3.32":
-  version "2.3.32"
-  resolved "https://registry.yarnpkg.com/@ecency/sdk/-/sdk-2.3.32.tgz#20dbc5fb489105f9596f1c8311f27d7fdd9e5c88"
-  integrity sha512-9mS/Lpr9yCtiteyhCEt3jXeVuT8Y+kaVpCNhw32dBrizJ/GsssEQ2iVRGAzfPMAjbugranoFLswtFnj6wD3inw==
+"@ecency/sdk@^2.3.35":
+  version "2.3.35"
+  resolved "https://registry.yarnpkg.com/@ecency/sdk/-/sdk-2.3.35.tgz#27b4cb0841f4d3ee7b915459602925bde79c7997"
+  integrity sha512-SL00TfLIK512jgFRPNjfExymRvCakmCb0Exn6FroGuIbP11zn6oGKaaUZhakOzKaoZ84IQBM6jPvfDoSEUagqA==
   dependencies:
     "@noble/ciphers" "^2.1.1"
     "@noble/curves" "^2.0.1"


### PR DESCRIPTION
Cross-platform parity with web (ecency/vision-next#1081) for the Streak Freeze Points sink. Backend: ecency/ePoints#24; proxy: ecency/vision-api#41.

## What
On the perks quests card, under the 🔥 streak badge:
- an ❄️ in-reserve freeze count (from `streak.freezes_owned`), and
- a **Protect streak (300 Points)** button (hidden once `freezes_owned >= STREAK_FREEZE_MAX_OWNED`) that buys a freeze via the SDK `useBuyStreakFreeze`.

On success the count + balance refresh via cache invalidation. On a 402 (insufficient Points) it routes to the Boost (buy Points) screen — the top-up funnel. A 409 (already at max) is swallowed and the button hides after the count refetches.

## Changes
- `@ecency/sdk` bumped `^2.3.32` -> `^2.3.35` (adds `useBuyStreakFreeze`, `freezes_owned`, `STREAK_FREEZE_PRICE`/`MAX_OWNED`).
- `questsCard.tsx`: freeze UI + buy handler (username/code from `useAuth`).
- `perksStyles.ts`: freeze row/count/button styles (theme-safe vars).
- `en-US.json`: `perks.streak_freeze_*` strings.

Prettier-clean (`--config .prettierrc`); JSON validated. Ships with the next app build after the SDK bump. Relies on CI lint+jest (no local node_modules).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “streak freeze” option in the perks area, including the ability to buy freezes and see how many you own.
  * Updated the UI to show purchase progress and disable the button while a request is in progress.

* **Bug Fixes**
  * Improved error handling for streak freeze purchases, including clearer feedback when payment or purchase limits are reached.

* **Documentation**
  * Added new localized messages for streak freeze-related states and errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->