### PR TITLE
Fix translate chip overlapping vote count; open waves links natively

### DIFF
--- a/src/components/postCard/styles/postCard.styles.ts
+++ b/src/components/postCard/styles/postCard.styles.ts
@@ -19,7 +19,7 @@ export default EStyleSheet.create({
     color: '$iconColor',
     margin: 0,
     width: 20,
-    marginLeft: 25,
+    marginLeft: 12,
   },
   postBodyWrapper: {
     marginHorizontal: 9,
@@ -77,8 +77,10 @@ export default EStyleSheet.create({
     flexDirection: 'row',
     justifyContent: 'flex-start',
   },
+  // sized by content (no flex) so extra actions like the translate chip can
+  // never overflow leftwards over the vote count; the left wrapper absorbs
+  // the remaining row width instead
   rightFooterWrapper: {
-    flex: 1,
     flexDirection: 'row',
     justifyContent: 'flex-end',
   },

--- a/src/components/postElements/body/view/postBodyView.tsx
+++ b/src/components/postElements/body/view/postBodyView.tsx
@@ -181,7 +181,7 @@ const PostBody = ({
           author,
           permlink,
         },
-        key: permlink,
+        key: `${author}/${permlink}`,
       });
     }
   };

--- a/src/components/postElements/body/view/postBodyView.tsx
+++ b/src/components/postElements/body/view/postBodyView.tsx
@@ -17,6 +17,7 @@ import { GLOBAL_POST_FILTERS_VALUE } from '../../../../constants/options/filters
 import { CopyModal, ImageViewer, PostHtmlRenderer, VideoPlayer } from '../../..';
 import { useAppDispatch, useLinkProcessor } from '../../../../hooks';
 import { isHiveUri, isWebUrl } from '../../../../utils/hive-uri';
+import { parseWavesUrl } from '../../../../utils/postUrlParser';
 import showExploreLinkWarning from '../../../../utils/showExploreLinkWarning';
 import { SheetNames } from '../../../../navigation/sheets';
 
