### PR TITLE
Add compose-side translation to editor

### DIFF
--- a/src/components/composeTranslateModal/composeTranslateModal.styles.ts
+++ b/src/components/composeTranslateModal/composeTranslateModal.styles.ts
@@ -1,0 +1,144 @@
+import { TextStyle, ViewStyle } from 'react-native';
+import EStyleSheet from 'react-native-extended-stylesheet';
+
+export default EStyleSheet.create({
+  sheetContent: {
+    backgroundColor: '$primaryBackgroundColor',
+  } as ViewStyle,
+
+  indicator: {
+    backgroundColor: '$iconColor',
+  } as ViewStyle,
+
+  contentContainer: {
+    paddingHorizontal: 16,
+    paddingBottom: 40,
+  } as ViewStyle,
+
+  hintText: {
+    fontSize: 12,
+    color: '$iconColor',
+    marginBottom: 12,
+    lineHeight: 18,
+  } as TextStyle,
+
+  labelsRow: {
+    flexDirection: 'row',
+    marginBottom: 6,
+  } as ViewStyle,
+
+  dropdownLabel: {
+    flex: 1,
+    fontSize: 12,
+    fontWeight: '600',
+    color: '$primaryDarkGray',
+    textAlign: 'center',
+  } as TextStyle,
+
+  languageSelectorRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    height: 60,
+    backgroundColor: '$primaryLightBackground',
+    borderRadius: 16,
+  } as ViewStyle,
+
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    flex: 1,
+  } as ViewStyle,
+
+  convertIcon: {
+    color: '$iconColor',
+  } as TextStyle,
+
+  dropdownRowTextStyle: {
+    color: '$primaryBlack',
+    fontSize: 14,
+  } as TextStyle,
+
+  detectedText: {
+    fontSize: 12,
+    color: '$iconColor',
+    marginTop: 8,
+  } as TextStyle,
+
+  checkboxRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginTop: 16,
+  } as ViewStyle,
+
+  checkboxLabel: {
+    fontSize: 14,
+    color: '$primaryBlack',
+    marginLeft: 8,
+    flex: 1,
+  } as TextStyle,
+
+  progressRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 10,
+    padding: 16,
+  } as ViewStyle,
+
+  progressText: {
+    fontSize: 13,
+    color: '$primaryBlack',
+  } as TextStyle,
+
+  errorText: {
+    fontSize: 12,
+    color: '$primaryRed',
+    marginTop: 12,
+  } as TextStyle,
+
+  previewBox: {
+    borderWidth: 1,
+    borderColor: '$primaryLightBackground',
+    borderRadius: 10,
+    padding: 14,
+    maxHeight: 300,
+    marginTop: 16,
+  } as ViewStyle,
+
+  previewText: {
+    fontSize: 14,
+    color: '$primaryBlack',
+    lineHeight: 20,
+  } as TextStyle,
+
+  previewTextRtl: {
+    writingDirection: 'rtl',
+    textAlign: 'right',
+  } as TextStyle,
+
+  buttonsRow: {
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+    gap: 8,
+    marginTop: 16,
+  } as ViewStyle,
+
+  actionButton: {
+    borderRadius: 8,
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    backgroundColor: '$primaryBlue',
+  } as ViewStyle,
+
+  actionButtonDisabled: {
+    opacity: 0.5,
+  } as ViewStyle,
+
+  actionButtonText: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: '$white',
+  } as TextStyle,
+});

