### PR TITLE
feat(waves): onboarding checklist card for new users

### DIFF
--- a/src/components/quickPostModal/usePostSubmitter.ts
+++ b/src/components/quickPostModal/usePostSubmitter.ts
@@ -1,5 +1,5 @@
 import { useDispatch } from 'react-redux';
-import { Alert } from 'react-native';
+import { Alert, DeviceEventEmitter } from 'react-native';
 import { useIntl } from 'react-intl';
 import { useComment } from '@ecency/sdk';
 import { SheetManager } from 'react-native-actions-sheet';
@@ -19,6 +19,7 @@ import { toastNotification } from '../../redux/actions/uiAction';
 import { wavesQueries } from '../../providers/queries';
 import { PollDraft } from '../../providers/ecency/ecency.types';
 import { usePublishWaveMutation } from '../../providers/queries/postQueries/wavesQueries';
+import { WAVES_ONBOARDING_LATCH_EVENT } from '../../utils/wavesOnboarding';
 import { PostTypes } from '../../constants/postTypes';
 import { WAVES_HOSTS } from '../../constants/waves';
 import extractHashTags from '../../utils/extractHashTags';
@@ -450,6 +451,7 @@ export const usePostSubmitter = () => {
 
       if (_cacheCommentData) {
         pusblishWaveMutation.mutate(_cacheCommentData);
+        DeviceEventEmitter.emit(WAVES_ONBOARDING_LATCH_EVENT, 'wave');
       }
 
       return _cacheCommentData;

--- a/src/config/locales/en-US.json
+++ b/src/config/locales/en-US.json
@@ -56,6 +56,18 @@
     "mute": "Mute",
     "unmute": "Unmute"
   },
