### PR TITLE
chore(deps): bump @ecency/sdk to 2.3.48

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@babel/preset-typescript": "^7.26.0",
     "@babel/runtime": "^7.26.7",
     "@ecency/render-helper": "^2.5.17",
-    "@ecency/sdk": "^2.3.41",
+    "@ecency/sdk": "^2.3.48",
     "@esteemapp/react-native-autocomplete-input": "^4.2.1",
     "@esteemapp/react-native-multi-slider": "^1.1.0",
     "@native-html/iframe-plugin": "^2.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1211,10 +1211,10 @@
     url "^0.11.0"
     xss "^1.0.9"
 
-"@ecency/sdk@^2.3.41":
-  version "2.3.41"
-  resolved "https://registry.yarnpkg.com/@ecency/sdk/-/sdk-2.3.41.tgz#ef150556b13118f1bc8545c2c686de11b40226e7"
-  integrity sha512-eyl8i1zExPywMO3b6ZZbvuL89Ssn+uYGQyTCwGFsS7gRXCx1X2WJED8sxYD1iCNr3Ay0O3MVA9iOwOqpT6USMw==
+"@ecency/sdk@^2.3.48":
+  version "2.3.48"
+  resolved "https://registry.yarnpkg.com/@ecency/sdk/-/sdk-2.3.48.tgz#c44a2a7c7342bf2955b47a5196b66c162b2d5086"
+  integrity sha512-/qUpfDDUaASlWEwi5r1IU9NDDOEjVZEgxlnhp4LUqWCZ40b3XBKzfYPx+qQZPhN6T1XFjZaPPnRVQGr8loV77g==
   dependencies:
     "@noble/ciphers" "^2.1.1"
     "@noble/curves" "^2.0.1"


### PR DESCRIPTION
Bumps `@ecency/sdk` from `^2.3.41` to `^2.3.48` (lockfile updated; dependency set unchanged).

Includes the search-api client header and SDK fixes released since 2.3.41. No app-code changes required; the header ships by default. A `setClientId("mobile")` call can be wired later for analytics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Ecency SDK dependency to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->