### PR TITLE
Fix payout double-count flash after voting

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@babel/preset-typescript": "^7.26.0",
     "@babel/runtime": "^7.26.7",
     "@ecency/render-helper": "^2.5.17",
-    "@ecency/sdk": "^2.3.37",
+    "@ecency/sdk": "^2.3.39",
     "@esteemapp/react-native-autocomplete-input": "^4.2.1",
     "@esteemapp/react-native-multi-slider": "^1.1.0",
     "@native-html/iframe-plugin": "^2.6.1",

--- a/src/components/upvotePopover/container/upvotePopover.tsx
+++ b/src/components/upvotePopover/container/upvotePopover.tsx
@@ -438,11 +438,11 @@ const UpvotePopover = forwardRef(({}, ref) => {
           permlink: _permlink,
           weight,
           // Downvotes REDUCE payout, but the SDK's post-broadcast cache write
-          // adds `estimated` unsigned (entry.payout + estimated), which would
-          // briefly show the payout INCREASED by the vote value. Pass 0 so that
-          // write stays at the base payout; our at-press cache update already
-          // reflects the reduction and the deferred refetch reconciles.
-          estimated: 0,
+          // adds `estimated` unsigned (entry.payout + estimated), so a positive
+          // value would briefly show the payout INCREASED by the vote value.
+          // Pass the negative delta, clamped to the pre-vote payout, so that
+          // write lands on the same reduced value our at-press update shows.
+          estimated: -Math.min(parseFloat(amount) || 0, content?.total_payout || 0),
         });
 
         setIsDownVoted(!!sliderValue);

--- a/src/components/upvotePopover/container/upvotePopover.tsx
+++ b/src/components/upvotePopover/container/upvotePopover.tsx
@@ -437,7 +437,12 @@ const UpvotePopover = forwardRef(({}, ref) => {
           author: _author,
           permlink: _permlink,
           weight,
-          estimated: parseFloat(amount),
+          // Downvotes REDUCE payout, but the SDK's post-broadcast cache write
+          // adds `estimated` unsigned (entry.payout + estimated), which would
+          // briefly show the payout INCREASED by the vote value. Pass 0 so that
+          // write stays at the base payout; our at-press cache update already
+          // reflects the reduction and the deferred refetch reconciles.
+          estimated: 0,
         });
 
         setIsDownVoted(!!sliderValue);

--- a/src/providers/queries/postQueries/voteCacheUtils.test.ts
+++ b/src/providers/queries/postQueries/voteCacheUtils.test.ts
@@ -1,8 +1,17 @@
-import { applyVoteToPost, VoteCacheEntry } from './voteCacheUtils';
+import {
+  applyRecentVoteOverrideToEntry,
+  applyVoteToPost,
+  updateVoteInQueryCaches,
+  VoteCacheEntry,
+} from './voteCacheUtils';
 
 // voteCacheUtils imports getQueryClient from the queries barrel at module load;
 // stub it so this unit test doesn't pull in the heavy query/provider graph.
