### PR TITLE
Add templates tab to drafts and hide template drafts

### DIFF
--- a/src/components/draftListItem/view/draftListItemView.tsx
+++ b/src/components/draftListItem/view/draftListItemView.tsx
@@ -34,6 +34,7 @@ const DraftListItemView = ({
   isFormatedDate,
   status,
   isSchedules,
+  isTemplate,
   isDeleting,
   isUnsaved,
   handleOnClonePressed,
@@ -128,7 +129,7 @@ const DraftListItemView = ({
                 />
               </PopoverWrapper>
             )}
-            {!isSchedules && (
+            {!isSchedules && !isTemplate && (
               <IconButton
                 backgroundColor="transparent"
                 name="copy"
@@ -201,7 +202,9 @@ const DraftListItemView = ({
           intl.formatMessage({ id: 'alert.delete' }),
           intl.formatMessage({ id: 'alert.cancel' }),
         ]}
-        title={intl.formatMessage({ id: 'alert.remove_alert' })}
+        title={intl.formatMessage({
+          id: isTemplate ? 'templates.delete_confirm' : 'alert.remove_alert',
+        })}
         cancelButtonIndex={1}
         destructiveButtonIndex={0}
         onPress={(index) => {
@@ -256,6 +259,7 @@ export default React.memo(injectIntl(DraftListItemView), (prev, next) => {
     prev.isFormatedDate === next.isFormatedDate &&
     prev.status === next.status &&
     prev.isSchedules === next.isSchedules &&
+    prev.isTemplate === next.isTemplate &&
     prev.isUnsaved === next.isUnsaved &&
     prev.id === next.id &&
     prev.handleOnPressItem === next.handleOnPressItem &&

--- a/src/config/locales/en-US.json
+++ b/src/config/locales/en-US.json
@@ -318,6 +318,13 @@
     "unsynced_title": "Unsynced Draft",
     "empty_list": "Nothing here"
   },
+  "templates": {
+    "title": "Templates",
+    "untitled": "Untitled template",
+    "empty_list": "Save a post as template on Ecency web to reuse it here.",
+    "delete_confirm": "Are you sure you want to delete this template?",
+    "applied": "Template applied as new post"
+  },
   "selection_list": {
     "available": "Available {postfix}",
     "no_selected": "Please add from available",

--- a/src/constants/draftTypes.ts
+++ b/src/constants/draftTypes.ts
@@ -1,4 +1,5 @@
 export enum DraftTypes {
   DRAFTS = 'drafts',
   SCHEDULES = 'schedules',
+  TEMPLATES = 'templates',
 }

--- a/src/providers/queries/draftQueries.ts
+++ b/src/providers/queries/draftQueries.ts
@@ -32,7 +32,7 @@ const schedulesInfiniteQueryKey = (
  * Uses SDK's getDraftsInfiniteQueryOptions for efficient data loading
  *
  * @param limit - Number of items to load per page (default: 20)
- * @returns Flattened drafts array with pagination controls
+ * @returns Flattened drafts array with pagination controls and loaded pages count
  */
 export const useGetDraftsQuery = (limit = 20) => {
   const { username, code } = useAuth();
@@ -53,6 +53,7 @@ export const useGetDraftsQuery = (limit = 20) => {
   return {
     ...infiniteQuery,
     data,
+    pagesLoaded: infiniteQuery.data?.pages?.length ?? 0,
   };
 };
 

--- a/src/screens/drafts/container/draftsContainer.tsx
+++ b/src/screens/drafts/container/draftsContainer.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { connect } from 'react-redux';
 import { injectIntl } from 'react-intl';
 
@@ -23,9 +23,13 @@ import { DraftTypes } from '../../../constants/draftTypes';
 
 // Utilities
 import { selectCurrentAccount } from '../../../redux/selectors';
+import { isTemplateDraft } from '../../../utils/draftTemplates';
 
 // Component
 import DraftsScreen from '../screen/draftsScreen';
+
+// Empty lists never fire onEndReached, so auto-fetching ahead is bounded to this many pages
+const AUTO_FETCH_PAGE_BUDGET = 5;
 
 const DraftsContainer = ({ currentAccount, navigation, route }) => {
   const { mutate: _cloneDraft, isLoading: isCloningDraft } = useAddDraftMutation();
@@ -38,13 +42,18 @@ const DraftsContainer = ({ currentAccount, navigation, route }) => {
 
   const {
     isLoading: isLoadingDrafts,
-    data: drafts = [],
+    data: allDrafts = [],
     isFetching: isFetchingDrafts,
     refetch: refetchDrafts,
     fetchNextPage: fetchNextDraftsPage,
     hasNextPage: hasNextDraftsPage,
     isFetchingNextPage: isFetchingNextDraftsPage,
+    pagesLoaded: draftsPagesLoaded,
   } = useGetDraftsQuery();
+
+  // template drafts (meta.postTemplate) share the drafts query but render in their own tab
+  const drafts = useMemo(() => allDrafts.filter((item) => !isTemplateDraft(item)), [allDrafts]);
+  const templates = useMemo(() => allDrafts.filter((item) => isTemplateDraft(item)), [allDrafts]);
 
   const {
     isLoading: isLoadingSchedules,
@@ -61,6 +70,26 @@ const DraftsContainer = ({ currentAccount, navigation, route }) => {
   const [batchSelectedSchedules, setBatchSelectedSchedules] = useState<string[]>([]);
   // const [selectedTabIndex, setSelectedTabIndex] = useState(route.params?.showSchedules ? 1 : 0);
 
+  // onEndReached never fires on an empty list; if either split list is empty while more
+  // pages remain, fetch ahead so items beyond the first pages can still surface
+  useEffect(() => {
+    if (
+      (drafts.length === 0 || templates.length === 0) &&
+      hasNextDraftsPage &&
+      !isFetchingNextDraftsPage &&
+      draftsPagesLoaded < AUTO_FETCH_PAGE_BUDGET
+    ) {
+      fetchNextDraftsPage();
+    }
+  }, [
+    drafts.length,
+    templates.length,
+    hasNextDraftsPage,
+    isFetchingNextDraftsPage,
+    draftsPagesLoaded,
+    fetchNextDraftsPage,
+  ]);
+
   // Component Functions
   const _onRefresh = () => {
     refetchDrafts();
@@ -73,6 +102,17 @@ const DraftsContainer = ({ currentAccount, navigation, route }) => {
       key: `editor_draft_${id}`,
       params: {
         draftId: id,
+      },
+    });
+  };
+
+  // opens editor hydrated from the template as a new post instead of editing the template
+  const _applyTemplate = (template: any) => {
+    navigation.navigate({
+      name: ROUTES.SCREENS.EDITOR,
+      key: `editor_template_${template._id}`,
+      params: {
+        templateDraft: template,
       },
     });
   };
@@ -98,7 +138,8 @@ const DraftsContainer = ({ currentAccount, navigation, route }) => {
     return _tempArr;
   };
   const _handleItemLongPress = (id, type) => {
-    if (type === DraftTypes.DRAFTS) {
+    if (type === DraftTypes.DRAFTS || type === DraftTypes.TEMPLATES) {
+      // templates are drafts server-side, so they share the drafts batch delete flow
       setBatchSelectedDrafts(_getUpdatedArray(batchSelectedDrafts, id));
     } else if (type === DraftTypes.SCHEDULES) {
       setBatchSelectedSchedules(_getUpdatedArray(batchSelectedSchedules, id));
@@ -141,8 +182,10 @@ const DraftsContainer = ({ currentAccount, navigation, route }) => {
         draftsBatchDeleteMutation.isLoading || schedulesBatchDeleteMutation.isLoading
       }
       editDraft={_editDraft}
+      applyTemplate={_applyTemplate}
       currentAccount={currentAccount}
       drafts={drafts}
+      templates={templates}
       schedules={schedules}
       removeDraft={_removeDraft}
       moveScheduleToDraft={_moveScheduleToDraft}

--- a/src/screens/drafts/container/draftsContainer.tsx
+++ b/src/screens/drafts/container/draftsContainer.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { connect } from 'react-redux';
 import { injectIntl } from 'react-intl';
 
@@ -27,9 +27,6 @@ import { isTemplateDraft } from '../../../utils/draftTemplates';
 
 // Component
 import DraftsScreen from '../screen/draftsScreen';
-
-// Empty lists never fire onEndReached, so auto-fetching ahead is bounded to this many pages
-const AUTO_FETCH_PAGE_BUDGET = 5;
 
 const DraftsContainer = ({ currentAccount, navigation, route }) => {
   const { mutate: _cloneDraft, isLoading: isCloningDraft } = useAddDraftMutation();
@@ -69,26 +66,6 @@ const DraftsContainer = ({ currentAccount, navigation, route }) => {
   const [batchSelectedDrafts, setBatchSelectedDrafts] = useState<string[]>([]);
   const [batchSelectedSchedules, setBatchSelectedSchedules] = useState<string[]>([]);
   // const [selectedTabIndex, setSelectedTabIndex] = useState(route.params?.showSchedules ? 1 : 0);
-
-  // onEndReached never fires on an empty list; if either split list is empty while more
-  // pages remain, fetch ahead so items beyond the first pages can still surface
-  useEffect(() => {
-    if (
-      (drafts.length === 0 || templates.length === 0) &&
-      hasNextDraftsPage &&
-      !isFetchingNextDraftsPage &&
-      draftsPagesLoaded < AUTO_FETCH_PAGE_BUDGET
-    ) {
-      fetchNextDraftsPage();
-    }
-  }, [
-    drafts.length,
-    templates.length,
-    hasNextDraftsPage,
-    isFetchingNextDraftsPage,
-    draftsPagesLoaded,
-    fetchNextDraftsPage,
-  ]);
 
   // Component Functions
   const _onRefresh = () => {
@@ -186,6 +163,7 @@ const DraftsContainer = ({ currentAccount, navigation, route }) => {
       currentAccount={currentAccount}
       drafts={drafts}
       templates={templates}
+      draftsPagesLoaded={draftsPagesLoaded}
       schedules={schedules}
       removeDraft={_removeDraft}
       moveScheduleToDraft={_moveScheduleToDraft}

--- a/src/screens/drafts/screen/draftsScreen.tsx
+++ b/src/screens/drafts/screen/draftsScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef, useCallback } from 'react';
+import React, { useEffect, useMemo, useRef, useCallback } from 'react';
 import { injectIntl } from 'react-intl';
 import { View, FlatList, Text, Platform, RefreshControl } from 'react-native';
 import { default as AnimatedView, SlideInRight, SlideOutRight } from 'react-native-reanimated';
@@ -29,6 +29,9 @@ import { useAppSelector } from '../../../hooks';
 import { DEFAULT_USER_DRAFT_ID } from '../../../redux/constants/constants';
 import { selectIsDarkTheme, selectDraftById } from '../../../redux/selectors';
 
+// Bounds the empty-tab page waterfall (templates are sparse among drafts)
+const AUTO_FETCH_PAGE_BUDGET = 5;
+
 const DraftsScreen = ({
   currentAccount,
   removeDraft,
@@ -53,6 +56,7 @@ const DraftsScreen = ({
   fetchNextDraftsPage,
   hasNextDraftsPage,
   isFetchingNextDraftsPage,
+  draftsPagesLoaded,
   fetchNextSchedulesPage,
   hasNextSchedulesPage,
   isFetchingNextSchedulesPage,
@@ -81,6 +85,30 @@ const DraftsScreen = ({
   }, [_idLessDraft]);
 
   const [index, setIndex] = React.useState(initialTabIndex);
+
+  // onEndReached never fires on an empty list, so when the ACTIVE tab has no
+  // items while more draft pages remain (templates live among drafts on the
+  // server), fetch ahead, bounded to a few pages.
+  useEffect(() => {
+    const activeListEmpty =
+      (index === 0 && drafts.length === 0) || (index === 2 && templates.length === 0);
+    if (
+      activeListEmpty &&
+      hasNextDraftsPage &&
+      !isFetchingNextDraftsPage &&
+      draftsPagesLoaded < AUTO_FETCH_PAGE_BUDGET
+    ) {
+      fetchNextDraftsPage();
+    }
+  }, [
+    index,
+    drafts.length,
+    templates.length,
+    hasNextDraftsPage,
+    isFetchingNextDraftsPage,
+    draftsPagesLoaded,
+    fetchNextDraftsPage,
+  ]);
   const [routes] = React.useState([
     {
       key: 'drafts',

--- a/src/screens/drafts/screen/draftsScreen.tsx
+++ b/src/screens/drafts/screen/draftsScreen.tsx
@@ -10,6 +10,7 @@ import { TabView } from 'react-native-tab-view';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { catchImageFromMetadata, catchDraftImage } from '../../../utils/image';
 import { getFormatedCreatedDate } from '../../../utils/time';
+import { templateDisplayName } from '../../../utils/draftTemplates';
 
 // Components
 import {
@@ -32,6 +33,7 @@ const DraftsScreen = ({
   currentAccount,
   removeDraft,
   editDraft,
+  applyTemplate,
   removeSchedule,
   isLoading,
   isDeleting,
@@ -39,6 +41,7 @@ const DraftsScreen = ({
   onRefresh,
   intl,
   drafts,
+  templates,
   schedules,
   moveScheduleToDraft,
   initialTabIndex,
@@ -57,6 +60,7 @@ const DraftsScreen = ({
   const actionSheet = useRef(null);
   const draftsListRef = useRef<FlatList>(null);
   const schedulesListRef = useRef<FlatList>(null);
+  const templatesListRef = useRef<FlatList>(null);
   const isDarkTheme = useAppSelector(selectIsDarkTheme);
 
   // Use specific draft selector instead of entire draftsCollection
@@ -90,6 +94,12 @@ const DraftsScreen = ({
         id: 'schedules.title',
       }),
     },
+    {
+      key: 'templates',
+      title: intl.formatMessage({
+        id: 'templates.title',
+      }),
+    },
   ]);
 
   // Pre-compute draft data ONCE - move heavy processing out of _renderItem
@@ -118,6 +128,34 @@ const DraftsScreen = ({
       };
     });
   }, [drafts]);
+
+  // Pre-compute template data ONCE
+  const processedTemplates = useMemo(() => {
+    return templates.map((item) => {
+      const tags = item.tags ? item.tags.split(/[ ,]+/) : [];
+      const tag = tags[0] || '';
+
+      const image =
+        item.meta && item.meta.image
+          ? catchImageFromMetadata(item.meta)
+          : catchDraftImage(item.body);
+      const thumbnail =
+        item.meta && item.meta.image
+          ? catchImageFromMetadata(item.meta, 'match', true)
+          : catchDraftImage(item.body, 'match', true);
+      const summary = postBodySummary({ ...item, last_update: item.modified }, 100, Platform.OS);
+
+      return {
+        ...item,
+        _processedTag: tag,
+        _processedImage: image,
+        _processedThumbnail: thumbnail,
+        _processedSummary: summary,
+        _processedTitle:
+          templateDisplayName(item) || intl.formatMessage({ id: 'templates.untitled' }),
+      };
+    });
+  }, [templates, intl]);
 
   // Pre-compute schedule data ONCE
   const processedSchedules = useMemo(() => {
@@ -180,9 +218,12 @@ const DraftsScreen = ({
     (item, type) => {
       const isSchedules = type === 'schedules';
       const isUnsaved = type === 'unsaved';
+      const isTemplates = type === 'templates';
 
       const _onItemPress = () => {
-        if (!isSchedules) {
+        if (isTemplates) {
+          applyTemplate(item);
+        } else if (!isSchedules) {
           editDraft(item._id);
         }
       };
@@ -195,7 +236,7 @@ const DraftsScreen = ({
         <DraftListItem
           created={isSchedules ? getFormatedCreatedDate(item.schedule) : item.created}
           mainTag={item._processedTag}
-          title={item.title}
+          title={isTemplates ? item._processedTitle : item.title}
           summary={item._processedSummary}
           isFormatedDate={isSchedules}
           image={item._processedImage ? { uri: item._processedImage } : null}
@@ -209,6 +250,7 @@ const DraftsScreen = ({
           key={item._id}
           status={item.status}
           isSchedules={isSchedules}
+          isTemplate={isTemplates}
           isDeleting={isDeleting}
           isUnsaved={isUnsaved}
           handleOnClonePressed={cloneDraft}
@@ -224,6 +266,7 @@ const DraftsScreen = ({
       currentAccount.name,
       currentAccount.reputation,
       editDraft,
+      applyTemplate,
       moveScheduleToDraft,
       removeSchedule,
       removeDraft,
@@ -235,24 +278,27 @@ const DraftsScreen = ({
     ],
   );
 
-  const _renderEmptyContent = useCallback(() => {
-    if (isLoading) {
-      return (
-        <View>
-          <PostCardPlaceHolder />
-          <PostCardPlaceHolder />
-        </View>
-      );
-    }
+  const _renderEmptyContent = useCallback(
+    (type) => {
+      if (isLoading) {
+        return (
+          <View>
+            <PostCardPlaceHolder />
+            <PostCardPlaceHolder />
+          </View>
+        );
+      }
 
-    return (
-      <Text style={globalStyles.hintText}>
-        {intl.formatMessage({
-          id: 'drafts.empty_list',
-        })}
-      </Text>
-    );
-  }, [intl, isLoading]);
+      return (
+        <Text style={globalStyles.hintText}>
+          {intl.formatMessage({
+            id: type === 'templates' ? 'templates.empty_list' : 'drafts.empty_list',
+          })}
+        </Text>
+      );
+    },
+    [intl, isLoading],
+  );
 
   const _renderHeader = useCallback(() => {
     return _renderItem(processedIdLessDraft, 'unsaved');
@@ -261,11 +307,13 @@ const DraftsScreen = ({
   const _getTabItem = useCallback(
     (data, type, listRef) => {
       const isDraftsTab = type === 'drafts';
-      const fetchNextPage = isDraftsTab ? fetchNextDraftsPage : fetchNextSchedulesPage;
-      const hasNextPage = isDraftsTab ? hasNextDraftsPage : hasNextSchedulesPage;
-      const isFetchingNextPage = isDraftsTab
-        ? isFetchingNextDraftsPage
-        : isFetchingNextSchedulesPage;
+      const isSchedulesTab = type === 'schedules';
+      // drafts and templates tabs are fed by the same infinite query
+      const fetchNextPage = isSchedulesTab ? fetchNextSchedulesPage : fetchNextDraftsPage;
+      const hasNextPage = isSchedulesTab ? hasNextSchedulesPage : hasNextDraftsPage;
+      const isFetchingNextPage = isSchedulesTab
+        ? isFetchingNextSchedulesPage
+        : isFetchingNextDraftsPage;
 
       const handleLoadMore = () => {
         if (hasNextPage && !isFetchingNextPage) {
@@ -287,7 +335,7 @@ const DraftsScreen = ({
             windowSize={21}
             renderItem={renderItem}
             ListHeaderComponent={isDraftsTab && processedIdLessDraft ? _renderHeader : null}
-            ListEmptyComponent={_renderEmptyContent}
+            ListEmptyComponent={() => _renderEmptyContent(type)}
             onEndReached={handleLoadMore}
             onEndReachedThreshold={0.5}
             ListFooterComponent={isFetchingNextPage ? <PostCardPlaceHolder /> : null}
@@ -360,9 +408,15 @@ const DraftsScreen = ({
               {_getTabItem(processedSchedules, 'schedules', schedulesListRef)}
             </View>
           );
+        case 'templates':
+          return (
+            <View style={styles.tabbarItem}>
+              {_getTabItem(processedTemplates, 'templates', templatesListRef)}
+            </View>
+          );
       }
     },
-    [processedDrafts, processedSchedules, _getTabItem],
+    [processedDrafts, processedSchedules, processedTemplates, _getTabItem],
   );
 
   return (
@@ -382,7 +436,12 @@ const DraftsScreen = ({
             <TabBar
               {...tabProps}
               onTabPress={({ route }) => {
-                const listRef = route.key === 'schedules' ? schedulesListRef : draftsListRef;
+                const listRef =
+                  route.key === 'schedules'
+                    ? schedulesListRef
+                    : route.key === 'templates'
+                    ? templatesListRef
+                    : draftsListRef;
                 listRef.current?.scrollToOffset({ offset: 0, animated: true });
               }}
             />

--- a/src/screens/editor/container/editorContainer.tsx
+++ b/src/screens/editor/container/editorContainer.tsx
@@ -57,6 +57,7 @@ import {
 } from '../../../redux/actions/cacheActions';
 import { usePostsCachePrimer } from '../../../providers/queries/postQueries/postQueries';
 import { deriveDiscussionRoot } from '../../../utils/discussionRoot';
+import { isTemplateDraft } from '../../../utils/draftTemplates';
 import {
   useCommentMutations,
   addOptimisticComment,
@@ -144,11 +145,13 @@ class EditorContainer extends Component<EditorContainerProps, any> {
     let post;
     let _draft;
     let hasSharedIntent = false;
+    let hasTemplateDraft = false;
 
     if (route.params) {
       const navigationParams = route.params;
-      const { hasSharedIntent: _hasShared, draftId: _draftId } = navigationParams;
+      const { hasSharedIntent: _hasShared, draftId: _draftId, templateDraft } = navigationParams;
       hasSharedIntent = _hasShared;
+      hasTemplateDraft = !!templateDraft;
 
       if (_draftId) {
         draftId = _draftId;
@@ -202,6 +205,10 @@ class EditorContainer extends Component<EditorContainerProps, any> {
               );
             });
         }
+      }
+
+      if (templateDraft) {
+        this._applyTemplateDraft(templateDraft);
       }
 
       if (navigationParams.community) {
@@ -285,7 +292,7 @@ class EditorContainer extends Component<EditorContainerProps, any> {
       }
     }
 
-    if (!isEdit && !_draft && !draftId && !hasSharedIntent) {
+    if (!isEdit && !_draft && !draftId && !hasSharedIntent && !hasTemplateDraft) {
       this._fetchDraftsForComparison(isReply);
     }
     this._requestKeyboardFocus();
@@ -401,6 +408,45 @@ class EditorContainer extends Component<EditorContainerProps, any> {
     }
   };
 
+  // hydrates editor from a template draft as a NEW post; draftId is intentionally left
+  // unset so the first save/autosave creates a new draft instead of editing the template
+  _applyTemplateDraft = (templateDraft: any) => {
+    const { dispatch, intl } = this.props;
+
+    // SDK returns tags_arr (array) and tags (string)
+    let _tags = [];
+    if (templateDraft.tags_arr && Array.isArray(templateDraft.tags_arr)) {
+      _tags = templateDraft.tags_arr;
+    } else if (templateDraft.tags) {
+      _tags = templateDraft.tags
+        .split(/[,\s]+/)
+        .map((tag) => tag.trim())
+        .filter((tag) => !!tag);
+    }
+
+    // strip template markers so they don't carry over into the new post's draft
+    const _meta = templateDraft.meta ? { ...templateDraft.meta } : null;
+    if (_meta) {
+      delete _meta.postTemplate;
+      delete _meta.templateName;
+    }
+
+    this.setState({
+      draftPost: {
+        title: templateDraft.title || '',
+        body: templateDraft.body || '',
+        tags: _tags,
+        meta: _meta,
+      },
+    });
+
+    // no _id and no state.draftId here, so beneficiaries/poll land under the same
+    // default key the new-post flow reads (DEFAULT_USER_DRAFT_ID + account name)
+    this._loadMeta({ meta: _meta });
+
+    dispatch(toastNotification(intl.formatMessage({ id: 'templates.applied' })));
+  };
+
   // load meta from local/param drfat into state
   _loadMeta = (draft: any) => {
     const { dispatch, currentAccount } = this.props;
@@ -503,7 +549,10 @@ class EditorContainer extends Component<EditorContainerProps, any> {
       const draftsQueryOptions = getDraftsQueryOptions(username, accessToken);
       const { queryClient } = this.props;
       const result = await queryClient.fetchQuery(draftsQueryOptions);
-      const remoteDrafts = Array.isArray(result) ? result : result?.data || [];
+      // templates are applied explicitly from the templates tab, never offered as recent draft
+      const remoteDrafts = (Array.isArray(result) ? result : result?.data || []).filter(
+        (draft) => !isTemplateDraft(draft),
+      );
 
       const loadRecentDraft = () => {
         // if no draft available means local draft is recent

--- a/src/screens/editor/container/editorContainer.tsx
+++ b/src/screens/editor/container/editorContainer.tsx
@@ -143,7 +143,6 @@ class EditorContainer extends Component<EditorContainerProps, any> {
     let draftId;
     let isEdit;
     let post;
-    let _draft;
     let hasSharedIntent = false;
     let hasTemplateDraft = false;
 
@@ -292,7 +291,7 @@ class EditorContainer extends Component<EditorContainerProps, any> {
       }
     }
 
-    if (!isEdit && !_draft && !draftId && !hasSharedIntent && !hasTemplateDraft) {
+    if (!isEdit && !draftId && !hasSharedIntent && !hasTemplateDraft) {
       this._fetchDraftsForComparison(isReply);
     }
     this._requestKeyboardFocus();

--- a/src/utils/draftTemplates.test.ts
+++ b/src/utils/draftTemplates.test.ts
@@ -1,0 +1,40 @@
+import { isTemplateDraft, templateDisplayName } from './draftTemplates';
+
+describe('isTemplateDraft', () => {
+  it('returns true when meta.postTemplate is truthy', () => {
+    expect(isTemplateDraft({ meta: { postTemplate: true } })).toBe(true);
+    expect(isTemplateDraft({ meta: { postTemplate: 1 } })).toBe(true);
+  });
+
+  it('returns false when meta.postTemplate is falsy', () => {
+    expect(isTemplateDraft({ meta: { postTemplate: false } })).toBe(false);
+    expect(isTemplateDraft({ meta: {} })).toBe(false);
+  });
+
+  it('returns false when meta or draft is missing', () => {
+    expect(isTemplateDraft({})).toBe(false);
+    expect(isTemplateDraft(null)).toBe(false);
+    expect(isTemplateDraft(undefined)).toBe(false);
+  });
+});
+
+describe('templateDisplayName', () => {
+  it('prefers meta.templateName over title', () => {
+    expect(
+      templateDisplayName({ title: 'Draft title', meta: { templateName: 'Weekly report' } }),
+    ).toBe('Weekly report');
+  });
+
+  it('falls back to draft title', () => {
+    expect(templateDisplayName({ title: 'Draft title', meta: { postTemplate: true } })).toBe(
+      'Draft title',
+    );
+  });
+
+  it('returns empty string when neither is set', () => {
+    expect(templateDisplayName({ meta: {} })).toBe('');
+    expect(templateDisplayName({})).toBe('');
+    expect(templateDisplayName(null)).toBe('');
+    expect(templateDisplayName(undefined)).toBe('');
+  });
+});

--- a/src/utils/draftTemplates.ts
+++ b/src/utils/draftTemplates.ts
@@ -1,0 +1,7 @@
+// Post templates are ordinary private-api drafts flagged with meta.postTemplate (created on
+// Ecency web); meta.templateName carries the template label.
+
+export const isTemplateDraft = (draft: any): boolean => !!draft?.meta?.postTemplate;
+
+export const templateDisplayName = (draft: any): string =>
+  draft?.meta?.templateName || draft?.title || '';


### PR DESCRIPTION
Mobile counterpart of ecency/vision-next#1079. Post templates are drafts carrying `meta.postTemplate: true` and `meta.templateName`; without this change they show up as ordinary drafts in the app.

## What
- Drafts screen gains a third Templates tab (shares the drafts query; items split by the new `isTemplateDraft` helper). The regular drafts tab no longer shows templates.
- Tapping a template opens the editor hydrated from it as a NEW post: title/body/tags/meta applied, template markers stripped, no draftId so the first save creates a fresh draft. Beneficiaries and poll land under the default new-post key. The recent-draft comparison offer also excludes templates.
- Deleting uses the existing draft delete flow (confirm dialog with template wording, long-press batch delete included). Clone is hidden for templates.
- Empty lists never fire onEndReached, so the container auto-fetches ahead while either split list is empty, bounded to 5 pages.

## Notes
- v1 has no save-as-template on mobile; templates are created on web.
- New unit tests for the helper; full suite passes (30 suites / 507 tests), eslint delta clean on changed files.