@@ -216,10 +217,19 @@ const PostBody = ({
   const _handleSetSelectedLink = (link) => {
     if (isHiveUri(link)) {
       linkProcessor.handleLink(link);
-    } else {
-      setSelectedLink(link);
-      actionLink.current.show();
+      return;
     }
+
+    // waves permalinks have no @author segment, so render-helper classifies
+    // them as external; open the wave thread natively instead of the link sheet
+    const wavesLink = parseWavesUrl(link);
+    if (wavesLink) {
+      _handleOnPostPress(wavesLink.permlink, wavesLink.author);
+      return;
+    }
+
+    setSelectedLink(link);
+    actionLink.current.show();
   };
 
   const _handleSetSelectedImage = (imageLink, postImgUrls) => {

--- a/src/components/postHtmlRenderer/postInteractionHandler.tsx
+++ b/src/components/postHtmlRenderer/postInteractionHandler.tsx
@@ -16,6 +16,7 @@ import VideoPlayer from '../videoPlayer/videoPlayerView';
 
 import { PostTypes } from '../../constants/postTypes';
 import { isHiveUri, isWebUrl } from '../../utils/hive-uri';
+import { parseWavesUrl } from '../../utils/postUrlParser';
 import showExploreLinkWarning from '../../utils/showExploreLinkWarning';
 import { ImageViewer } from '../imageViewer';
 import { useLinkProcessor } from '../../hooks';
@@ -53,10 +54,26 @@ export const PostHtmlInteractionHandler = forwardRef(
       handleLinkPress: (url: string) => {
         if (isHiveUri(url)) {
           linkProcessor.handleLink(url);
-        } else {
-          setSelectedLink(url);
-          actionLink.current?.show();
+          return;
         }
+
+        // waves permalinks have no @author segment, so render-helper classifies
+        // them as external; open the wave thread natively instead of the link sheet
+        const wavesLink = parseWavesUrl(url);
+        if (wavesLink) {
+          navigation.navigate({
+            name: ROUTES.SCREENS.POST,
+            params: {
+              author: wavesLink.author,
+              permlink: wavesLink.permlink,
+            },
+            key: `${wavesLink.author}/${wavesLink.permlink}`,
+          } as never);
+          return;
+        }
+
+        setSelectedLink(url);
+        actionLink.current?.show();
       },
       handleYoutubePress: (videoId, startTime) => {
         if (videoId && youtubePlayerRef.current) {

--- a/src/utils/deepLinkParser.test.ts
+++ b/src/utils/deepLinkParser.test.ts
@@ -61,6 +61,12 @@ describe('deepLinkParser', () => {
       expect(result.name).toBe(ROUTES.TABBAR.WAVES);
       expect(result.key).toBe('waves');
     });
+
+    it('routes waves permalink named like a profile filter to post screen', async () => {
+      const result = await deepLinkParser('https://ecency.com/waves/alice/wallet');
+      expect(result.name).toBe(ROUTES.SCREENS.POST);
+      expect(result.params).toEqual({ author: 'alice', permlink: 'wallet' });
+    });
   });
 
   describe('profile URLs', () => {

--- a/src/utils/deepLinkParser.test.ts
+++ b/src/utils/deepLinkParser.test.ts
@@ -35,6 +35,34 @@ describe('deepLinkParser', () => {
     });
   });
 
+  describe('waves URLs', () => {
+    it('routes waves permalink (no @author) to post screen', async () => {
+      const result = await deepLinkParser('https://ecency.com/waves/jza/wave-202677t12348900z');
+      expect(result.name).toBe(ROUTES.SCREENS.POST);
+      expect(result.params).toEqual({ author: 'jza', permlink: 'wave-202677t12348900z' });
+      expect(result.key).toBe('jza/wave-202677t12348900z');
+    });
+
+    it('routes waves permalink with @author to post screen', async () => {
+      const result = await deepLinkParser('https://ecency.com/waves/@jza/wave-202677t12348900z');
+      expect(result.name).toBe(ROUTES.SCREENS.POST);
+      expect(result.params).toEqual({ author: 'jza', permlink: 'wave-202677t12348900z' });
+    });
+
+    it('parses ecency:// deep link for waves', async () => {
+      const result = await deepLinkParser('ecency://waves/jza/wave-202677t12348900z');
+      expect(result.name).toBe(ROUTES.SCREENS.POST);
+      expect(result.params.author).toBe('jza');
+      expect(result.params.permlink).toBe('wave-202677t12348900z');
+    });
+
+    it('routes bare waves url to waves tab', async () => {
+      const result = await deepLinkParser('https://ecency.com/waves');
+      expect(result.name).toBe(ROUTES.TABBAR.WAVES);
+      expect(result.key).toBe('waves');
+    });
+  });
+
   describe('profile URLs', () => {
     it('routes to profile when author only (no permlink)', async () => {
       const result = await deepLinkParser('https://ecency.com/@alice');

--- a/src/utils/deepLinkParser.ts
+++ b/src/utils/deepLinkParser.ts
@@ -110,6 +110,11 @@ export const deepLinkParser = async (url) => {
         params = {};
         keey = 'wallet';
         break;
+      case 'waves':
+        routeName = ROUTES.TABBAR.WAVES;
+        params = {};
+        keey = 'waves';
+        break;
       default:
         break;
     }

--- a/src/utils/deepLinkParser.ts
+++ b/src/utils/deepLinkParser.ts
@@ -1,6 +1,6 @@
 import get from 'lodash/get';
 import { getQueryClient, getAccountFullQueryOptions } from '@ecency/sdk';
-import postUrlParser from './postUrlParser';
+import postUrlParser, { parseWavesUrl } from './postUrlParser';
 import parseAuthUrl, { AUTH_MODES } from './parseAuthUrl';
 import ROUTES from '../constants/routeNames';
 import parsePurchaseUrl from './parsePurchaseUrl';
@@ -12,6 +12,18 @@ export const deepLinkParser = async (url) => {
   let params;
   let profile;
   let keey;
+
+  // waves permalinks always open the thread view; route them before the
+  // generic author/permlink flow so reserved permlink names like 'wallet'
+  // or 'followers' cannot be misread as profile filters
+  const wavesLink = parseWavesUrl(url);
+  if (wavesLink) {
+    return {
+      name: ROUTES.SCREENS.POST,
+      params: { author: wavesLink.author, permlink: wavesLink.permlink },
+      key: `${wavesLink.author}/${wavesLink.permlink}`,
+    };
+  }
 
   // profess url for post/content
   const postUrl = postUrlParser(url);

--- a/src/utils/postUrlParser.test.ts
+++ b/src/utils/postUrlParser.test.ts
@@ -15,7 +15,7 @@ describe('parseWavesUrl', () => {
     });
   });
 
-  it('parses www host and ecency:// scheme', () => {
+  it('parses www host and ecency:// / esteem:// schemes', () => {
     expect(parseWavesUrl('https://www.ecency.com/waves/alice.bob/wave-1a2b')).toEqual({
       author: 'alice.bob',
       permlink: 'wave-1a2b',
@@ -23,6 +23,28 @@ describe('parseWavesUrl', () => {
     expect(parseWavesUrl('ecency://waves/jza/wave-1a2b')).toEqual({
       author: 'jza',
       permlink: 'wave-1a2b',
+    });
+    expect(parseWavesUrl('esteem://waves/jza/wave-1a2b')).toEqual({
+      author: 'jza',
+      permlink: 'wave-1a2b',
+    });
+  });
+
+  it('parses legacy ecency-owned hosts', () => {
+    expect(parseWavesUrl('https://esteem.app/waves/jza/wave-1a2b')).toEqual({
+      author: 'jza',
+      permlink: 'wave-1a2b',
+    });
+    expect(parseWavesUrl('https://estm.to/waves/jza/wave-1a2b')).toEqual({
+      author: 'jza',
+      permlink: 'wave-1a2b',
+    });
+  });
+
+  it('lowercases author but preserves permlink case', () => {
+    expect(parseWavesUrl('https://Ecency.com/waves/@Jza/wave-1A2B')).toEqual({
+      author: 'jza',
+      permlink: 'wave-1A2B',
     });
   });
 

--- a/src/utils/postUrlParser.test.ts
+++ b/src/utils/postUrlParser.test.ts
@@ -1,0 +1,60 @@
+import postUrlParser, { parseWavesUrl } from './postUrlParser';
+
+describe('parseWavesUrl', () => {
+  it('parses waves permalink without @author', () => {
+    expect(parseWavesUrl('https://ecency.com/waves/jza/wave-202677t12348900z')).toEqual({
+      author: 'jza',
+      permlink: 'wave-202677t12348900z',
+    });
+  });
+
+  it('parses waves permalink with @author', () => {
+    expect(parseWavesUrl('https://ecency.com/waves/@jza/wave-202677t12348900z')).toEqual({
+      author: 'jza',
+      permlink: 'wave-202677t12348900z',
+    });
+  });
+
+  it('parses www host and ecency:// scheme', () => {
+    expect(parseWavesUrl('https://www.ecency.com/waves/alice.bob/wave-1a2b')).toEqual({
+      author: 'alice.bob',
+      permlink: 'wave-1a2b',
+    });
+    expect(parseWavesUrl('ecency://waves/jza/wave-1a2b')).toEqual({
+      author: 'jza',
+      permlink: 'wave-1a2b',
+    });
+  });
+
+  it('ignores query params and fragments', () => {
+    expect(parseWavesUrl('https://ecency.com/waves/jza/wave-1a2b?referral=alice#foo')).toEqual({
+      author: 'jza',
+      permlink: 'wave-1a2b',
+    });
+  });
+
+  it('returns null for non-waves and non-ecency urls', () => {
+    expect(parseWavesUrl('https://ecency.com/hive/@alice/my-post')).toBeNull();
+    expect(parseWavesUrl('https://ecency.com/waves')).toBeNull();
+    expect(parseWavesUrl('https://example.com/waves/jza/wave-1a2b')).toBeNull();
+    expect(parseWavesUrl('https://ecency.com/@alice')).toBeNull();
+    expect(parseWavesUrl('')).toBeNull();
+  });
+});
+
+describe('postUrlParser', () => {
+  it('resolves waves permalink to author/permlink', () => {
+    expect(postUrlParser('https://ecency.com/waves/jza/wave-202677t12348900z')).toEqual({
+      author: 'jza',
+      permlink: 'wave-202677t12348900z',
+    });
+  });
+
+  it('still resolves regular post urls', () => {
+    expect(postUrlParser('https://ecency.com/hive/@alice/my-first-post')).toEqual({
+      category: 'hive',
+      author: 'alice',
+      permlink: 'my-first-post',
+    });
+  });
+});

--- a/src/utils/postUrlParser.ts
+++ b/src/utils/postUrlParser.ts
@@ -14,11 +14,14 @@ export const parseWavesUrl = (url: string): PostUrlParseResult | null => {
     return null;
   }
 
-  const normalized = url.toLowerCase().replace(/^(ecency|esteem):\/\//, 'https://ecency.com/');
-  const match = normalized.match(/^https?:\/\/(?:www\.)?ecency\.com\/waves\/@?([\w.-]+)\/([\w-]+)/);
+  const normalized = url.replace(/^(ecency|esteem):\/\//i, 'https://ecency.com/');
+  const match = normalized.match(
+    /^https?:\/\/(?:www\.)?(?:ecency\.com|esteem\.app|estm\.to)\/waves\/@?([\w.-]+)\/([\w-]+)/i,
+  );
   if (match) {
     return {
-      author: match[1],
+      // account names are lowercase-only on Hive; keep the permlink as written
+      author: match[1].toLowerCase(),
       permlink: match[2],
     };
   }

--- a/src/utils/postUrlParser.ts
+++ b/src/utils/postUrlParser.ts
@@ -6,6 +6,26 @@ interface PostUrlParseResult {
   permlink?: string | null;
 }
 
+// Waves permalinks (https://ecency.com/waves/{author}/{permlink}) carry no @
+// before the author segment, so none of the @-based post regexes below match
+// them; parse them explicitly so wave links open natively as a thread.
+export const parseWavesUrl = (url: string): PostUrlParseResult | null => {
+  if (!url) {
+    return null;
+  }
+
+  const normalized = url.toLowerCase().replace(/^(ecency|esteem):\/\//, 'https://ecency.com/');
+  const match = normalized.match(/^https?:\/\/(?:www\.)?ecency\.com\/waves\/@?([\w.-]+)\/([\w-]+)/);
+  if (match) {
+    return {
+      author: match[1],
+      permlink: match[2],
+    };
+  }
+
+  return null;
+};
+
 const parseCatAuthorPermlink = (u: string): PostUrlParseResult | null => {
   const postRegex = /^https?:\/\/(.*)\/(.*)\/(@[\w.\d-]+)\/(.*?)(?:\?|$)/i;
   const postMatch = u.match(postRegex);
@@ -64,6 +84,11 @@ const postUrlParser = (url: string): PostUrlParseResult | null => {
     url = url
       .replace('ecency://', 'https://ecency.com/')
       .replace('esteem://', 'https://ecency.com/');
+  }
+
+  const wavesMatch = parseWavesUrl(url);
+  if (wavesMatch) {
+    return wavesMatch;
   }
 
   // eslint-disable-next-line no-useless-escape


### PR DESCRIPTION
Two feed/content fixes:

**Translate chip overlapping vote count (feed cards)**
The post card footer split into two `flex: 1` halves; with the translate chip as a 4th right-side action, the right group's fixed-width children exceeded their 50% share and overflowed leftwards over the heart/vote count (RN doesn't clip, `justifyContent: flex-end` spills toward the left). The right group is now sized by content so it can never be pushed over the left group, and icon spacing is tightened (25 -> 12) so four actions fit on narrow screens.

**Waves links opened the generic link sheet**
Waves permalinks (`ecency.com/waves/{author}/{permlink}`) have no `@author` segment, so render-helper classifies them as external links and taps showed the Copy / Open in Explore / Open in System browser sheet. Added `parseWavesUrl` in `postUrlParser`:
- body-link taps (`postInteractionHandler`, `postBodyView`) now open the wave in the post/thread screen (which already renders waves via `isWavePost`)
- OS deep links route the same way via `deepLinkParser`; bare `/waves` links land on the Waves tab
- covers `@`-prefixed variants, `www.`, and `ecency://waves/...` scheme links

Added unit tests for the parser and deep-link routing (39 tests in the two suites, full suite green).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for opening Waves permalinks directly in the relevant post thread.
  * Added support for Waves deep links, including links with or without an `@` author prefix.
  * Added routing for the standalone Waves page (including `ecency.com/waves` patterns).
* **UI Improvements**
  * Reduced spacing around the comment icon for a more compact post footer.
* **Bug Fixes**
  * Waves links now route directly to the post thread (instead of showing link options), with improved navigation targeting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->