-jest.mock('../index', () => ({ getQueryClient: jest.fn() }));
+// setQueriesData is a no-op: updateVoteInQueryCaches is only used here to seed
+// the module-level recent-votes map that applyRecentVoteOverrideToEntry reads.
+jest.mock('../index', () => ({
+  getQueryClient: jest.fn(() => ({ setQueriesData: jest.fn() })),
+}));
 
 const upvote: VoteCacheEntry = {
   amount: 0.012,
@@ -122,5 +131,157 @@ describe('applyVoteToPost net_votes (custom waves feed)', () => {
     expect(result.net_votes).toBeUndefined();
     // The existing stats-based count path is unaffected.
     expect(result.stats.total_votes).toBe(2);
+  });
+});
+
+describe('applyRecentVoteOverrideToEntry payout double-count guard', () => {
+  const seedRecentVote = (permlink: string, amount: number) => {
+    updateVoteInQueryCaches('alice', permlink, {
+      ...upvote,
+      amount,
+      votedAt: Date.now(),
+    });
+  };
+
+  it('skips re-applying when the entry already carries the vote without an amount marker', () => {
+    seedRecentVote('post-indexed', 2);
+
+    // Post-broadcast shape: SDK cache write / server-indexed data both hold the
+    // voter's record as bare { rshares, voter } and a payout that already
+    // includes the vote. Re-adding the amount here is the 3 -> 5 payout flash.
+    const entry = {
+      author: 'alice',
+      permlink: 'post-indexed',
+      total_payout: 3,
+      pending_payout_value: '3.000 HBD',
+      active_votes: [{ voter: 'dave', rshares: 987654321 }],
+    };
+
+    const result = applyRecentVoteOverrideToEntry(entry);
+
+    expect(result).toBe(entry);
+    expect(result.pending_payout_value).toBe('3.000 HBD');
+    expect(result.total_payout).toBe(3);
+  });
+
+  it('re-applies the vote when refetched data does not include it yet', () => {
+    seedRecentVote('post-lagging', 2);
+
+    // Chain/indexer lag: refetch returned pre-vote data, so the override must
+    // still add the vote back.
+    const entry = {
+      author: 'alice',
+      permlink: 'post-lagging',
+      total_payout: 1,
+      pending_payout_value: '1.000 HBD',
+      active_votes: [],
+    };
+
+    const result = applyRecentVoteOverrideToEntry(entry);
+
+    expect(result.pending_payout_value).toBe('3.000 HBD');
+    expect(result.total_payout).toBe(3);
+    expect(result.isUpVoted).toBe(true);
+  });
+
+  it('stays idempotent over our own optimistic record (amount marker present)', () => {
+    seedRecentVote('post-optimistic', 2);
+
+    const entry = {
+      author: 'alice',
+      permlink: 'post-optimistic',
+      total_payout: 3,
+      pending_payout_value: '3.000 HBD',
+      active_votes: [{ voter: 'dave', rshares: 100, percent: 5000, amount: 2 }],
+    };
+
+    const result = applyRecentVoteOverrideToEntry(entry);
+
+    // Same amount in the record and the recent vote -> zero payout delta.
+    expect(result.pending_payout_value).toBe('3.000 HBD');
+    expect(result.total_payout).toBe(3);
+  });
+
+  it('skips re-applying a recent downvote when the entry already carries the bare record', () => {
+    updateVoteInQueryCaches('alice', 'post-indexed-down', {
+      ...upvote,
+      isDownvote: true,
+      rshares: -100,
+      percent: -5000,
+      amount: 2,
+      votedAt: Date.now(),
+    });
+
+    const entry = {
+      author: 'alice',
+      permlink: 'post-indexed-down',
+      pending_payout_value: '0.000 HBD',
+      active_votes: [{ voter: 'dave', rshares: -987654321 }],
+    };
+
+    const result = applyRecentVoteOverrideToEntry(entry);
+
+    expect(result).toBe(entry);
+    expect(result.pending_payout_value).toBe('0.000 HBD');
+  });
+
+  it('treats an amount of 0 as a present marker and still applies the vote delta', () => {
+    seedRecentVote('post-zero-amount', 2);
+
+    // amount: 0 is a real numeric marker (tiny estimates and removal records
+    // carry it) — the guard must not confuse it with a missing amount.
+    const entry = {
+      author: 'alice',
+      permlink: 'post-zero-amount',
+      pending_payout_value: '1.000 HBD',
+      active_votes: [{ voter: 'dave', rshares: 100, percent: 5000, amount: 0 }],
+    };
+
+    const result = applyRecentVoteOverrideToEntry(entry);
+
+    expect(result.pending_payout_value).toBe('3.000 HBD');
+  });
+
+  it('does not re-apply once the recent vote is older than the TTL', () => {
+    updateVoteInQueryCaches('alice', 'post-expired', {
+      ...upvote,
+      amount: 2,
+      votedAt: Date.now() - 16 * 1000,
+    });
+
+    const entry = {
+      author: 'alice',
+      permlink: 'post-expired',
+      pending_payout_value: '1.000 HBD',
+      active_votes: [],
+    };
+
+    const result = applyRecentVoteOverrideToEntry(entry);
+
+    expect(result).toBe(entry);
+    expect(result.pending_payout_value).toBe('1.000 HBD');
+  });
+
+  it('still removes the vote for a recent unvote even without an amount marker', () => {
+    updateVoteInQueryCaches('alice', 'post-unvoted', {
+      ...upvote,
+      amount: 0,
+      rshares: 0,
+      percent: 0,
+      status: 'DELETED',
+      votedAt: Date.now(),
+    });
+
+    const entry = {
+      author: 'alice',
+      permlink: 'post-unvoted',
+      pending_payout_value: '3.000 HBD',
+      active_votes: [{ voter: 'dave', rshares: 987654321 }],
+    };
+
+    const result = applyRecentVoteOverrideToEntry(entry);
+
+    expect(result.active_votes).toHaveLength(0);
+    expect(result.isUpVoted).toBe(false);
   });
 });