--- a/src/components/composeTranslateModal/composeTranslateModal.tsx
+++ b/src/components/composeTranslateModal/composeTranslateModal.tsx
@@ -1,0 +1,324 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  ActivityIndicator,
+  Platform,
+  ScrollView,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { useIntl } from 'react-intl';
+import ActionSheet, { SheetManager, SheetProps } from 'react-native-actions-sheet';
+import { postBodySummary } from '@ecency/render-helper';
+import { CheckBox, DropdownButton, Icon, ModalHeader } from '..';
+import { translateMarkdown } from '../../providers/translation/translateMarkdown';
+import { useAppSelector } from '../../hooks';
+import { selectLanguage } from '../../redux/selectors';
+import {
+  francToIso1,
+  isRtlLang,
+  languageDisplayName,
+  LIBRETRANSLATE_CODES,
+  LIBRETRANSLATE_SOURCES,
+  LIBRETRANSLATE_TARGETS,
+  normLang,
+} from '../../utils/iso639';
+import { SheetNames } from '../../navigation/sheets';
+import styles from './composeTranslateModal.styles';
+
+// Same sampling bounds as the reader-side language gate: a few hundred clean
+// chars are plenty for franc, and rendering a whole long draft would be waste.
+const SAMPLE_CHARS = 600;
+const RAW_SAMPLE_CHARS = 2000;
+// Below this much plain text detection is unreliable and translating is moot.
+const MIN_TRANSLATE_CHARS = 30;
+const TITLE_MAX_CHARS = 255;
+
+/**
+ * Compose-side translate sheet: detects the language of the author's own draft,
+ * lets them pick a target, machine-translates the markdown structure-aware and
+ * previews the result. Apply hands the caller an appendix (`---` + heading +
+ * translation) and an optional title marker; nothing is published here.
+ */
+export const ComposeTranslateModal = ({ payload }: SheetProps<SheetNames.COMPOSE_TRANSLATE>) => {
+  const intl = useIntl();
+  const appLang = useAppSelector(selectLanguage);
+
+  const body = payload?.body ?? '';
+  const title = payload?.title ?? '';
+
+  const [source, setSource] = useState('en');
+  const [target, setTarget] = useState('es');
+  const [detected, setDetected] = useState('');
+  const [addTitleMarker, setAddTitleMarker] = useState(true);
+  const [translated, setTranslated] = useState('');
+  const [translating, setTranslating] = useState(false);
+  const [progress, setProgress] = useState<[number, number]>([0, 0]);
+  const [failed, setFailed] = useState(false);
+
+  // Sheets stay mounted; a closed sheet cancels the request chain so it stops
+  // hitting the translation service in the background.
+  const closedRef = useRef(false);
+
+  const sample = useMemo(
+    () =>
+      body
+        ? postBodySummary(body.slice(0, RAW_SAMPLE_CHARS), 0, Platform.OS as any).slice(
+            0,
+            SAMPLE_CHARS,
+          )
+        : '',
+    [body],
+  );
+  const tooShort = sample.trim().length < MIN_TRANSLATE_CHARS;
+
+  // Reset state and re-detect the source language on every open (payload is a
+  // fresh object per SheetManager.show).
+  useEffect(() => {
+    closedRef.current = false;
+    setTranslated('');
+    setFailed(false);
+    setTranslating(false);
+    setProgress([0, 0]);
+    setAddTitleMarker(true);
+    setDetected('');
+    let lang = 'en';
+    if (sample.trim().length >= MIN_TRANSLATE_CHARS) {
+      try {
+        // franc-min@5 is CommonJS; its default export is the detector function.
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        const franc = require('franc-min');
+        const guess = francToIso1(franc(sample));
+        if (guess && LIBRETRANSLATE_SOURCES.has(guess)) {
+          lang = guess;
+          setDetected(guess);
+        }
+      } catch {
+        // Detector unavailable — keep the default, the user can pick manually.
+      }
+    }
+    setSource(lang);
+  }, [payload, sample]);
+
+  // Non-English drafts almost always want English; English drafts target the
+  // app language when supported, otherwise Spanish.
+  useEffect(() => {
+    if (source !== 'en') {
+      setTarget('en');
+      return;
+    }
+    const reader = normLang(appLang);
+    setTarget(reader && reader !== 'en' && LIBRETRANSLATE_TARGETS.has(reader) ? reader : 'es');
+  }, [source, appLang]);
+
+  // A result translated into a previous language pair must never be applied.
+  useEffect(() => {
+    setTranslated('');
+    setFailed(false);
+  }, [source, target]);
+
+  const sourceOptions = useMemo(
+    () => LIBRETRANSLATE_CODES.map((code) => languageDisplayName(code)),
+    [],
+  );
+  const targetCodes = useMemo(
+    () => LIBRETRANSLATE_CODES.filter((code) => code !== source),
+    [source],
+  );
+  const targetOptions = useMemo(
+    () => targetCodes.map((code) => languageDisplayName(code)),
+    [targetCodes],
+  );
+
+  const _translate = async () => {
+    setTranslating(true);
+    setFailed(false);
+    setTranslated('');
+    setProgress([0, 0]);
+    try {
+      const result = await translateMarkdown(
+        body,
+        source,
+        target,
+        (done, total) => setProgress([done, total]),
+        () => closedRef.current,
+      );
+      setTranslated(result);
+    } catch (error) {
+      console.log('translate error : ', error);
+      if (!closedRef.current) {
+        setFailed(true);
+      }
+    } finally {
+      if (!closedRef.current) {
+        setTranslating(false);
+      }
+    }
+  };
+
+  const _apply = () => {
+    if (!translated) {
+      return;
+    }
+    const appendix = `\n\n---\n\n## ${languageDisplayName(target, target)}\n\n${translated}`;
+    let titleMarker: string | undefined;
+    if (addTitleMarker && title.trim()) {
+      const marker = ` [${source.toUpperCase()} | ${target.toUpperCase()}]`;
+      if (title.length + marker.length <= TITLE_MAX_CHARS) {
+        titleMarker = marker;
+      }
+    }
+    SheetManager.hide(SheetNames.COMPOSE_TRANSLATE);
+    payload?.onApply(appendix, titleMarker);
+  };
+
+  const _handleOnSheetClose = () => {
+    closedRef.current = true;
+    setTranslating(false);
+  };
+
+  const _renderLanguageSelector = () => (
+    <>
+      <View style={styles.labelsRow}>
+        <Text style={styles.dropdownLabel}>
+          {intl.formatMessage({ id: 'compose_translate.source' })}
+        </Text>
+        <Text style={styles.dropdownLabel}>
+          {intl.formatMessage({ id: 'compose_translate.target' })}
+        </Text>
+      </View>
+      <View style={styles.languageSelectorRow}>
+        <View style={styles.row}>
+          <DropdownButton
+            defaultText={languageDisplayName(source)}
+            isHasChildIcon
+            noHighlight
+            onSelect={(index) => setSource(LIBRETRANSLATE_CODES[index])}
+            options={sourceOptions}
+            textStyle={styles.dropdownRowTextStyle}
+            disableFrameAdjustment={true}
+          />
+        </View>
+
+        <Icon iconType="MaterialIcons" name="translate" style={styles.convertIcon} size={24} />
+        <Icon iconType="MaterialIcons" name="arrow-forward" style={styles.convertIcon} size={16} />
+
+        <View style={styles.row}>
+          <DropdownButton
+            defaultText={languageDisplayName(target)}
+            isHasChildIcon
+            noHighlight
+            onSelect={(index) => setTarget(targetCodes[index])}
+            options={targetOptions}
+            textStyle={styles.dropdownRowTextStyle}
+            disableFrameAdjustment={true}
+          />
+        </View>
+      </View>
+    </>
+  );
+
+  const _renderForm = () => (
+    <>
+      <Text style={styles.hintText}>
+        {intl.formatMessage({ id: 'compose_translate.review_note' })}
+      </Text>
+
+      {_renderLanguageSelector()}
+
+      {!!detected && (
+        <Text style={styles.detectedText}>
+          {intl.formatMessage(
+            { id: 'compose_translate.detected' },
+            { lang: languageDisplayName(detected) },
+          )}
+        </Text>
+      )}
+
+      {!!title.trim() && (
+        <View style={styles.checkboxRow}>
+          <CheckBox
+            isChecked={addTitleMarker}
+            clicked={(_val, checked) => setAddTitleMarker(checked)}
+            value="title_marker"
+          />
+          <Text style={styles.checkboxLabel} onPress={() => setAddTitleMarker(!addTitleMarker)}>
+            {intl.formatMessage({ id: 'compose_translate.add_title_marker' })}
+          </Text>
+        </View>
+      )}
+
+      {translating && (
+        <View style={styles.progressRow}>
+          <ActivityIndicator />
+          {progress[1] > 0 && (
+            <Text style={styles.progressText}>
+              {intl.formatMessage(
+                { id: 'compose_translate.progress' },
+                { done: progress[0], total: progress[1] },
+              )}
+            </Text>
+          )}
+        </View>
+      )}
+
+      {failed && (
+        <Text style={styles.errorText}>
+          {intl.formatMessage({ id: 'compose_translate.error' })}
+        </Text>
+      )}
+
+      {!!translated && !translating && (
+        <ScrollView style={styles.previewBox} nestedScrollEnabled>
+          <Text style={[styles.previewText, isRtlLang(target) && styles.previewTextRtl]}>
+            {translated}
+          </Text>
+        </ScrollView>
+      )}
+
+      <View style={styles.buttonsRow}>
+        <TouchableOpacity
+          style={[styles.actionButton, translating && styles.actionButtonDisabled]}
+          onPress={_translate}
+          disabled={translating}
+          activeOpacity={0.7}
+        >
+          <Text style={styles.actionButtonText}>
+            {intl.formatMessage({ id: 'compose_translate.translate' })}
+          </Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={[styles.actionButton, (!translated || translating) && styles.actionButtonDisabled]}
+          onPress={_apply}
+          disabled={!translated || translating}
+          activeOpacity={0.7}
+        >
+          <Text style={styles.actionButtonText}>
+            {intl.formatMessage({ id: 'compose_translate.apply' })}
+          </Text>
+        </TouchableOpacity>
+      </View>
+    </>
+  );
+
+  return (
+    <ActionSheet
+      id={SheetNames.COMPOSE_TRANSLATE}
+      gestureEnabled={true}
+      containerStyle={styles.sheetContent}
+      indicatorStyle={styles.indicator}
+      onClose={_handleOnSheetClose}
+    >
+      <ModalHeader title={intl.formatMessage({ id: 'compose_translate.title' })} />
+      <View style={styles.contentContainer}>
+        {tooShort ? (
+          <Text style={styles.hintText}>
+            {intl.formatMessage({ id: 'compose_translate.too_short' })}
+          </Text>
+        ) : (
+          _renderForm()
+        )}
+      </View>
+    </ActionSheet>
+  );
+};

