### PR TITLE
Fix hidden web link action in editor format bar

### DIFF
--- a/src/components/markdownEditor/children/formats/formats.ts
+++ b/src/components/markdownEditor/children/formats/formats.ts
@@ -32,6 +32,11 @@ export default [
   {
     key: 'link',
     title: 'WEB',
-    onPress: applyWebLinkFormat,
+    icon: 'link',
+    iconType: 'FontAwesome',
+    // applyWebLinkFormat reads text/url from `item` when one is passed, but the
+    // format bar hands over this format entry itself; null it out so the
+    // selection is wrapped with the function's own placeholders instead.
+    onPress: (params) => applyWebLinkFormat({ ...params, item: null }),
   },
 ];

--- a/src/components/markdownEditor/children/textFormatModal.tsx
+++ b/src/components/markdownEditor/children/textFormatModal.tsx
@@ -53,7 +53,7 @@ export const TextFormatModal = forwardRef(
           style={styles.formatsWrapper}
           data={Formats}
           keyboardShouldPersistTaps="always"
-          renderItem={({ item, index }) => index < 3 && _renderMarkupButton({ item })}
+          renderItem={({ item }) => _renderMarkupButton({ item })}
           horizontal
         />
       );


### PR DESCRIPTION
The text format bar (shown on selection) rendered only the first 3 of 4 entries in the Formats array because of an `index < 3` guard, hiding the web link action.

- Renders all format entries.
- The link entry had no icon and its `onPress` received the format entry itself as `item`, which `applyWebLinkFormat` would read `text`/`url` from, producing `[undefined](undefined)`. It now has a link icon and passes `item: null` so the selection is wrapped with the function's own placeholders (`[selected text](https://example.com)`).

The insert-link modal in the main toolbar is unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed web link formatting so it uses the correct placeholder values when inserting or editing links.
  * Improved the formatting picker to show all available formatting options instead of only a limited subset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->