--- a/src/providers/queries/postQueries/voteCacheUtils.ts
+++ b/src/providers/queries/postQueries/voteCacheUtils.ts
@@ -79,6 +79,18 @@ export function applyRecentVoteOverrideToEntry(entry: any): any {
     recentVotesByPostPath.delete(postPath);
     return entry;
   }
+  // If the entry already carries this voter's record WITHOUT our optimistic
+  // `amount` marker, the data already includes the vote — either the server
+  // indexed it, or the SDK's post-broadcast cache write replaced our record
+  // with a bare { rshares, voter }. The vote's old payout contribution is
+  // unknown then, so re-applying the full amount on top would double-count
+  // (payout briefly showing base + 2x the vote value).
+  if (recentVote.status !== 'DELETED' && Array.isArray(entry.active_votes)) {
+    const existingVote = entry.active_votes.find((v: any) => v?.voter === recentVote.voter);
+    if (existingVote && typeof existingVote.amount !== 'number') {
+      return entry;
+    }
+  }
   return applyVoteToPost(entry, recentVote);
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1211,10 +1211,10 @@
     url "^0.11.0"
     xss "^1.0.9"
 
-"@ecency/sdk@^2.3.37":
-  version "2.3.37"
-  resolved "https://registry.yarnpkg.com/@ecency/sdk/-/sdk-2.3.37.tgz#9cf7a9139c7ae293605bab529c371ebc326f086d"
-  integrity sha512-DseS9GCR8jd265lDeg0JipXRon4T4CJUUsWrxK28SffHJO8w8iBNhgVvH398v8bR16nPQPv5ReXlkz3p55evXw==
+"@ecency/sdk@^2.3.39":
+  version "2.3.39"
+  resolved "https://registry.yarnpkg.com/@ecency/sdk/-/sdk-2.3.39.tgz#701f94a4dd8ad176b63e1c5d595f5f2555e85b3d"
+  integrity sha512-We7tpll2FLvy448Lzod5gMeL9isxStaj2gm/OlgsN9gV4QcZdWoTmwvAhSn/Jf5A2+26ZH3gs3GwRWDMCcg0sg==
   dependencies:
     "@noble/ciphers" "^2.1.1"
     "@noble/curves" "^2.0.1"


### PR DESCRIPTION
### What

Voting on the post page briefly showed the payout increased by twice the vote value (e.g. payout 1 + vote 2 showed 3, then flashed 5, then settled at 3).

### Why

Two optimistic layers stack on the same cached entry:

1. At press, `updateVoteInQueryCaches` bumps the payout and stores the voter's record with an `amount` field, which `applyRecentVoteOverrideToEntry` uses to stay idempotent.
2. On broadcast success, the SDK's `useVote` onSuccess rewrites the same `["posts", "entry", ...]` cache entry: payout is re-derived from the untouched numeric `payout` field (correct), but the voter's record is replaced with a bare `{ rshares, voter }` — dropping `amount`.
3. The recent-vote override (15s TTL) then sees an unknown old contribution, assumes 0, and re-adds the full vote value on every render → base + 2x vote, until the SDK's deferred (4s) invalidation refetches and reconciles.

### How

- `applyRecentVoteOverrideToEntry` now skips re-applying when the entry already carries the voter's record without a numeric `amount` marker: that data already includes the vote (server-indexed or SDK-written) and re-adding is always an overcount. Unvotes (DELETED) are unaffected.
- Downvotes now pass a signed estimate, clamped to the pre-vote payout: the SDK adds `estimated` unsigned, so the positive value briefly showed the payout *increased* by the downvote's value once the override stopped compensating for it. The clamped negative delta makes the SDK's write land on the same reduced value the at-press update shows.

Complementary SDK-side fix (skips the stacked write entirely): ecency/vision-next#1096. This change fixes the visible flash on its own with the currently pinned SDK; the SDK bump can follow the usual release order.

### Tests

7 new jest cases in `voteCacheUtils.test.ts` covering the skip (up/down), lagging-refetch re-apply, amount-marker idempotency, `amount: 0` semantics, TTL expiry, and the unvote path. Verified the guard test fails against the pre-fix code with the exact reported values (5.000 vs 3.000).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed downvote payout flicker by ensuring the downvote estimate is clamped to the pre-vote payout, preventing a brief incorrect payout increase.
  * Prevented recent vote overrides from double-counting when a cached vote entry already exists without an amount marker.
  * Improved reconciliation of vote totals after cache refreshes, with added unit test coverage for recent vote/unvote edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->