--- a/src/components/composeTranslateModal/index.ts
+++ b/src/components/composeTranslateModal/index.ts
@@ -1,0 +1,1 @@
+export { ComposeTranslateModal } from './composeTranslateModal';

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -117,6 +117,7 @@ import { WalkthroughMarker } from './walkthroughMarker';
 import { LinkPreview, HiveLinkPreview } from './linkPreview';
 import { CrossPostModal } from './crossPostModal';
 import { AiAssistModal } from './aiAssistModal';
+import { ComposeTranslateModal } from './composeTranslateModal';
 import { ChatOptionsSheet } from './chatOptionsSheet';
 import { ChatChannelOptionsSheet } from './chatChannelOptionsSheet';
 import { TTSControls } from './textToSpeech/ttsControls';
@@ -296,6 +297,7 @@ export {
   HiveLinkPreview,
   CrossPostModal,
   AiAssistModal,
+  ComposeTranslateModal,
   CopyModal,
   ChatOptionsSheet,
   ChatChannelOptionsSheet,

--- a/src/components/markdownEditor/children/editorToolbar.tsx
+++ b/src/components/markdownEditor/children/editorToolbar.tsx
@@ -57,6 +57,7 @@ type Props = {
   handleOnMarkupButtonPress: (item) => void;
   handleShowSnippets: () => void;
   handleAiAssistResult?: (output: string, action: string) => void;
+  handleShowTranslate?: () => void;
 };
 
 export const EditorToolbar = ({
@@ -74,6 +75,7 @@ export const EditorToolbar = ({
   handleOnMarkupButtonPress,
   handleShowSnippets,
   handleAiAssistResult,
+  handleShowTranslate,
 }: Props) => {
   const navigation = useNavigation();
   const insets = useSafeAreaInsets();
@@ -465,6 +467,16 @@ export const EditorToolbar = ({
               badgeCount="AI"
               badgeStyle={styles.aiBadge}
               badgeTextStyle={styles.aiBadgeText}
+            />
+            <IconButton
+              onPress={() => {
+                handleShowTranslate && handleShowTranslate();
+              }}
+              style={styles.rightIcons}
+              size={18}
+              iconStyle={styles.icon}
+              iconType="MaterialIcons"
+              name="translate"
             />
             <IconButton
               onPress={_showVideoUploads}

--- a/src/components/markdownEditor/view/markdownEditorView.tsx
+++ b/src/components/markdownEditor/view/markdownEditorView.tsx
@@ -381,6 +381,29 @@ const MarkdownEditorView = ({
     [_setTextAndSelection, onTitleChanged, onTagChanged],
   );
 
+  // Compose-side translation: the sheet builds an appendix from the current
+  // body and hands it back here, where it is appended through the same
+  // programmatic write the AI assist result uses.
+  const _showTranslateModal = () => {
+    const currentTitle = fields?.title ?? '';
+    SheetManager.show(SheetNames.COMPOSE_TRANSLATE, {
+      payload: {
+        body: bodyTextRef.current,
+        title: currentTitle,
+        onApply: (appendix: string, titleMarker?: string) => {
+          const newBody = `${bodyTextRef.current}${appendix}`;
+          _setTextAndSelection({
+            text: newBody,
+            selection: { start: newBody.length, end: newBody.length },
+          });
+          if (titleMarker) {
+            onTitleChanged?.(`${currentTitle}${titleMarker}`);
+          }
+        },
+      },
+    });
+  };
+
   const _renderFloatingDraftButton = () => {
     if (showDraftLoadButton) {
       const _onPress = () => {
@@ -505,6 +528,7 @@ const MarkdownEditorView = ({
           handleShowSnippets={() => setIsSnippetsOpen(true)}
           handleOnClearPress={() => clearRef.current.show()}
           handleAiAssistResult={_handleAiAssistResult}
+          handleShowTranslate={_showTranslateModal}
           handleOnMarkupButtonPress={(item) => {
             item.onPress({
               text: bodyTextRef.current,

--- a/src/config/locales/en-US.json
+++ b/src/config/locales/en-US.json
@@ -214,6 +214,19 @@
     "translated_from": "Translated from {lang}",
     "change_language": "Change language"
   },
+  "compose_translate": {
+    "title": "Translate post",
+    "source": "Source language",
+    "target": "Target language",
+    "detected": "Detected: {lang}",
+    "translate": "Translate",
+    "apply": "Apply",
+    "review_note": "Adds a machine translation of your own writing to the end of the post. Review and edit before publishing.",
+    "too_short": "Write a bit more first. Translation needs at least a few sentences.",
+    "progress": "Translating {done} of {total}...",
+    "error": "Translation failed. Please try again.",
+    "add_title_marker": "Add language marker to title"
+  },
   "side_menu": {
     "profile": "Profile",
     "add_account": "Add Account",

--- a/src/navigation/sheets.tsx
+++ b/src/navigation/sheets.tsx
@@ -15,6 +15,7 @@ import {
   EmojiPickerSheet,
   AuthUpgradeSheet,
   AiAssistModal,
+  ComposeTranslateModal,
   TransferFavoritesSheet,
 } from '../components';
 import { ShareIntentSheet } from '../components/shareIntentSheet';
@@ -42,6 +43,7 @@ export enum SheetNames {
   EMOJI_PICKER = 'emoji_picker',
   AUTH_UPGRADE = 'auth_upgrade',
   AI_ASSIST = 'ai_assist',
+  COMPOSE_TRANSLATE = 'compose_translate',
   SHARE_INTENT = 'share_intent',
   SIGN_CONFIRM = 'sign_confirm',
   RECEIVE_QR = 'receive_qr',
@@ -65,6 +67,7 @@ registerSheet(SheetNames.HIVE_AUTH_BROADCAST, HiveAuthBroadcastSheet);
 registerSheet(SheetNames.EMOJI_PICKER, EmojiPickerSheet);
 registerSheet(SheetNames.AUTH_UPGRADE, AuthUpgradeSheet);
 registerSheet(SheetNames.AI_ASSIST, AiAssistModal);
+registerSheet(SheetNames.COMPOSE_TRANSLATE, ComposeTranslateModal);
 registerSheet(SheetNames.SHARE_INTENT, ShareIntentSheet);
 registerSheet(SheetNames.SIGN_CONFIRM, SignConfirmSheet);
 registerSheet(SheetNames.RECEIVE_QR, ReceiveQrSheet);
@@ -188,6 +191,13 @@ declare module 'react-native-actions-sheet' {
         text: string;
         onApply?: (output: string, action: string) => void;
         supportedActions?: string[];
+      };
+    }>;
+    [SheetNames.COMPOSE_TRANSLATE]: SheetDefinition<{
+      payload: {
+        body: string;
+        title?: string;
+        onApply: (appendix: string, titleMarker?: string) => void;
       };
     }>;
     [SheetNames.SIGN_CONFIRM]: SheetDefinition<{

--- a/src/providers/translation/translateMarkdown.test.ts
+++ b/src/providers/translation/translateMarkdown.test.ts
@@ -290,4 +290,18 @@ describe('translateMarkdown', () => {
       ].join('\n\n'),
     );
   });
+  it('still skips a real GFM table (separator directly under the header row)', async () => {
+    const table = '| a | b |\n|---|---|\n| 1 | 2 |';
+    const result = await translateMarkdown(`Intro.\n\n${table}`, 'es', 'en');
+
+    expect(result).toBe(`\u00abIntro.\u00bb\n\n${table}`);
+  });
+
+  it('translates prose containing pipes and a stray separator-like line', async () => {
+    const block = 'El valor |x| es absoluto\nnota al margen\n|---|';
+    const result = await translateMarkdown(block, 'es', 'en');
+
+    expect(result).toContain('\u00ab');
+    expect(mockedPost).toHaveBeenCalled();
+  });
 });

--- a/src/providers/translation/translateMarkdown.test.ts
+++ b/src/providers/translation/translateMarkdown.test.ts
@@ -1,0 +1,293 @@
+import { translateMarkdown } from './translateMarkdown';
+import translationApi from '../../config/translationApi';
+
+jest.mock('../../config/translationApi', () => ({
+  __esModule: true,
+  default: { post: jest.fn(), get: jest.fn() },
+}));
+jest.mock('@sentry/react-native', () => ({ captureException: jest.fn() }));
+
+const mockedPost = translationApi.post as jest.Mock;
+
+// Reversible fake: every request comes back wrapped in «…» so tests can assert
+// both that a piece of text was translated and that its position/markers were
+// left intact.
+const wrap = (text: string) => `«${text}»`;
+
+beforeEach(() => {
+  mockedPost.mockReset();
+  mockedPost.mockImplementation((_url: string, body: { q: string }) =>
+    Promise.resolve({ data: { translatedText: wrap(body.q) } }),
+  );
+});
+
+describe('translateMarkdown', () => {
+  it('translates plain paragraphs and rejoins them with blank lines', async () => {
+    const result = await translateMarkdown('First paragraph.\n\nSecond paragraph.', 'es', 'en');
+
+    expect(result).toBe(wrap('First paragraph.\n\nSecond paragraph.'));
+  });
+
+  it('batches consecutive plain paragraphs into a single request', async () => {
+    await translateMarkdown('First paragraph.\n\nSecond paragraph.', 'es', 'en');
+
+    expect(mockedPost).toHaveBeenCalledTimes(1);
+    expect(mockedPost.mock.calls[0][1].q).toBe('First paragraph.\n\nSecond paragraph.');
+  });
+
+  it('returns empty/whitespace-only input unchanged without any request', async () => {
+    expect(await translateMarkdown('', 'es', 'en')).toBe('');
+    expect(await translateMarkdown('   \n\n  ', 'es', 'en')).toBe('   \n\n  ');
+    expect(mockedPost).not.toHaveBeenCalled();
+  });
+
+  it('passes fenced code blocks through untouched, including inner blank lines', async () => {
+    const fence = '```js\nconst a = 1;\n\nconst b = 2;\n```';
+    const result = await translateMarkdown(`Intro.\n\n${fence}\n\nOutro.`, 'es', 'en');
+
+    expect(result).toBe(`${wrap('Intro.')}\n\n${fence}\n\n${wrap('Outro.')}`);
+    // The fence must break batching: intro and outro are separate requests.
+    expect(mockedPost).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps an unclosed fence at the end of the document untouched', async () => {
+    const result = await translateMarkdown('Text.\n\n```py\nx = 1', 'es', 'en');
+
+    expect(result).toBe(`${wrap('Text.')}\n\n\`\`\`py\nx = 1`);
+  });
+
+  it('treats a fence directly under a heading as its own block', async () => {
+    const result = await translateMarkdown('## Setup\n```bash\nnpm i\n```', 'es', 'en');
+
+    expect(result).toBe(`## ${wrap('Setup')}\n\n\`\`\`bash\nnpm i\n\`\`\``);
+  });
+
+  it('skips image-only blocks but translates a paragraph containing an image line', async () => {
+    const result = await translateMarkdown(
+      [
+        'Hello.',
+        '![alt](https://images.ecency.com/pic.png)',
+        'Look:\n![inline](https://x/y.png)\nWhat a view.',
+      ].join('\n\n'),
+      'es',
+      'en',
+    );
+
+    expect(result).toBe(
+      [
+        wrap('Hello.'),
+        '![alt](https://images.ecency.com/pic.png)',
+        wrap('Look:\n![inline](https://x/y.png)\nWhat a view.'),
+      ].join('\n\n'),
+    );
+  });
+
+  it('skips a block of stacked image lines', async () => {
+    const images = '![one](https://x/1.png)\n![two](https://x/2.png)';
+    const result = await translateMarkdown(`Intro.\n\n${images}`, 'es', 'en');
+
+    expect(result).toBe(`${wrap('Intro.')}\n\n${images}`);
+  });
+
+  it('skips tables entirely', async () => {
+    const table = '| Name | Age |\n| --- | --- |\n| Ana | 30 |';
+    const result = await translateMarkdown(`Intro.\n\n${table}\n\nOutro.`, 'es', 'en');
+
+    expect(result).toBe(`${wrap('Intro.')}\n\n${table}\n\n${wrap('Outro.')}`);
+  });
+
+  it('skips raw HTML blocks', async () => {
+    const html = '<div class="pull-left">\nHola\n</div>';
+    const result = await translateMarkdown(`Intro.\n\n${html}\n\nOutro.`, 'es', 'en');
+
+    expect(result).toBe(`${wrap('Intro.')}\n\n${html}\n\n${wrap('Outro.')}`);
+  });
+
+  it('skips horizontal rules and URL-only lines, never batching across them', async () => {
+    const result = await translateMarkdown(
+      'One.\n\n---\n\nTwo.\n\nhttps://example.com/page\n\nThree.',
+      'es',
+      'en',
+    );
+
+    expect(result).toBe(
+      [wrap('One.'), '---', wrap('Two.'), 'https://example.com/page', wrap('Three.')].join('\n\n'),
+    );
+    expect(mockedPost).toHaveBeenCalledTimes(3);
+  });
+
+  it('keeps spaced horizontal rules like * * * untouched', async () => {
+    const result = await translateMarkdown('One.\n\n* * *\n\nTwo.', 'es', 'en');
+
+    expect(result).toBe(`${wrap('One.')}\n\n* * *\n\n${wrap('Two.')}`);
+  });
+
+  it('preserves heading markers and translates only the heading text', async () => {
+    const result = await translateMarkdown('# Mi viaje\n\n### Otro dia', 'es', 'en');
+
+    expect(result).toBe(`# ${wrap('Mi viaje')}\n\n### ${wrap('Otro dia')}`);
+  });
+
+  it('preserves quote and list markers line by line', async () => {
+    const result = await translateMarkdown(
+      '> una cita\n\n- primero\n- segundo\n\n1. uno\n2. dos',
+      'es',
+      'en',
+    );
+
+    expect(result).toBe(
+      [
+        `> ${wrap('una cita')}`,
+        `- ${wrap('primero')}\n- ${wrap('segundo')}`,
+        `1. ${wrap('uno')}\n2. ${wrap('dos')}`,
+      ].join('\n\n'),
+    );
+  });
+
+  it('preserves nested list markers with their indentation', async () => {
+    const result = await translateMarkdown('- parent\n  - child\n    1. deep', 'es', 'en');
+
+    expect(result).toBe(`- ${wrap('parent')}\n  - ${wrap('child')}\n    1. ${wrap('deep')}`);
+  });
+
+  it('preserves leading indentation on marker-less continuation lines', async () => {
+    const result = await translateMarkdown('- item uno\n    continua aqui', 'es', 'en');
+
+    expect(result).toBe(`- ${wrap('item uno')}\n    ${wrap('continua aqui')}`);
+  });
+
+  it('keeps image and URL lines inside a list untouched', async () => {
+    const result = await translateMarkdown(
+      '- texto\n- ![pic](https://x/1.png)\n- https://example.com',
+      'es',
+      'en',
+    );
+
+    expect(result).toBe(`- ${wrap('texto')}\n- ![pic](https://x/1.png)\n- https://example.com`);
+    expect(mockedPost).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps a marker-only line as-is instead of sending an empty request', async () => {
+    const result = await translateMarkdown('> \n> cita', 'es', 'en');
+
+    expect(result).toBe(`> \n> ${wrap('cita')}`);
+    expect(mockedPost).toHaveBeenCalledTimes(1);
+  });
+
+  it('splits batches once they exceed the size limit', async () => {
+    const blockA = 'a'.repeat(900);
+    const blockB = 'b'.repeat(900);
+    await translateMarkdown(`${blockA}\n\n${blockB}`, 'es', 'en');
+
+    expect(mockedPost).toHaveBeenCalledTimes(2);
+    expect(mockedPost.mock.calls[0][1].q).toBe(blockA);
+    expect(mockedPost.mock.calls[1][1].q).toBe(blockB);
+  });
+
+  it('chunks a single oversized paragraph instead of sending one huge request', async () => {
+    const words = Array.from({ length: 400 }, (_, i) => `palabra${i}`).join(' ');
+    await translateMarkdown(words, 'es', 'en');
+
+    expect(mockedPost.mock.calls.length).toBeGreaterThan(1);
+    mockedPost.mock.calls.forEach(([, body]) => expect(body.q.length).toBeLessThanOrEqual(1500));
+  });
+
+  it('chunks a single overlong marked line into multiple requests', async () => {
+    const long = Array.from({ length: 200 }, (_, i) => `palabra${i}`).join(' ');
+    const result = await translateMarkdown(`- ${long}`, 'es', 'en');
+
+    expect(mockedPost.mock.calls.length).toBeGreaterThan(1);
+    expect(result.startsWith('- ')).toBe(true);
+    // Stripping the wrap markers must restore the original text: no words may
+    // be lost or duplicated at chunk boundaries.
+    expect(result.slice(2).replace(/[«»]/g, '')).toBe(long);
+  });
+
+  it('keeps emoji out of the request and re-attaches them to the result', async () => {
+    const result = await translateMarkdown('Hola amigos 😊', 'es', 'en');
+
+    expect(mockedPost.mock.calls[0][1].q).toBe('Hola amigos');
+    expect(result).toBe(`${wrap('Hola amigos')} 😊`);
+  });
+
+  it('normalizes CRLF input', async () => {
+    const result = await translateMarkdown('First.\r\n\r\nSecond.', 'es', 'en');
+
+    expect(result).toBe(wrap('First.\n\nSecond.'));
+  });
+
+  it('tolerates trailing whitespace without emitting empty blocks', async () => {
+    const result = await translateMarkdown('Hola mundo.   \n\n', 'es', 'en');
+
+    expect(result).toBe(wrap('Hola mundo.   '));
+  });
+
+  it('reports progress per request, starting at zero', async () => {
+    const onProgress = jest.fn();
+    await translateMarkdown('One.\n\n---\n\nTwo.\n\n---\n\nThree.', 'es', 'en', onProgress);
+
+    expect(onProgress.mock.calls).toEqual([
+      [0, 3],
+      [1, 3],
+      [2, 3],
+      [3, 3],
+    ]);
+  });
+
+  it('rejects on any request failure instead of returning a partial result', async () => {
+    mockedPost
+      .mockImplementationOnce((_url: string, body: { q: string }) =>
+        Promise.resolve({ data: { translatedText: wrap(body.q) } }),
+      )
+      .mockRejectedValueOnce(new Error('boom'));
+
+    await expect(
+      translateMarkdown('One.\n\n---\n\nTwo.\n\n---\n\nThree.', 'es', 'en'),
+    ).rejects.toThrow('boom');
+  });
+
+  it('stops issuing requests once cancelled', async () => {
+    let calls = 0;
+    mockedPost.mockImplementation((_url: string, body: { q: string }) => {
+      calls += 1;
+      return Promise.resolve({ data: { translatedText: wrap(body.q) } });
+    });
+
+    await expect(
+      translateMarkdown(
+        'One.\n\n---\n\nTwo.\n\n---\n\nThree.',
+        'es',
+        'en',
+        undefined,
+        () => calls >= 1,
+      ),
+    ).rejects.toThrow('translate-cancelled');
+    expect(calls).toBe(1);
+  });
+
+  it('handles a mixed document end to end', async () => {
+    const input = [
+      '# Titulo',
+      'Un parrafo con texto.',
+      '```\ncode\n\nmore code\n```',
+      '> cita famosa',
+      '| a | b |\n|---|---|\n| 1 | 2 |',
+      '![foto](https://x/f.jpg)',
+      'Cierre.',
+    ].join('\n\n');
+
+    const result = await translateMarkdown(input, 'es', 'en');
+
+    expect(result).toBe(
+      [
+        `# ${wrap('Titulo')}`,
+        wrap('Un parrafo con texto.'),
+        '```\ncode\n\nmore code\n```',
+        `> ${wrap('cita famosa')}`,
+        '| a | b |\n|---|---|\n| 1 | 2 |',
+        '![foto](https://x/f.jpg)',
+        wrap('Cierre.'),
+      ].join('\n\n'),
+    );
+  });
+});

--- a/src/providers/translation/translateMarkdown.ts
+++ b/src/providers/translation/translateMarkdown.ts
@@ -1,0 +1,211 @@
+import { chunkText, getTranslation } from './translation';
+
+// Markdown-aware translation for the compose-side feature: only prose is sent
+// to LibreTranslate; code fences, images, tables, raw HTML, bare URLs and
+// horizontal rules pass through untouched, and heading/quote/list markers are
+// stripped before and re-attached after translation. Batches stay below the
+// long-text chunk limit since blocks are joined with blank lines.
+const MAX_BLOCK_BATCH_CHARS = 1500;
+
+const FENCE_LINE = /^\s*(`{3,}|~{3,})/;
+const IMAGE_ONLY_LINE = /^\s*!\[[^\]]*\]\([^)]*\)\s*$/;
+const HORIZONTAL_RULE_LINE = /^\s*([-*_][^\S\n]*){3,}$/;
+const URL_ONLY_LINE = /^\s*https?:\/\/\S+\s*$/;
+const TABLE_SEPARATOR_LINE = /^\s*[|:\s-]+\s*$/;
+// Leading line markers that must survive translation: headings, quotes and
+// list items, possibly nested ("  - ", "> > ").
+const LINE_MARKER_PREFIX = /^(\s*(?:(?:#{1,6}|>|[-*+]|\d+\.)\s+)+)/;
+
+/**
+ * Split markdown into blocks on blank lines, keeping fenced code regions
+ * together even when they contain blank lines. A fence directly under text
+ * (no separating blank line) still starts its own block so the surrounding
+ * prose can be translated without dragging the code along.
+ */
+const splitMarkdownBlocks = (markdown: string): string[] => {
+  const blocks: string[] = [];
+  let current: string[] = [];
+  let fence: string | null = null;
+
+  const flush = () => {
+    if (current.length > 0) {
+      blocks.push(current.join('\n'));
+      current = [];
+    }
+  };
+
+  markdown.split('\n').forEach((line) => {
+    const fenceMatch = line.match(FENCE_LINE);
+    if (fence) {
+      current.push(line);
+      if (fenceMatch && fenceMatch[1][0] === fence[0] && fenceMatch[1].length >= fence.length) {
+        fence = null;
+        flush();
+      }
+    } else if (fenceMatch) {
+      flush();
+      // eslint-disable-next-line prefer-destructuring
+      fence = fenceMatch[1];
+      current.push(line);
+    } else if (!line.trim()) {
+      flush();
+    } else {
+      current.push(line);
+    }
+  });
+  flush();
+  return blocks;
+};
+
+const isSkippableBlock = (block: string): boolean => {
+  if (FENCE_LINE.test(block) || /^\s*</.test(block)) {
+    return true;
+  }
+  const lines = block.split('\n');
+  if (
+    lines.every((line) => HORIZONTAL_RULE_LINE.test(line)) ||
+    lines.every((line) => IMAGE_ONLY_LINE.test(line)) ||
+    lines.every((line) => URL_ONLY_LINE.test(line))
+  ) {
+    return true;
+  }
+  // Tables: a pipe row plus a |---| separator row. Cell-safe translation is
+  // out of scope, so the whole block is passed through.
+  return (
+    lines.some((line) => line.includes('|')) &&
+    lines.some(
+      (line) => line.includes('|') && line.includes('-') && TABLE_SEPARATOR_LINE.test(line),
+    )
+  );
+};
+
+interface TranslateRequest {
+  text: string;
+  apply: (translated: string) => void;
+}
+
+/**
+ * Translate a markdown document while preserving its structure. Consecutive
+ * plain paragraphs are batched into one request (whole blocks only, never
+ * across skipped blocks); marker lines are translated line-wise with their
+ * prefix re-attached. Requests run sequentially and any failure rejects the
+ * whole call, so callers never apply a partially translated document.
+ */
+export const translateMarkdown = async (
+  markdown: string,
+  source: string,
+  target: string,
+  onProgress?: (done: number, total: number) => void,
+  isCancelled?: () => boolean,
+): Promise<string> => {
+  const normalized = markdown.replace(/\r\n?/g, '\n');
+  if (!normalized.trim()) {
+    return normalized;
+  }
+
+  const blocks = splitMarkdownBlocks(normalized);
+  const output: (string | null)[] = [...blocks];
+  const requests: TranslateRequest[] = [];
+
+  let batchIndices: number[] = [];
+  let batchSize = 0;
+  const flushBatch = () => {
+    if (batchIndices.length === 0) {
+      return;
+    }
+    const indices = batchIndices;
+    requests.push({
+      text: indices.map((i) => blocks[i]).join('\n\n'),
+      apply: (translated) => {
+        output[indices[0]] = translated;
+        indices.slice(1).forEach((i) => {
+          output[i] = null;
+        });
+      },
+    });
+    batchIndices = [];
+    batchSize = 0;
+  };
+
+  blocks.forEach((block, index) => {
+    if (isSkippableBlock(block)) {
+      flushBatch();
+      return;
+    }
+
+    const lines = block.split('\n');
+    if (lines.some((line) => LINE_MARKER_PREFIX.test(line))) {
+      flushBatch();
+      const translatedLines = [...lines];
+      lines.forEach((line, lineIndex) => {
+        const marker = line.match(LINE_MARKER_PREFIX);
+        // Marker-less continuation lines keep their leading indentation,
+        // which translation would otherwise strip.
+        const prefix = marker ? marker[1] : line.match(/^\s*/)?.[0] ?? '';
+        const rest = line.slice(prefix.length);
+        if (!rest.trim() || IMAGE_ONLY_LINE.test(rest) || URL_ONLY_LINE.test(rest)) {
+          return;
+        }
+        const chunks =
+          rest.length > MAX_BLOCK_BATCH_CHARS ? chunkText(rest, MAX_BLOCK_BATCH_CHARS) : [rest];
+        const parts: string[] = new Array(chunks.length).fill('');
+        chunks.forEach((chunk, chunkIndex) => {
+          requests.push({
+            text: chunk,
+            apply: (translated) => {
+              parts[chunkIndex] = translated;
+              translatedLines[lineIndex] = `${prefix}${parts.join(' ')}`;
+              output[index] = translatedLines.join('\n');
+            },
+          });
+        });
+      });
+      return;
+    }
+
+    if (block.length > MAX_BLOCK_BATCH_CHARS) {
+      flushBatch();
+      const chunks = chunkText(block, MAX_BLOCK_BATCH_CHARS);
+      const parts: string[] = new Array(chunks.length).fill('');
+      chunks.forEach((chunk, chunkIndex) => {
+        requests.push({
+          text: chunk,
+          apply: (translated) => {
+            parts[chunkIndex] = translated;
+            output[index] = parts.join(' ');
+          },
+        });
+      });
+      return;
+    }
+
+    if (batchIndices.length > 0 && batchSize + 2 + block.length > MAX_BLOCK_BATCH_CHARS) {
+      flushBatch();
+    }
+    batchSize += (batchIndices.length > 0 ? 2 : 0) + block.length;
+    batchIndices.push(index);
+  });
+  flushBatch();
+
+  if (requests.length === 0) {
+    return blocks.join('\n\n');
+  }
+
+  onProgress?.(0, requests.length);
+  let done = 0;
+  // Sequential on purpose: gentle on the shared LibreTranslate instance and
+  // keeps the progress counter meaningful.
+  // eslint-disable-next-line no-restricted-syntax
+  for (const request of requests) {
+    if (isCancelled?.()) {
+      throw new Error('translate-cancelled');
+    }
+    // eslint-disable-next-line no-await-in-loop
+    const { translatedText } = await getTranslation(request.text, source, target);
+    request.apply(translatedText);
+    done += 1;
+    onProgress?.(done, requests.length);
+  }
+
+  return output.filter((block): block is string => block !== null).join('\n\n');
+};

--- a/src/providers/translation/translateMarkdown.ts
+++ b/src/providers/translation/translateMarkdown.ts
@@ -69,13 +69,17 @@ const isSkippableBlock = (block: string): boolean => {
   ) {
     return true;
   }
-  // Tables: a pipe row plus a |---| separator row. Cell-safe translation is
-  // out of scope, so the whole block is passed through.
-  return (
-    lines.some((line) => line.includes('|')) &&
-    lines.some(
-      (line) => line.includes('|') && line.includes('-') && TABLE_SEPARATOR_LINE.test(line),
-    )
+  // Tables: a |---| separator row directly below a pipe row (the GFM shape).
+  // Cell-safe translation is out of scope, so the whole block is passed
+  // through; requiring adjacency keeps prose that merely contains pipe
+  // characters translatable.
+  return lines.some(
+    (line, i) =>
+      i > 0 &&
+      line.includes('|') &&
+      line.includes('-') &&
+      TABLE_SEPARATOR_LINE.test(line) &&
+      lines[i - 1].includes('|'),
   );
 };
 

--- a/src/providers/translation/translation.ts
+++ b/src/providers/translation/translation.ts
@@ -67,7 +67,7 @@ export const detectLanguage = async (text: string) => {
 
 const MAX_TRANSLATE_CHARS = 1800;
 
-const chunkText = (text: string, max: number): string[] => {
+export const chunkText = (text: string, max: number): string[] => {
   if (text.length <= max) {
     return [text];
   }

--- a/src/utils/iso639.test.ts
+++ b/src/utils/iso639.test.ts
@@ -114,4 +114,9 @@ describe('languageDisplayName', () => {
     expect(languageDisplayName('es')).toBe('Spanish');
     expect(languageDisplayName('zt').toLowerCase()).toContain('traditional');
   });
+
+  it('localizes the name when a UI language is passed', () => {
+    expect(languageDisplayName('es', 'es').toLowerCase()).toBe('español');
+    expect(languageDisplayName('de', 'de')).toBe('Deutsch');
+  });
 });

--- a/src/utils/iso639.ts
+++ b/src/utils/iso639.ts
@@ -213,23 +213,26 @@ const DISPLAY_NAME_FALLBACK: Record<string, string> = {
 /**
  * Human-readable language name. Prefers a static English label (Hermes lacks
  * reliable Intl.DisplayNames); falls back to Intl only when the map misses.
+ * When `uiLang` is passed the order flips: Intl is tried first so the name
+ * comes out localized (e.g. a target-language heading), with the static
+ * English label as the fallback.
  */
-export function languageDisplayName(code: string): string {
+export function languageDisplayName(code: string, uiLang?: string): string {
   const norm = normLang(code);
-  if (DISPLAY_NAME_FALLBACK[norm]) {
+  if (!uiLang && DISPLAY_NAME_FALLBACK[norm]) {
     return DISPLAY_NAME_FALLBACK[norm];
   }
   try {
     const AnyIntl = Intl as any;
     if (AnyIntl && typeof AnyIntl.DisplayNames === 'function') {
-      const dn = new AnyIntl.DisplayNames(['en'], { type: 'language' });
+      const dn = new AnyIntl.DisplayNames(uiLang ? [uiLang, 'en'] : ['en'], { type: 'language' });
       const name = dn.of(norm === 'zt' ? 'zh-Hant' : norm);
       if (name && name.toLowerCase() !== norm) {
-        return name;
+        return norm === 'zt' && uiLang ? `${name} (Traditional)` : name;
       }
     }
   } catch {
     // ignore
   }
-  return code;
+  return DISPLAY_NAME_FALLBACK[norm] ?? code;
 }


### PR DESCRIPTION
Mobile counterpart of ecency/vision-next#1080: a Translate action in the editor toolbar that machine-translates the author's own writing and appends it under a divider with a target-language heading, matching the common bilingual posting format.

## What
- New translate toolbar button opens a COMPOSE_TRANSLATE sheet: franc-based source detection (same sampling as the reader gate), source/target dropdowns from the LibreTranslate language list, progress indicator, preview with RTL support, and an optional `[ES | EN]` title marker (skipped when it would exceed the title limit).
- New `translateMarkdown` (ported from web) translates block-aware while preserving structure: code fences, images, tables, raw HTML, bare URLs and horizontal rules pass through untouched; heading/quote/list markers are re-attached; indented continuation lines keep their whitespace; plain blocks batch per request. Any failure rejects the whole run and closing the sheet cancels the request chain.
- Changing source or target clears a pending result so a translation can never be applied under the wrong language heading.
- Apply appends through the same programmatic write the AI assist flow uses; nothing auto-publishes.

## Notes
- Kept separate from the AI assist sheet since translation is unbilled (LibreTranslate) while AI assist is Points-priced.
- `languageDisplayName` gained an optional locale argument (1-arg behavior unchanged, covered by an added test).
- 28 new unit tests for the translator; scoped suites 46/46 green, full suite passes, eslint delta clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a translate-in-compose flow for drafts, including a new modal, toolbar action, translated preview, progress updates, and an option to apply the translated text back into the editor.
  * Added localized labels and messages for translation settings, detected language, errors, and publishing reminders.

* **Bug Fixes**
  * Improved markdown translation handling so formatting, code blocks, tables, images, and other special content are preserved more reliably.
  * Added localized language display names for more accurate language labeling in the UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->