+  "waves_onboarding": {
+    "title": "Getting started",
+    "subtitle": "New here? Waves are short posts and the easiest way to jump in.",
+    "progress": "{completed}/{total}",
+    "dismiss": "Dismiss",
+    "item_wave": "Post your first Wave",
+    "item_vote": "Vote on a Wave you like",
+    "item_reply": "Reply to someone",
+    "item_checkin": "Check in to start your streak",
+    "all_done_title": "All done 🎉",
+    "all_done_subtitle": "You're all set. Keep the waves coming!"
+  },
   "profile": {
     "havent_commented": "haven't commented anything yet",
     "full_in": "Full in",

--- a/src/screens/feed/screen/feedScreen.tsx
+++ b/src/screens/feed/screen/feedScreen.tsx
@@ -23,6 +23,7 @@ import { TabItem } from '../../../components/tabbedPosts/types/tabbedPosts.types
 import ROUTES from '../../../constants/routeNames';
 import showLoginAlert from '../../../utils/showLoginAlert';
 import { selectCurrentAccount, selectIsLoggedIn } from '../../../redux/selectors';
+import WavesOnboardingChecklist from '../../waves/children/wavesOnboardingChecklist';
 
 const FeedScreen = () => {
   const intl = useIntl();
@@ -100,6 +101,9 @@ const FeedScreen = () => {
     <Fragment>
       <Header showQR={true} showBoost={true} />
       <View style={styles.container} onLayout={_lazyLoadContent}>
+        {/* Feed is the landing screen after signup/login; the card self-gates
+            to fresh accounts and renders nothing for established users. */}
+        {isLoggedIn && <WavesOnboardingChecklist />}
         {lazyLoad && (
           <TabbedPosts
             key={tabbedPostsKey} // Use memoized key to reset tabbedposts when filters change (addresses Android filter change bug)

--- a/src/screens/waves/children/wavesOnboardingChecklist.tsx
+++ b/src/screens/waves/children/wavesOnboardingChecklist.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { Text, TouchableOpacity, View } from 'react-native';
+import { DeviceEventEmitter, Text, TouchableOpacity, View } from 'react-native';
 import { useIntl } from 'react-intl';
 import EStyleSheet from 'react-native-extended-stylesheet';
 import { SheetManager } from 'react-native-actions-sheet';
@@ -14,6 +14,7 @@ import RootNavigation from '../../../navigation/rootNavigation';
 import ROUTES from '../../../constants/routeNames';
 import {
   deriveWavesOnboardingState,
+  WAVES_ONBOARDING_LATCH_EVENT,
   WavesOnboardingItem,
   WavesOnboardingItemId,
 } from '../../../utils/wavesOnboarding';
@@ -80,25 +81,54 @@ const WavesOnboardingChecklist = () => {
     setItemToStorage(_storageKey(username), next);
   };
 
-  // Latch newly-completed items: daily quest progress resets at 00:00 UTC, so a
-  // checklist item must never un-check itself the next day.
+  // Latch items completed by the submit path (a wave has no live quest signal,
+  // see WAVES_ONBOARDING_LATCH_EVENT). Functional update keeps this safe next
+  // to the effect below; both instances of the card (feed + waves tabs) write
+  // the same merged value, so the double storage write is idempotent.
+  useEffect(() => {
+    if (!username) {
+      return undefined;
+    }
+    const sub = DeviceEventEmitter.addListener(
+      WAVES_ONBOARDING_LATCH_EVENT,
+      (id: WavesOnboardingItemId) => {
+        setPersisted((prev) => {
+          if (!prev || (prev.done ?? []).includes(id)) {
+            return prev;
+          }
+          const next = { ...prev, done: [...(prev.done ?? []), id] };
+          setItemToStorage(_storageKey(username), next);
+          return next;
+        });
+      },
+    );
+    return () => sub.remove();
+  }, [username]);
+
+  // Latch newly-completed items (daily quest progress resets at 00:00 UTC, so a
+  // checklist item must never un-check itself the next day) and celebrate once
+  // everything is done, in a SINGLE write: two separate effects would race on
+  // the same persisted snapshot and the celebration write could drop the
+  // just-latched final item.
   useEffect(() => {
     if (!state || !persisted) {
       return;
     }
     const done = state.items.filter((i) => i.completed).map((i) => i.id);
     const prev = persisted.done ?? [];
-    if (done.some((id) => !prev.includes(id))) {
-      _persist({ ...persisted, done });
-    }
-  }, [state]);
-
-  useEffect(() => {
-    if (state?.allComplete && persisted && !persisted.celebrated) {
+    const latchNeeded = done.some((id) => !prev.includes(id));
+    const celebrationNeeded = state.allComplete && !persisted.celebrated;
+    if (celebrationNeeded) {
       setCelebrating(true);
-      _persist({ ...persisted, celebrated: true });
     }
-  }, [state?.allComplete, persisted]);
+    if (latchNeeded || celebrationNeeded) {
+      _persist({
+        ...persisted,
+        done: latchNeeded ? done : prev,
+        celebrated: persisted.celebrated || celebrationNeeded,
+      });
+    }
+  }, [state, persisted]);
 
   if (
     !username ||

--- a/src/screens/waves/children/wavesOnboardingChecklist.tsx
+++ b/src/screens/waves/children/wavesOnboardingChecklist.tsx
@@ -28,6 +28,26 @@ interface PersistedOnboarding {
 
 const _storageKey = (username: string) => `waves_onboarding_${username}`;
 
+/**
+ * The checklist is mounted from both the Feed and Waves tabs at once, so the
+ * per-user flags live here at module scope as the single source of truth.
+ * Updates are synchronous read-modify-write against this map, so no instance
+ * can overwrite another's flags from a stale snapshot; storage is
+ * write-through and the state event keeps every mounted instance in sync.
+ */
+const WAVES_ONBOARDING_STATE_EVENT = 'wavesOnboarding:state';
+const memoryState = new Map<string, PersistedOnboarding>();
+
+const _updatePersisted = (
+  username: string,
+  updater: (prev: PersistedOnboarding) => PersistedOnboarding,
+) => {
+  const next = updater(memoryState.get(username) ?? {});
+  memoryState.set(username, next);
+  setItemToStorage(_storageKey(username), next);
+  DeviceEventEmitter.emit(WAVES_ONBOARDING_STATE_EVENT, { username, next });
+};
+
 const DISMISS_HIT_SLOP = { top: 8, bottom: 8, left: 8, right: 8 };
 
 /**
@@ -62,13 +82,30 @@ const WavesOnboardingChecklist = () => {
     if (!username) {
       return undefined;
     }
-    getItemFromStorage(_storageKey(username)).then((data: PersistedOnboarding | null) => {
-      if (mounted) {
-        setPersisted(data || {});
-      }
-    });
+    const cached = memoryState.get(username);
+    if (cached) {
+      setPersisted(cached);
+    } else {
+      getItemFromStorage(_storageKey(username)).then((data: PersistedOnboarding | null) => {
+        if (!memoryState.has(username)) {
+          memoryState.set(username, data || {});
+        }
+        if (mounted) {
+          setPersisted(memoryState.get(username) ?? {});
+        }
+      });
+    }
+    const sub = DeviceEventEmitter.addListener(
+      WAVES_ONBOARDING_STATE_EVENT,
+      (payload: { username: string; next: PersistedOnboarding }) => {
+        if (payload.username === username) {
+          setPersisted(payload.next);
+        }
+      },
+    );
     return () => {
       mounted = false;
+      sub.remove();
     };
   }, [username]);
 
@@ -82,14 +119,6 @@ const WavesOnboardingChecklist = () => {
         : null,
     [quests, currentAccount, persisted, pendingLatches],
   );
-
-  const _persist = (next: PersistedOnboarding) => {
-    if (!username) {
-      return;
-    }
-    setPersisted(next);
-    setItemToStorage(_storageKey(username), next);
-  };
 
   // Items completed by the submit path (a wave has no live quest signal, see
   // WAVES_ONBOARDING_LATCH_EVENT) only buffer into state here; the derivation
@@ -106,28 +135,26 @@ const WavesOnboardingChecklist = () => {
 
   // Latch newly-completed items (daily quest progress resets at 00:00 UTC, so a
   // checklist item must never un-check itself the next day) and celebrate once
-  // everything is done, in a SINGLE write: two separate effects would race on
-  // the same persisted snapshot and the celebration write could drop the
-  // just-latched final item.
+  // everything is done, in a SINGLE updater-style write: the updater merges
+  // against the authoritative module-scope value, never this render's snapshot.
   useEffect(() => {
-    if (!state || !persisted) {
+    if (!username || !state || !persisted) {
       return;
     }
     const done = state.items.filter((i) => i.completed).map((i) => i.id);
-    const prev = persisted.done ?? [];
-    const latchNeeded = done.some((id) => !prev.includes(id));
+    const latchNeeded = done.some((id) => !(persisted.done ?? []).includes(id));
     const celebrationNeeded = state.allComplete && !persisted.celebrated;
     if (celebrationNeeded) {
       setCelebrating(true);
     }
     if (latchNeeded || celebrationNeeded) {
-      _persist({
-        ...persisted,
-        done: latchNeeded ? done : prev,
-        celebrated: persisted.celebrated || celebrationNeeded,
-      });
+      _updatePersisted(username, (prev) => ({
+        ...prev,
+        done: Array.from(new Set([...(prev.done ?? []), ...done])),
+        celebrated: prev.celebrated || celebrationNeeded,
+      }));
     }
-  }, [state, persisted]);
+  }, [username, state, persisted]);
 
   if (
     !username ||
@@ -140,9 +167,7 @@ const WavesOnboardingChecklist = () => {
   }
 
   const _onDismiss = () => {
-    if (persisted) {
-      _persist({ ...persisted, dismissed: true });
-    }
+    _updatePersisted(username, (prev) => ({ ...prev, dismissed: true }));
   };
 
   const _onCreateWavePress = () => {

--- a/src/screens/waves/children/wavesOnboardingChecklist.tsx
+++ b/src/screens/waves/children/wavesOnboardingChecklist.tsx
@@ -46,6 +46,10 @@ const WavesOnboardingChecklist = () => {
   // null until the per-user flags load, so the card never flashes before the
   // dismissed/latched state is known.
   const [persisted, setPersisted] = useState<PersistedOnboarding | null>(null);
+  // Items latched by submit-path events, held in state only: the merged effect
+  // below is the SINGLE storage writer, so an event write can never clobber a
+  // concurrent celebration/latch write to the same key.
+  const [pendingLatches, setPendingLatches] = useState<WavesOnboardingItemId[]>([]);
   // True only for the mount where the last item completes: the celebration
   // renders once, then the persisted flag hides the card on later mounts.
   const [celebrating, setCelebrating] = useState(false);
@@ -53,6 +57,7 @@ const WavesOnboardingChecklist = () => {
   useEffect(() => {
     let mounted = true;
     setPersisted(null);
+    setPendingLatches([]);
     setCelebrating(false);
     if (!username) {
       return undefined;
@@ -69,8 +74,13 @@ const WavesOnboardingChecklist = () => {
 
   const state = useMemo(
     () =>
-      persisted ? deriveWavesOnboardingState(quests, currentAccount, persisted.done ?? []) : null,
-    [quests, currentAccount, persisted],
+      persisted
+        ? deriveWavesOnboardingState(quests, currentAccount, [
+            ...(persisted.done ?? []),
+            ...pendingLatches,
+          ])
+        : null,
+    [quests, currentAccount, persisted, pendingLatches],
   );
 
   const _persist = (next: PersistedOnboarding) => {
@@ -81,29 +91,18 @@ const WavesOnboardingChecklist = () => {
     setItemToStorage(_storageKey(username), next);
   };
 
-  // Latch items completed by the submit path (a wave has no live quest signal,
-  // see WAVES_ONBOARDING_LATCH_EVENT). Functional update keeps this safe next
-  // to the effect below; both instances of the card (feed + waves tabs) write
-  // the same merged value, so the double storage write is idempotent.
+  // Items completed by the submit path (a wave has no live quest signal, see
+  // WAVES_ONBOARDING_LATCH_EVENT) only buffer into state here; the derivation
+  // treats them as completed and the merged effect below persists them.
   useEffect(() => {
-    if (!username) {
-      return undefined;
-    }
     const sub = DeviceEventEmitter.addListener(
       WAVES_ONBOARDING_LATCH_EVENT,
       (id: WavesOnboardingItemId) => {
-        setPersisted((prev) => {
-          if (!prev || (prev.done ?? []).includes(id)) {
-            return prev;
-          }
-          const next = { ...prev, done: [...(prev.done ?? []), id] };
-          setItemToStorage(_storageKey(username), next);
-          return next;
-        });
+        setPendingLatches((prev) => (prev.includes(id) ? prev : [...prev, id]));
       },
     );
     return () => sub.remove();
-  }, [username]);
+  }, []);
 
   // Latch newly-completed items (daily quest progress resets at 00:00 UTC, so a
   // checklist item must never un-check itself the next day) and celebrate once

--- a/src/screens/waves/children/wavesOnboardingChecklist.tsx
+++ b/src/screens/waves/children/wavesOnboardingChecklist.tsx
@@ -1,0 +1,224 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { Text, TouchableOpacity, View } from 'react-native';
+import { useIntl } from 'react-intl';
+import EStyleSheet from 'react-native-extended-stylesheet';
+import { SheetManager } from 'react-native-actions-sheet';
+
+import { Icon } from '../../../components';
+import { useAppSelector } from '../../../hooks';
+import { useGetQuestsQuery } from '../../../providers/queries/pointQueries';
+import { getItemFromStorage, setItemToStorage } from '../../../realm/realm';
+import { selectCurrentAccount } from '../../../redux/selectors';
+import { SheetNames } from '../../../navigation/sheets';
+import RootNavigation from '../../../navigation/rootNavigation';
+import ROUTES from '../../../constants/routeNames';
+import {
+  deriveWavesOnboardingState,
+  WavesOnboardingItem,
+  WavesOnboardingItemId,
+} from '../../../utils/wavesOnboarding';
+import styles from '../styles/wavesOnboardingChecklist.styles';
+
+interface PersistedOnboarding {
+  dismissed?: boolean;
+  celebrated?: boolean;
+  done?: WavesOnboardingItemId[];
+}
+
+const _storageKey = (username: string) => `waves_onboarding_${username}`;
+
+const DISMISS_HIT_SLOP = { top: 8, bottom: 8, left: 8, right: 8 };
+
+/**
+ * Dismissible "Getting started" checklist for new accounts, nudging the first
+ * Wave as the entry action. Completion is derived from the daily quests API and
+ * latched per-user in AsyncStorage so items never un-check when the daily quest
+ * window resets at 00:00 UTC. Once every item is done it celebrates once, then
+ * hides for good. Mirrors the web (vision-next) WavesOnboardingChecklist.
+ */
+const WavesOnboardingChecklist = () => {
+  const intl = useIntl();
+  const currentAccount = useAppSelector(selectCurrentAccount);
+  const username = currentAccount?.name as string | undefined;
+  const { data: quests } = useGetQuestsQuery(username);
+
+  // null until the per-user flags load, so the card never flashes before the
+  // dismissed/latched state is known.
+  const [persisted, setPersisted] = useState<PersistedOnboarding | null>(null);
+  // True only for the mount where the last item completes: the celebration
+  // renders once, then the persisted flag hides the card on later mounts.
+  const [celebrating, setCelebrating] = useState(false);
+
+  useEffect(() => {
+    let mounted = true;
+    setPersisted(null);
+    setCelebrating(false);
+    if (!username) {
+      return undefined;
+    }
+    getItemFromStorage(_storageKey(username)).then((data: PersistedOnboarding | null) => {
+      if (mounted) {
+        setPersisted(data || {});
+      }
+    });
+    return () => {
+      mounted = false;
+    };
+  }, [username]);
+
+  const state = useMemo(
+    () =>
+      persisted ? deriveWavesOnboardingState(quests, currentAccount, persisted.done ?? []) : null,
+    [quests, currentAccount, persisted],
+  );
+
+  const _persist = (next: PersistedOnboarding) => {
+    if (!username) {
+      return;
+    }
+    setPersisted(next);
+    setItemToStorage(_storageKey(username), next);
+  };
+
+  // Latch newly-completed items: daily quest progress resets at 00:00 UTC, so a
+  // checklist item must never un-check itself the next day.
+  useEffect(() => {
+    if (!state || !persisted) {
+      return;
+    }
+    const done = state.items.filter((i) => i.completed).map((i) => i.id);
+    const prev = persisted.done ?? [];
+    if (done.some((id) => !prev.includes(id))) {
+      _persist({ ...persisted, done });
+    }
+  }, [state]);
+
+  useEffect(() => {
+    if (state?.allComplete && persisted && !persisted.celebrated) {
+      setCelebrating(true);
+      _persist({ ...persisted, celebrated: true });
+    }
+  }, [state?.allComplete, persisted]);
+
+  if (
+    !username ||
+    !state ||
+    !state.eligible ||
+    persisted?.dismissed ||
+    (state.allComplete && !celebrating)
+  ) {
+    return null;
+  }
+
+  const _onDismiss = () => {
+    if (persisted) {
+      _persist({ ...persisted, dismissed: true });
+    }
+  };
+
+  const _onCreateWavePress = () => {
+    SheetManager.show(SheetNames.QUICK_POST, {
+      payload: { mode: 'wave' },
+    });
+  };
+
+  const _onCheckinPress = () => {
+    RootNavigation.navigate({ name: ROUTES.SCREENS.PERKS });
+  };
+
+  const _renderItem = (item: WavesOnboardingItem) => {
+    const label = intl.formatMessage({ id: `waves_onboarding.item_${item.id}` });
+    const actionable = !item.completed && (item.id === 'wave' || item.id === 'checkin');
+    const content = (
+      <>
+        <Icon
+          iconType="MaterialCommunityIcons"
+          name={item.completed ? 'check-circle' : 'checkbox-blank-circle-outline'}
+          size={20}
+          color={EStyleSheet.value(item.completed ? '$primaryGreen' : '$iconColor')}
+        />
+        <Text
+          style={[
+            styles.itemLabel,
+            item.completed && styles.itemLabelDone,
+            actionable && styles.itemLabelAction,
+          ]}
+        >
+          {label}
+        </Text>
+      </>
+    );
+
+    if (actionable) {
+      return (
+        <TouchableOpacity
+          key={item.id}
+          style={styles.itemRow}
+          onPress={item.id === 'wave' ? _onCreateWavePress : _onCheckinPress}
+        >
+          {content}
+        </TouchableOpacity>
+      );
+    }
+
+    return (
+      <View key={item.id} style={styles.itemRow}>
+        {content}
+      </View>
+    );
+  };
+
+  const pct = Math.round((state.completedCount / state.totalCount) * 100);
+
+  return (
+    <View style={styles.card}>
+      <TouchableOpacity
+        style={styles.dismissBtn}
+        onPress={_onDismiss}
+        hitSlop={DISMISS_HIT_SLOP}
+        accessibilityLabel={intl.formatMessage({ id: 'waves_onboarding.dismiss' })}
+      >
+        <Icon
+          iconType="MaterialCommunityIcons"
+          name="close"
+          size={18}
+          color={EStyleSheet.value('$primaryDarkGray')}
+        />
+      </TouchableOpacity>
+
+      {state.allComplete ? (
+        <>
+          <Text style={styles.cardTitle}>
+            {intl.formatMessage({ id: 'waves_onboarding.all_done_title' })}
+          </Text>
+          <Text style={styles.cardSubtitle}>
+            {intl.formatMessage({ id: 'waves_onboarding.all_done_subtitle' })}
+          </Text>
+        </>
+      ) : (
+        <>
+          <View style={styles.headerRow}>
+            <Text style={styles.cardTitle}>
+              {intl.formatMessage({ id: 'waves_onboarding.title' })}
+            </Text>
+            <Text style={styles.progressText}>
+              {intl.formatMessage(
+                { id: 'waves_onboarding.progress' },
+                { completed: state.completedCount, total: state.totalCount },
+              )}
+            </Text>
+          </View>
+          <Text style={styles.cardSubtitle}>
+            {intl.formatMessage({ id: 'waves_onboarding.subtitle' })}
+          </Text>
+          <View style={styles.track}>
+            <View style={[styles.fill, { width: `${pct}%` }]} />
+          </View>
+          <View style={styles.itemsWrap}>{state.items.map(_renderItem)}</View>
+        </>
+      )}
+    </View>
+  );
+};
+
+export default WavesOnboardingChecklist;

--- a/src/screens/waves/children/wavesOnboardingChecklist.tsx
+++ b/src/screens/waves/children/wavesOnboardingChecklist.tsx
@@ -37,6 +37,7 @@ const _storageKey = (username: string) => `waves_onboarding_${username}`;
  */
 const WAVES_ONBOARDING_STATE_EVENT = 'wavesOnboarding:state';
 const memoryState = new Map<string, PersistedOnboarding>();
+const writeQueues = new Map<string, Promise<unknown>>();
 
 const _updatePersisted = (
   username: string,
@@ -44,7 +45,17 @@ const _updatePersisted = (
 ) => {
   const next = updater(memoryState.get(username) ?? {});
   memoryState.set(username, next);
-  setItemToStorage(_storageKey(username), next);
+  // Chain same-user disk writes so ordering never depends on AsyncStorage
+  // internals: an older object can never land after a newer one. A failed
+  // write is logged, not rethrown — memoryState stays authoritative for the
+  // session and the next write persists the newest merged value anyway.
+  const queue = writeQueues.get(username) ?? Promise.resolve();
+  writeQueues.set(
+    username,
+    queue
+      .then(() => setItemToStorage(_storageKey(username), next))
+      .catch((err) => console.warn('waves onboarding: failed to persist flags', err)),
+  );
   DeviceEventEmitter.emit(WAVES_ONBOARDING_STATE_EVENT, { username, next });
 };
 

--- a/src/screens/waves/screen/wavesScreen.tsx
+++ b/src/screens/waves/screen/wavesScreen.tsx
@@ -29,6 +29,7 @@ import styles from '../styles/wavesScreen.styles';
 import { wavesQueries } from '../../../providers/queries';
 import { useAppSelector } from '../../../hooks';
 import { WavesHeader } from '../children/wavesHeader';
+import WavesOnboardingChecklist from '../children/wavesOnboardingChecklist';
 import WavesReelsView from '../children/wavesReelsView';
 import { PostTypes } from '../../../constants/postTypes';
 import { SHORTS_SOURCE, waveSourceLabel } from '../../../constants/waves';
@@ -513,6 +514,10 @@ const WavesScreen = () => {
       <Header />
 
       <View style={styles.contentContainer} onLayout={_lazyLoadContent}>
+        {/* Getting-started nudges for new accounts; the card gates itself on
+            account freshness, dismissal and completion, so it renders nothing
+            for established users. */}
+        {isLoggedIn && <WavesOnboardingChecklist />}
         {lazyLoad ? (
           <TabView
             navigationState={{ index: wavesIndex, routes: wavesRoutes }}

--- a/src/screens/waves/styles/wavesOnboardingChecklist.styles.ts
+++ b/src/screens/waves/styles/wavesOnboardingChecklist.styles.ts
@@ -1,0 +1,78 @@
+import { TextStyle, ViewStyle } from 'react-native';
+import EStyleSheet from 'react-native-extended-stylesheet';
+
+export default EStyleSheet.create({
+  card: {
+    backgroundColor: '$primaryLightBackground',
+    borderRadius: 12,
+    padding: 16,
+    marginHorizontal: 16,
+    marginTop: 8,
+    marginBottom: 8,
+  } as ViewStyle,
+  dismissBtn: {
+    position: 'absolute',
+    top: 10,
+    right: 10,
+    padding: 4,
+    zIndex: 1,
+  } as ViewStyle,
+  headerRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingRight: 28,
+  } as ViewStyle,
+  cardTitle: {
+    fontSize: 16,
+    fontWeight: 'bold',
+    color: '$primaryDarkText',
+    fontFamily: '$primaryFont',
+  } as TextStyle,
+  cardSubtitle: {
+    fontSize: 13,
+    color: '$primaryDarkGray',
+    marginTop: 2,
+    paddingRight: 28,
+    fontFamily: '$primaryFont',
+  } as TextStyle,
+  progressText: {
+    fontSize: 12,
+    color: '$primaryDarkGray',
+    fontFamily: '$primaryFont',
+  } as TextStyle,
+  track: {
+    height: 6,
+    borderRadius: 3,
+    backgroundColor: '$borderColor',
+    marginTop: 10,
+    overflow: 'hidden',
+  } as ViewStyle,
+  fill: {
+    height: 6,
+    borderRadius: 3,
+    backgroundColor: '$primaryBlue',
+  } as ViewStyle,
+  itemsWrap: {
+    marginTop: 6,
+  } as ViewStyle,
+  itemRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 6,
+  } as ViewStyle,
+  itemLabel: {
+    fontSize: 14,
+    color: '$primaryDarkText',
+    marginLeft: 10,
+    fontFamily: '$primaryFont',
+  } as TextStyle,
+  itemLabelDone: {
+    textDecorationLine: 'line-through',
+    opacity: 0.5,
+  } as TextStyle,
+  itemLabelAction: {
+    color: '$primaryBlue',
+    fontWeight: '600',
+  } as TextStyle,
+});

--- a/src/utils/wavesOnboarding.test.ts
+++ b/src/utils/wavesOnboarding.test.ts
@@ -62,6 +62,18 @@ describe('deriveWavesOnboardingState', () => {
     expect(deriveWavesOnboardingState(makeQuests() as any, null, [], NOW)).toBeNull();
   });
 
+  it('returns null for a truthy but partial account object', () => {
+    expect(deriveWavesOnboardingState(makeQuests() as any, {} as any, [], NOW)).toBeNull();
+    expect(
+      deriveWavesOnboardingState(
+        makeQuests() as any,
+        { created: '2026-07-01T00:00:00' } as any,
+        [],
+        NOW,
+      ),
+    ).toBeNull();
+  });
+
   it('starts with every item incomplete for a fresh account', () => {
     const state = deriveWavesOnboardingState(makeQuests() as any, makeAccount(), [], NOW);
     expect(state).toEqual({

--- a/src/utils/wavesOnboarding.test.ts
+++ b/src/utils/wavesOnboarding.test.ts
@@ -1,0 +1,158 @@
+import { deriveWavesOnboardingState, isNewAccount } from './wavesOnboarding';
+
+const NOW = Date.parse('2026-07-07T12:00:00Z');
+
+const makeQuests = (
+  overrides: {
+    post?: number;
+    vote?: number;
+    comment?: number;
+    checkin?: number;
+    streak?: Record<string, any>;
+  } = {},
+) => {
+  const { post = 0, vote = 0, comment = 0, checkin = 0, streak } = overrides;
+  return {
+    period: { day: '2026-07-07', week: '2026-W28', month: '2026-07', day_resets_in_secs: 3600 },
+    daily: [
+      { id: 'checkin', progress: checkin, reward_each: 1 },
+      { id: 'post', progress: post, cap: 3 },
+      { id: 'comment', progress: comment, cap: 10 },
+      { id: 'vote', progress: vote, cap: 30 },
+    ],
+    weekly: [],
+    monthly: [],
+    streak: { current: 0, best: 0, at_risk: false, ...streak },
+  };
+};
+
+const makeAccount = (overrides: { created?: string; post_count?: number } = {}) => ({
+  created: '2026-07-01T00:00:00',
+  post_count: 0,
+  ...overrides,
+});
+
+describe('isNewAccount', () => {
+  it('treats an account created within the last 30 days as new', () => {
+    expect(isNewAccount({ created: '2026-06-20T00:00:00', post_count: 500 }, NOW)).toBe(true);
+  });
+
+  it('treats an older account with few posts as new', () => {
+    expect(isNewAccount({ created: '2020-01-01T00:00:00', post_count: 9 }, NOW)).toBe(true);
+  });
+
+  it('rejects an older, active account', () => {
+    expect(isNewAccount({ created: '2020-01-01T00:00:00', post_count: 10 }, NOW)).toBe(false);
+  });
+
+  it('falls back to post_count when the created date is malformed', () => {
+    expect(isNewAccount({ created: 'not-a-date', post_count: 3 }, NOW)).toBe(true);
+    expect(isNewAccount({ created: 'not-a-date', post_count: 300 }, NOW)).toBe(false);
+  });
+});
+
+describe('deriveWavesOnboardingState', () => {
+  it('returns null while the quests query has no data yet', () => {
+    expect(deriveWavesOnboardingState(undefined, makeAccount(), [], NOW)).toBeNull();
+    expect(deriveWavesOnboardingState(null, makeAccount(), [], NOW)).toBeNull();
+  });
+
+  it('returns null while the account has not loaded', () => {
+    expect(deriveWavesOnboardingState(makeQuests() as any, undefined, [], NOW)).toBeNull();
+    expect(deriveWavesOnboardingState(makeQuests() as any, null, [], NOW)).toBeNull();
+  });
+
+  it('starts with every item incomplete for a fresh account', () => {
+    const state = deriveWavesOnboardingState(makeQuests() as any, makeAccount(), [], NOW);
+    expect(state).toEqual({
+      eligible: true,
+      items: [
+        { id: 'wave', completed: false },
+        { id: 'vote', completed: false },
+        { id: 'reply', completed: false },
+        { id: 'checkin', completed: false },
+      ],
+      completedCount: 0,
+      totalCount: 4,
+      allComplete: false,
+    });
+  });
+
+  it('marks items complete from daily quest progress', () => {
+    const state = deriveWavesOnboardingState(
+      makeQuests({ post: 1, comment: 2 }) as any,
+      makeAccount(),
+      [],
+      NOW,
+    );
+    expect(state).toMatchObject({
+      items: [
+        { id: 'wave', completed: true },
+        { id: 'vote', completed: false },
+        { id: 'reply', completed: true },
+        { id: 'checkin', completed: false },
+      ],
+      completedCount: 2,
+      allComplete: false,
+    });
+  });
+
+  it('completes check-in via an active streak even without a check-in today', () => {
+    const state = deriveWavesOnboardingState(
+      makeQuests({ streak: { current: 2, best: 4 } }) as any,
+      makeAccount(),
+      [],
+      NOW,
+    );
+    expect(state?.items[3]).toEqual({ id: 'checkin', completed: true });
+  });
+
+  it('keeps previously latched items complete after the daily window resets', () => {
+    const state = deriveWavesOnboardingState(
+      makeQuests() as any,
+      makeAccount(),
+      ['wave', 'vote'],
+      NOW,
+    );
+    expect(state).toMatchObject({
+      items: [
+        { id: 'wave', completed: true },
+        { id: 'vote', completed: true },
+        { id: 'reply', completed: false },
+        { id: 'checkin', completed: false },
+      ],
+      completedCount: 2,
+    });
+  });
+
+  it('reports allComplete when live progress and latched items cover the list', () => {
+    const state = deriveWavesOnboardingState(
+      makeQuests({ vote: 3, checkin: 1 }) as any,
+      makeAccount(),
+      ['wave', 'reply'],
+      NOW,
+    );
+    expect(state).toMatchObject({ completedCount: 4, totalCount: 4, allComplete: true });
+  });
+
+  it('flags established accounts as ineligible while still deriving items', () => {
+    const state = deriveWavesOnboardingState(
+      makeQuests({ post: 1 }) as any,
+      makeAccount({ created: '2020-01-01T00:00:00', post_count: 1200 }),
+      [],
+      NOW,
+    );
+    expect(state).toMatchObject({ eligible: false });
+    expect(state?.items[0]).toEqual({ id: 'wave', completed: true });
+  });
+
+  it('tolerates missing daily and streak sections', () => {
+    const state = deriveWavesOnboardingState(
+      { ...makeQuests(), daily: undefined, streak: undefined } as any,
+      makeAccount(),
+      [],
+      NOW,
+    );
+    expect(state).toMatchObject({ completedCount: 0, allComplete: false });
+  });
+});

--- a/src/utils/wavesOnboarding.test.ts
+++ b/src/utils/wavesOnboarding.test.ts
@@ -87,12 +87,14 @@ describe('deriveWavesOnboardingState', () => {
     );
     expect(state).toMatchObject({
       items: [
-        { id: 'wave', completed: true },
+        // A wave counts as comment activity on chain, so the wave item has no
+        // live quest signal; it completes only via the submit-path latch.
+        { id: 'wave', completed: false },
         { id: 'vote', completed: false },
         { id: 'reply', completed: true },
         { id: 'checkin', completed: false },
       ],
-      completedCount: 2,
+      completedCount: 1,
       allComplete: false,
     });
   });
@@ -139,7 +141,7 @@ describe('deriveWavesOnboardingState', () => {
     const state = deriveWavesOnboardingState(
       makeQuests({ post: 1 }) as any,
       makeAccount({ created: '2020-01-01T00:00:00', post_count: 1200 }),
-      [],
+      ['wave'],
       NOW,
     );
     expect(state).toMatchObject({ eligible: false });

--- a/src/utils/wavesOnboarding.ts
+++ b/src/utils/wavesOnboarding.ts
@@ -2,6 +2,14 @@ import type { QuestsResponse } from '@ecency/sdk';
 
 export type WavesOnboardingItemId = 'wave' | 'vote' | 'reply' | 'checkin';
 
+/**
+ * DeviceEventEmitter event fired on wave submit success. On chain a wave is a
+ * reply into the waves container, so the quests endpoint counts it as comment
+ * activity, not post: the only reliable "posted a wave" signal is the submit
+ * path itself. The mounted checklist listens and latches the item.
+ */
+export const WAVES_ONBOARDING_LATCH_EVENT = 'wavesOnboarding:latch';
+
 export interface WavesOnboardingItem {
   id: WavesOnboardingItemId;
   completed: boolean;
@@ -61,7 +69,9 @@ export const deriveWavesOnboardingState = (
 
   const streak = quests.streak?.current ?? 0;
   const items = [
-    item('wave', dailyProgress(quests, 'post') > 0),
+    // No live quest signal: a wave advances the comment quest (it is a reply
+    // on chain), so this item completes only via the submit-path latch.
+    item('wave', false),
     item('vote', dailyProgress(quests, 'vote') > 0),
     item('reply', dailyProgress(quests, 'comment') > 0),
     item('checkin', dailyProgress(quests, 'checkin') > 0 || streak >= 1),

--- a/src/utils/wavesOnboarding.ts
+++ b/src/utils/wavesOnboarding.ts
@@ -1,0 +1,79 @@
+import type { QuestsResponse } from '@ecency/sdk';
+
+export type WavesOnboardingItemId = 'wave' | 'vote' | 'reply' | 'checkin';
+
+export interface WavesOnboardingItem {
+  id: WavesOnboardingItemId;
+  completed: boolean;
+}
+
+export interface WavesOnboardingState {
+  /** the account is fresh enough (or quiet enough) to be nudged */
+  eligible: boolean;
+  items: WavesOnboardingItem[];
+  completedCount: number;
+  totalCount: number;
+  allComplete: boolean;
+}
+
+const NEW_ACCOUNT_WINDOW_DAYS = 30;
+const NEW_ACCOUNT_MAX_POSTS = 10;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+const dailyProgress = (quests: QuestsResponse, id: string): number =>
+  quests.daily?.find((q) => q.id === id)?.progress ?? 0;
+
+export const isNewAccount = (
+  account: { created: string; post_count: number },
+  now = Date.now(),
+): boolean => {
+  // Hive timestamps come without a timezone marker but are UTC.
+  const { created } = account;
+  const createdAt = Date.parse(created.indexOf('Z') === -1 ? `${created}Z` : created);
+  const withinWindow =
+    Number.isFinite(createdAt) && now - createdAt <= NEW_ACCOUNT_WINDOW_DAYS * DAY_MS;
+  return withinWindow || account.post_count < NEW_ACCOUNT_MAX_POSTS;
+};
+
+/**
+ * Pure derivation of the waves onboarding checklist from the quests endpoint
+ * response + account freshness. Daily quest progress resets at 00:00 UTC, so the
+ * caller passes completions it already latched to storage: a checklist item must
+ * never un-check itself the next day. Returns null until both inputs arrive so
+ * callers can distinguish "loading" from "nothing to show". Mirrors the web
+ * implementation (vision-next deriveWavesOnboardingState) so both apps behave
+ * the same.
+ */
+export const deriveWavesOnboardingState = (
+  quests: QuestsResponse | null | undefined,
+  account: { created: string; post_count: number } | null | undefined,
+  persistedCompleted: WavesOnboardingItemId[] = [],
+  now = Date.now(),
+): WavesOnboardingState | null => {
+  if (!quests || !account) {
+    return null;
+  }
+
+  const item = (id: WavesOnboardingItemId, liveComplete: boolean): WavesOnboardingItem => ({
+    id,
+    completed: liveComplete || persistedCompleted.includes(id),
+  });
+
+  const streak = quests.streak?.current ?? 0;
+  const items = [
+    item('wave', dailyProgress(quests, 'post') > 0),
+    item('vote', dailyProgress(quests, 'vote') > 0),
+    item('reply', dailyProgress(quests, 'comment') > 0),
+    item('checkin', dailyProgress(quests, 'checkin') > 0 || streak >= 1),
+  ];
+
+  const completedCount = items.filter((i) => i.completed).length;
+
+  return {
+    eligible: isNewAccount(account, now),
+    items,
+    completedCount,
+    totalCount: items.length,
+    allComplete: completedCount === items.length,
+  };
+};

--- a/src/utils/wavesOnboarding.ts
+++ b/src/utils/wavesOnboarding.ts
@@ -58,7 +58,9 @@ export const deriveWavesOnboardingState = (
   persistedCompleted: WavesOnboardingItemId[] = [],
   now = Date.now(),
 ): WavesOnboardingState | null => {
-  if (!quests || !account) {
+  // The redux currentAccount can be a truthy-but-partial object before the
+  // chain account loads; treat it as still loading.
+  if (!quests || typeof account?.created !== 'string' || typeof account?.post_count !== 'number') {
     return null;
   }
 


### PR DESCRIPTION
Mobile counterpart of ecency/vision-next#1116: a dismissible "Getting started" checklist card at the top of the Waves screen for new accounts (younger than 30 days or fewer than 10 posts), nudging the first wave as the first action.

- Four items derived from the daily quests API and streak state: post your first wave (opens the wave quick-post sheet), vote on a wave, reply to someone, check in to start your streak (opens Perks).
- Completion latches per user (realm storage wrapper) so the daily quest reset at 00:00 UTC never un-checks an item; one-time "All done" celebration, then hidden. Dismissible at any point.
- Pure derivation util with jest tests, mirroring the quest chip pattern; copy and semantics identical to the web card.

Full jest suite 595 passed / 0 failures; prettier and eslint clean on touched files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Getting started” Waves onboarding checklist card with progress, step-by-step actions (post/vote/reply/check-in), and an “All done 🎉” completion state.
  * The checklist appears for logged-in users on both the Waves and feed entry flows, supports dismiss, and routes each step to the right place.
  * Added the full onboarding copy for the new checklist.
  * New onboarding checklist UI styling.
* **Bug Fixes**
  * Preserves checklist progress across reloads and quest-window changes, preventing progress from resetting unexpectedly.
* **Tests**
  * Added unit tests for eligibility, derived completion rules (including streak/check-in), and persisted progress behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->