### PR TITLE
Template creation on mobile and translate table-detection parity

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@babel/preset-typescript": "^7.26.0",
     "@babel/runtime": "^7.26.7",
     "@ecency/render-helper": "^2.5.17",
-    "@ecency/sdk": "^2.3.36",
+    "@ecency/sdk": "^2.3.37",
     "@esteemapp/react-native-autocomplete-input": "^4.2.1",
     "@esteemapp/react-native-multi-slider": "^1.1.0",
     "@native-html/iframe-plugin": "^2.6.1",

--- a/src/config/locales/en-US.json
+++ b/src/config/locales/en-US.json
@@ -343,9 +343,12 @@
   "templates": {
     "title": "Templates",
     "untitled": "Untitled template",
-    "empty_list": "Save a post as template on Ecency web to reuse it here.",
+    "empty_list": "Save a post as template from the editor to reuse it here.",
     "delete_confirm": "Are you sure you want to delete this template?",
-    "applied": "Template applied as new post"
+    "applied": "Template applied as new post",
+    "save_as_template": "Save as template",
+    "name_placeholder": "Template name",
+    "saved": "Template saved"
   },
   "selection_list": {
     "available": "Available {postfix}",

--- a/src/providers/translation/translateMarkdown.test.ts
+++ b/src/providers/translation/translateMarkdown.test.ts
@@ -304,4 +304,20 @@ describe('translateMarkdown', () => {
     expect(result).toContain('\u00ab');
     expect(mockedPost).toHaveBeenCalled();
   });
+
+  it('translates pipe prose directly above a separator when cell counts differ', async () => {
+    const block = 'El valor |x| es absoluto\n|---|';
+    const result = await translateMarkdown(block, 'es', 'en');
+
+    expect(result).toContain('\u00ab');
+    expect(mockedPost).toHaveBeenCalled();
+  });
+
+  it('still skips a borderless GFM table (header without outer pipes)', async () => {
+    const table = 'a | b\n--- | ---\n1 | 2';
+    const result = await translateMarkdown(table, 'es', 'en');
+
+    expect(result).toBe(table);
+    expect(mockedPost).not.toHaveBeenCalled();
+  });
 });

--- a/src/providers/translation/translateMarkdown.ts
+++ b/src/providers/translation/translateMarkdown.ts
@@ -57,6 +57,19 @@ const splitMarkdownBlocks = (markdown: string): string[] => {
   return blocks;
 };
 
