### PR TITLE
fix(pin): fall back to last known profile when fetched merge base is empty

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@babel/preset-typescript": "^7.26.0",
     "@babel/runtime": "^7.26.7",
     "@ecency/render-helper": "^2.5.17",
-    "@ecency/sdk": "^2.3.40",
+    "@ecency/sdk": "^2.3.41",
     "@esteemapp/react-native-autocomplete-input": "^4.2.1",
     "@esteemapp/react-native-multi-slider": "^1.1.0",
     "@native-html/iframe-plugin": "^2.6.1",

--- a/src/components/postOptionsModal/container/postOptionsModal.tsx
+++ b/src/components/postOptionsModal/container/postOptionsModal.tsx
@@ -32,6 +32,7 @@ import ROUTES from '../../../constants/routeNames';
 
 // Utilities
 import { writeToClipboard } from '../../../utils/clipboard';
+import { resolveProfileMergeBase } from '../../../utils/profileMergeBase';
 import { getPostUrl, stripCategoryFromPostPath } from '../../../utils/post';
 
 // Component
@@ -533,8 +534,10 @@ const PostOptionsModal = ({ pageType, isWave, isVisibleTranslateModal, onDelete 
         ...getAccountFullQueryOptions(currentAccount.name),
         staleTime: 0,
       });
-      const baseProfile =
-        parseProfileMetadata(freshAccount?.posting_json_metadata) || currentAccount.profile || {};
+      const baseProfile = resolveProfileMergeBase(
+        parseProfileMetadata(freshAccount?.posting_json_metadata),
+        currentAccount.profile,
+      );
 
       const profileParams = {
         ...baseProfile,

--- a/src/utils/profileMergeBase.test.ts
+++ b/src/utils/profileMergeBase.test.ts
@@ -1,0 +1,31 @@
+import { resolveProfileMergeBase } from './profileMergeBase';
+
+describe('resolveProfileMergeBase', () => {
+  const fullProfile = {
+    name: 'Full Name',
+    about: 'bio',
+    profile_image: 'https://example.com/avatar.jpg',
+    pinned: 'some-post',
+    version: 2,
+  };
+
+  it('returns the parsed on-chain profile when it has keys', () => {
+    expect(resolveProfileMergeBase(fullProfile, { name: 'Stale' })).toBe(fullProfile);
+  });
+
+  it('falls back to the last known profile when the parsed profile is empty', () => {
+    // parseProfileMetadata returns {} (truthy) for empty/stripped metadata —
+    // a `||` chain would keep the empty object and wipe the profile on pin.
+    expect(resolveProfileMergeBase({}, fullProfile)).toBe(fullProfile);
+  });
+
+  it('falls back to the last known profile when the account fetch returned nothing', () => {
+    expect(resolveProfileMergeBase(undefined, fullProfile)).toBe(fullProfile);
+    expect(resolveProfileMergeBase(null, fullProfile)).toBe(fullProfile);
+  });
+
+  it('returns an empty object when no profile is known anywhere', () => {
+    expect(resolveProfileMergeBase({}, undefined)).toEqual({});
+    expect(resolveProfileMergeBase(undefined, null)).toEqual({});
+  });
+});

--- a/src/utils/profileMergeBase.ts
+++ b/src/utils/profileMergeBase.ts
@@ -1,0 +1,21 @@
+type ProfileLike = Record<string, unknown>;
+
+/**
+ * Pick the merge base for a partial profile update (e.g. pin-to-blog).
+ *
+ * The SDK's parseProfileMetadata returns a truthy empty object for
+ * missing/empty/unparseable posting_json_metadata, so a plain `||` chain never
+ * reaches its fallback. When a fetched account row carries no usable profile
+ * (misbehaving node serving stripped metadata, or account not found), the last
+ * known profile copy must win — otherwise a pin update shrinks the on-chain
+ * profile down to the partial payload.
+ */
+export const resolveProfileMergeBase = (
+  parsedProfile?: ProfileLike | null,
+  fallbackProfile?: ProfileLike | null,
+): ProfileLike => {
+  if (parsedProfile && Object.keys(parsedProfile).length) {
+    return parsedProfile;
+  }
+  return fallbackProfile || {};
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1211,10 +1211,10 @@
     url "^0.11.0"
     xss "^1.0.9"
 
-"@ecency/sdk@^2.3.40":
-  version "2.3.40"
-  resolved "https://registry.yarnpkg.com/@ecency/sdk/-/sdk-2.3.40.tgz#5c03e1e11488610770c24ceeaaad48a77f9d23ee"
-  integrity sha512-IXHwRzvMFtYgdYR4cYb2yN8sqLbiIjCUetVuGSwOSCkuXu+Gf4nh0B1wWLgnJ+ooECZk0T0rXYC/9db9D6dkWg==
+"@ecency/sdk@^2.3.41":
+  version "2.3.41"
+  resolved "https://registry.yarnpkg.com/@ecency/sdk/-/sdk-2.3.41.tgz#ef150556b13118f1bc8545c2c686de11b40226e7"
+  integrity sha512-eyl8i1zExPywMO3b6ZZbvuL89Ssn+uYGQyTCwGFsS7gRXCx1X2WJED8sxYD1iCNr3Ay0O3MVA9iOwOqpT6USMw==
   dependencies:
     "@noble/ciphers" "^2.1.1"
     "@noble/curves" "^2.0.1"


### PR DESCRIPTION
## What

Closes the pin-to-blog profile-wipe hole from both sides: bumps `@ecency/sdk` to **2.3.41** (the release carrying the poisoned-read guards from ecency/vision-next#1115) and fixes the app-side dead fallback in the pin flow.

Background: some public RPC nodes serve `get_accounts` rows with both json metadata fields stripped to empty strings inside a valid JSON-RPC envelope. A pin update whose fresh account fetch landed on such a node rebuilt the profile from an empty base and shrank the on-chain profile to just `{pinned, version}` — wiping avatar, cover, about and tokens.

## How

**SDK 2.3.41** (verified in the published tarball):
- `getAccountFull` cross-validates the chain row against `bridge.get_profile` from the same query; a stripped row with a populated hivemind profile triggers a validated re-read that walks other nodes, and the query fails rather than resolve/cache a lying row.
- `callRPC` treats validation-failing payloads as node faults: immediate per-API health cooldown (survives interleaved successes) + failover — verified live against real misbehaving nodes: first read detects and recovers, subsequent reads go straight to an honest node while the lying node keeps serving the API families it is honest about.
- `useAccountUpdate` picks the metadata-richer snapshot (fresh cache vs render-time data) as merge base, so a partial update can never shrink the profile while any snapshot still knows the full one.

**App-side** (works even before the bump): `parseProfileMetadata` returns a **truthy** empty object for missing/empty metadata, so the previous `parsed || currentAccount.profile || {}` chain never reached the Redux fallback. The merge base now goes through `resolveProfileMergeBase`, which only trusts the fetched profile when it actually has keys and otherwise falls back to the last known profile copy.

## Tests

- 4 unit tests for `resolveProfileMergeBase` (trusts populated fetch, falls back on empty object / null / undefined, empty when nothing known).
- Full suite with sdk 2.3.41: 582 passed, 1 skipped. Lint + prettier clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pinned blog post updates to choose the correct “merge base” profile, preserving personal details more reliably.
  * Prevented empty or missing profile metadata from replacing the most recent saved profile information.
* **Tests**
  * Added automated coverage to verify the profile fallback/merge-base selection behavior.
* **Chores**
  * Updated the `@ecency/sdk` dependency to the latest patch version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->