+// Cell count of a table row: strip one leading and one trailing border pipe
+// (if present) and count the remaining "|"-separated segments.
+const countTableCells = (line: string): number => {
+  let trimmed = line.trim();
+  if (trimmed.startsWith('|')) {
+    trimmed = trimmed.slice(1);
+  }
+  if (trimmed.endsWith('|')) {
+    trimmed = trimmed.slice(0, -1);
+  }
+  return trimmed.split('|').length;
+};
+
 const isSkippableBlock = (block: string): boolean => {
   if (FENCE_LINE.test(block) || /^\s*</.test(block)) {
     return true;
@@ -69,17 +82,18 @@ const isSkippableBlock = (block: string): boolean => {
   ) {
     return true;
   }
-  // Tables: a |---| separator row directly below a pipe row (the GFM shape).
-  // Cell-safe translation is out of scope, so the whole block is passed
-  // through; requiring adjacency keeps prose that merely contains pipe
-  // characters translatable.
+  // Tables: a |---| separator row directly below a pipe row with the same
+  // cell count (the GFM shape). Cell-safe translation is out of scope, so the
+  // whole block is passed through; requiring adjacency plus matching cell
+  // counts keeps prose that merely contains pipe characters translatable.
   return lines.some(
     (line, i) =>
       i > 0 &&
       line.includes('|') &&
       line.includes('-') &&
       TABLE_SEPARATOR_LINE.test(line) &&
-      lines[i - 1].includes('|'),
+      lines[i - 1].includes('|') &&
+      countTableCells(lines[i - 1]) === countTableCells(line),
   );
 };
 

--- a/src/screens/editor/children/postOptionsModal.tsx
+++ b/src/screens/editor/children/postOptionsModal.tsx
@@ -52,12 +52,14 @@ interface PostOptionsModalProps {
   rewardType: string;
   postDescription: string;
   isUploading: boolean;
+  canSaveTemplate: boolean;
   handleRewardChange: (rewardType: string) => void;
   handlePostDescriptionChange: (value: string) => void;
   handleThumbSelection: (url: string) => void;
   handleScheduleChange: (datetime: string | null) => void;
   handleShouldReblogChange: (shouldReblog: boolean) => void;
   handleFormUpdate: () => void;
+  handleSaveTemplatePress: () => void;
 }
 
 const PostOptionsModal = forwardRef(
@@ -71,12 +73,14 @@ const PostOptionsModal = forwardRef(
       rewardType,
       postDescription,
       isUploading,
+      canSaveTemplate,
       handleRewardChange,
       handleThumbSelection,
       handleScheduleChange,
       handleShouldReblogChange,
       handleFormUpdate,
       handlePostDescriptionChange,
+      handleSaveTemplatePress,
     }: PostOptionsModalProps,
     ref,
   ) => {
@@ -158,6 +162,14 @@ const PostOptionsModal = forwardRef(
     // handle index change here instead of useeffetc
     const _handleThumbIndexSelection = (url: string) => {
       handleThumbSelection(url);
+    };
+
+    // close the options modal first; the parent then presents the template
+    // name prompt once this formSheet has dismissed
+    const _onSaveTemplatePress = () => {
+      setShowModal(false);
+      handleFormUpdate();
+      handleSaveTemplatePress();
     };
 
     // handle save default reward checkbox here
@@ -242,6 +254,19 @@ const PostOptionsModal = forwardRef(
                     actionType="reblog"
                     isOn={shouldReblog}
                     handleOnChange={setShouldReblog}
+                  />
+                )}
+                {canSaveTemplate && (
+                  <SettingsItem
+                    title={intl.formatMessage({
+                      id: 'templates.save_as_template',
+                    })}
+                    text={intl.formatMessage({
+                      id: 'beneficiary_modal.save',
+                    })}
+                    type="button"
+                    actionType="saveTemplate"
+                    handleOnButtonPress={_onSaveTemplatePress}
                   />
                 )}
               </>

--- a/src/screens/editor/children/saveTemplateModal.tsx
+++ b/src/screens/editor/children/saveTemplateModal.tsx
@@ -1,0 +1,83 @@
+import React, { forwardRef, useImperativeHandle, useState } from 'react';
+import { useIntl } from 'react-intl';
+import { Alert, View } from 'react-native';
+import { Modal, TextInput } from '../../../components';
+import { TextButton } from '../../../components/buttons';
+import { useAppSelector } from '../../../hooks';
+import { selectIsDarkTheme } from '../../../redux/selectors';
+import styles from './saveTemplateModalStyles';
+
+export interface SaveTemplateModalRef {
+  show: () => void;
+}
+
+interface SaveTemplateModalProps {
+  onSave: (templateName: string) => void;
+}
+
+// Small name prompt for saving the current post as a template; follows the
+// snippetEditorModal pattern (Modal + TextInput + TextButton action panel).
+const SaveTemplateModal = ({ onSave }: SaveTemplateModalProps, ref) => {
+  const intl = useIntl();
+  const isDarkTheme = useAppSelector(selectIsDarkTheme);
+
+  const [templateName, setTemplateName] = useState('');
+  const [showModal, setShowModal] = useState(false);
+
+  useImperativeHandle(ref, () => ({
+    show: () => {
+      setTemplateName('');
+      setShowModal(true);
+    },
+  }));
+
+  const _onSavePress = () => {
+    const name = templateName.trim();
+    if (!name) {
+      Alert.alert(intl.formatMessage({ id: 'alert.can_not_be_empty' }));
+      return;
+    }
+    setShowModal(false);
+    onSave(name);
+  };
+
+  return (
+    <Modal
+      isOpen={showModal}
+      handleOnModalClose={() => {
+        setShowModal(false);
+      }}
+      presentationStyle="formSheet"
+      title={intl.formatMessage({ id: 'templates.save_as_template' })}
+      animationType="slide"
+      style={styles.modalStyle}
+    >
+      <View style={styles.container}>
+        <TextInput
+          autoFocus={true}
+          style={styles.nameInput}
+          placeholder={intl.formatMessage({ id: 'templates.name_placeholder' })}
+          placeholderTextColor={isDarkTheme ? '#526d91' : '#c1c5c7'}
+          maxLength={255}
+          onChangeText={setTemplateName}
+          value={templateName}
+        />
+        <View style={styles.actionPanel}>
+          <TextButton
+            text={intl.formatMessage({ id: 'snippets.btn_cancel' })}
+            onPress={() => setShowModal(false)}
+            style={styles.closeButton}
+          />
+          <TextButton
+            text={intl.formatMessage({ id: 'snippets.btn_save' })}
+            onPress={_onSavePress}
+            textStyle={styles.btnText}
+            style={styles.saveButton}
+          />
+        </View>
+      </View>
+    </Modal>
+  );
+};
+
+export default forwardRef(SaveTemplateModal);

--- a/src/screens/editor/children/saveTemplateModalStyles.ts
+++ b/src/screens/editor/children/saveTemplateModalStyles.ts
@@ -1,0 +1,51 @@
+import { TextStyle, StyleSheet, ViewStyle } from 'react-native';
+import EStyleSheet from 'react-native-extended-stylesheet';
+
+export default EStyleSheet.create({
+  modalStyle: {
+    flex: 1,
+    backgroundColor: '$primaryBackgroundColor',
+    margin: 0,
+    paddingTop: 32,
+    paddingBottom: 8,
+  },
+  container: {
+    flexGrow: 1,
+    marginTop: 24,
+    paddingHorizontal: 24,
+  } as ViewStyle,
+  nameInput: {
+    color: '$primaryBlack',
+    fontWeight: 'bold',
+    fontSize: 18,
+    textAlignVertical: 'top',
+    paddingVertical: 0,
+    backgroundColor: '$primaryBackgroundColor',
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: '$primaryDarkGray',
+  } as TextStyle,
+  btnText: {
+    color: '$pureWhite',
+  } as TextStyle,
+  saveButton: {
+    backgroundColor: '$primaryBlue',
+    width: 150,
+    paddingVertical: 16,
+    borderRadius: 32,
+    justifyContent: 'center',
+    alignItems: 'center',
+  } as ViewStyle,
+  closeButton: {
+    marginRight: 16,
+    paddingVertical: 8,
+    borderRadius: 16,
+    justifyContent: 'center',
+    alignItems: 'center',
+  } as ViewStyle,
+  actionPanel: {
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+    alignItems: 'center',
+    marginTop: 24,
+  } as ViewStyle,
+});

--- a/src/screens/editor/container/editorContainer.tsx
+++ b/src/screens/editor/container/editorContainer.tsx
@@ -827,6 +827,8 @@ class EditorContainer extends Component<EditorContainerProps, any> {
     try {
       const draftField = {
         ...fields,
+        // a template can be a title-only scaffold; keep body a string throughout
+        body: fields.body || '',
         tags: fields.tags && fields.tags.length > 0 ? fields.tags.join(' ') : '',
       };
 

--- a/src/screens/editor/container/editorContainer.tsx
+++ b/src/screens/editor/container/editorContainer.tsx
@@ -808,6 +808,91 @@ class EditorContainer extends Component<EditorContainerProps, any> {
     }
   };
 
+  // Saves the current compose state as a NEW template draft (meta.postTemplate +
+  // meta.templateName, same convention as Ecency web). Always addDraft: it never
+  // updates the draft being composed, never touches state.draftId/isDraftSaved/
+  // isDraftSaving and never clears local draft caches, so the normal draft
+  // autosave flow keeps working on whatever the user is writing.
+  _saveAsTemplate = async (fields, templateName: string) => {
+    const { isReply, isEdit, thumbUrl, rewardType, postDescription } = this.state;
+    const { currentAccount, dispatch, intl, queryClient, pinCode } = this.props;
+
+    if (isReply || isEdit || !fields) {
+      return;
+    }
+
+    const beneficiaries = this._extractBeneficiaries();
+    const pollDraft = this._extractPollDraft();
+
+    try {
+      const draftField = {
+        ...fields,
+        tags: fields.tags && fields.tags.length > 0 ? fields.tags.join(' ') : '',
+      };
+
+      const _extractedMeta = await extractMetadata({
+        body: draftField.body,
+        thumbUrl,
+        fetchRatios: false,
+      });
+
+      const postBodySummaryContent = postBodySummary(
+        draftField.body || '',
+        200,
+        Platform.OS as any,
+      );
+
+      const meta = Object.assign({}, _extractedMeta, {
+        tags: draftField.tags,
+        beneficiaries,
+        poll: pollDraft,
+        rewardType,
+        description: postDescription || postBodySummaryContent,
+        postTemplate: true,
+        templateName,
+      });
+
+      const jsonMeta = makeJsonMetadata(meta, draftField.tags);
+
+      const accessToken = currentAccount?.local?.accessToken
+        ? decryptKey(currentAccount.local.accessToken, getDigitPinCode(pinCode))
+        : '';
+
+      if (!accessToken) {
+        dispatch(toastNotification(intl.formatMessage({ id: 'editor.draft_save_fail' })));
+        return;
+      }
+
+      await addDraft(
+        accessToken,
+        draftField.title || '',
+        draftField.body,
+        draftField.tags,
+        jsonMeta,
+      );
+
+      dispatch(toastNotification(intl.formatMessage({ id: 'templates.saved' })));
+
+      // refresh drafts/templates lists so the new template shows up
+      if (queryClient) {
+        const { queryKey: draftsQueryKey } = getDraftsQueryOptions(
+          currentAccount.name,
+          accessToken,
+        );
+        const { queryKey: draftsInfiniteKey } = getDraftsInfiniteQueryOptions(
+          currentAccount.name,
+          accessToken,
+          20,
+        );
+        queryClient.invalidateQueries({ queryKey: draftsQueryKey });
+        queryClient.invalidateQueries({ queryKey: draftsInfiniteKey });
+      }
+    } catch (err) {
+      console.warn('Failed to save template', err);
+      dispatch(toastNotification(intl.formatMessage({ id: 'editor.draft_save_fail' })));
+    }
+  };
+
   _updateDraftFields = (fields) => {
     this._updatedDraftFields = fields;
   };
@@ -1784,6 +1869,7 @@ class EditorContainer extends Component<EditorContainerProps, any> {
         updateDraftFields={this._updateDraftFields}
         saveCurrentDraft={this._saveCurrentDraft}
         saveDraftToDB={this._saveDraftToDB}
+        saveAsTemplate={this._saveAsTemplate}
         uploadedImage={uploadedImage}
         tags={tags}
         community={community}

--- a/src/screens/editor/screen/editorScreen.tsx
+++ b/src/screens/editor/screen/editorScreen.tsx
@@ -26,6 +26,7 @@ import { isCommunity } from '../../../utils/communityValidation';
 
 import styles from './editorScreenStyles';
 import PostOptionsModal from '../children/postOptionsModal';
+import SaveTemplateModal from '../children/saveTemplateModal';
 import { CommunityRole, CommunityTypeId } from '../../../providers/hive/hive.types';
 
 class EditorScreen extends Component {
@@ -34,6 +35,8 @@ class EditorScreen extends Component {
    *   @prop { type }    name                - Description....
    */
   postOptionsModalRef = null;
+
+  saveTemplateModalRef = null;
 
   constructor(props) {
     super(props);
@@ -248,6 +251,26 @@ class EditorScreen extends Component {
   _handleSettingsPress = () => {
     if (this.postOptionsModalRef) {
       this.postOptionsModalRef.show();
+    }
+  };
+
+  // called from the post options modal after it closes itself; the delay lets
+  // the options formSheet fully dismiss before presenting the name prompt
+  // (iOS cannot present a second native modal while one is still animating out)
+  _handleSaveTemplatePress = () => {
+    setTimeout(() => {
+      if (this.saveTemplateModalRef) {
+        this.saveTemplateModalRef.show();
+      }
+    }, 500);
+  };
+
+  _handleSaveAsTemplate = (templateName) => {
+    const { saveAsTemplate } = this.props;
+    const { fields } = this.state;
+
+    if (saveAsTemplate && (fields.title || fields.body)) {
+      saveAsTemplate(fields, templateName);
     }
   };
 
@@ -572,6 +595,15 @@ class EditorScreen extends Component {
           handleScheduleChange={this._handleScheduleChange}
           handleShouldReblogChange={handleShouldReblogChange}
           handleFormUpdate={this._handleFormUpdate}
+          canSaveTemplate={!isReply && !isEdit && !!(fields.title || fields.body)}
+          handleSaveTemplatePress={this._handleSaveTemplatePress}
+        />
+
+        <SaveTemplateModal
+          ref={(componentRef) => {
+            this.saveTemplateModalRef = componentRef;
+          }}
+          onSave={this._handleSaveAsTemplate}
         />
       </SafeAreaView>
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1211,10 +1211,10 @@
     url "^0.11.0"
     xss "^1.0.9"
 
-"@ecency/sdk@^2.3.36":
-  version "2.3.36"
-  resolved "https://registry.yarnpkg.com/@ecency/sdk/-/sdk-2.3.36.tgz#c2f36b91e56b42afca962a79d9fc675f3fd274a4"
-  integrity sha512-8rga9o2ms86KSE/H95YDHLwuJOHzoORLLCt1+29KBL4l9xv0d7WKoQFwZKGKJ5xbNMY5E7L0oaj9oOsyy3DAcA==
+"@ecency/sdk@^2.3.37":
+  version "2.3.37"
+  resolved "https://registry.yarnpkg.com/@ecency/sdk/-/sdk-2.3.37.tgz#9cf7a9139c7ae293605bab529c371ebc326f086d"
+  integrity sha512-DseS9GCR8jd265lDeg0JipXRon4T4CJUUsWrxK28SffHJO8w8iBNhgVvH398v8bR16nPQPv5ReXlkz3p55evXw==
   dependencies:
     "@noble/ciphers" "^2.1.1"
     "@noble/curves" "^2.0.1"


### PR DESCRIPTION
Two follow-ups bundled.

## Save as template
Mobile could apply and delete templates but not create them. The post options modal (gear) gains a "Save as template" row that prompts for a name and saves the current editor content as a template draft (`meta.postTemplate` + `templateName`, same shape as web), including tags, beneficiaries, poll, reward type and description.
- Hidden in reply and edit modes and when the editor is empty.
- Uses its own addDraft call and never touches the current draft id, autosave state, or editor caches, so drafting continues unaffected.
- Placed in the options modal because the save-icon alert already has three buttons (Android's Alert maximum). Name prompt follows the snippet editor modal idiom.
- The templates empty-state copy now says templates can be saved from the editor.

## Translate table-detection parity
Ports the web tightening from ecency/vision-next#1088: a separator row only marks a block as a table when it sits directly below a pipe row with the same cell count, so prose containing pipes near a separator-like line translates instead of being silently skipped. Web-mirroring tests added.

Full suite 550 passed / 1 skipped; eslint delta clean on all changed files.

## Review note
Title-only templates are allowed on purpose (same gate as web): a template holding just a title pattern plus tags, community, beneficiaries and reward settings is a valid scaffold, with the body written fresh on each use. Applying one cannot publish an empty post since the editor still requires a body before posting. The save path always writes body as a string.
