### PR TITLE
fix(editor): open saved drafts at the top instead of scrolling to the bottom

### DIFF
--- a/src/components/markdownEditor/view/markdownEditorView.tsx
+++ b/src/components/markdownEditor/view/markdownEditorView.tsx
@@ -103,19 +103,6 @@ const MarkdownEditorView = ({
   const tooltipRef = useRef<any>(null);
   const bodyTextRef = useRef('');
   const bodySelectionRef = useRef({ start: 0, end: 0 });
-  // Set when we open an existing post/draft (not a reply) that has no saved caret:
-  // in that case the draft-restore effect lands the cursor at the top and blurs the
-  // body so the view stays at the start and there is no active cursor to prepend
-  // into. The delayed focus effect reads this to skip focusing. Kept as a ref (not
-  // state) so toggling it never re-renders this deliberately-uncontrolled editor.
-  const suppressBodyAutoFocusRef = useRef(false);
-  // Records the selection we last pushed to native via setNativeProps (draft
-  // restore, snippet/link/media insert, reset). Native may echo that programmatic
-  // selection back through onSelectionChange; we must not treat that echo as a user
-  // caret move and persist it — otherwise restoring a no-caret draft at position 0
-  // would save caret 0, and the next open would resume focused at 0 (prepend), the
-  // very behavior this fix removes. Cleared after the matching echo is skipped.
-  const lastProgrammaticSelectionRef = useRef<{ start: number; end: number } | null>(null);
 
   const draftBtnTooltipState = useAppSelector((state) => state.walkthrough.walkthroughMap);
   const draftBtnTooltipRegistered = draftBtnTooltipState.get(walkthrough.EDITOR_DRAFT_BTN);
@@ -164,24 +151,21 @@ const MarkdownEditorView = ({
         selection: { start: caret, end: caret },
         text: draftBody,
       });
-      // Opening a post/draft with no saved caret intentionally lands at position 0.
-      // Do NOT keep an active cursor there: an auto-focused caret at 0 would prepend
-      // on the next keystroke (the concern that reverted the previous fix) and the
-      // keyboard would cover the draft. Blur the body and tell the delayed focus
-      // effect to skip, so the view stays at the top and the user taps where they
-      // want to continue — matching web, which opens drafts unfocused at the top.
       // Drop any caret write queued from the empty input's initial focus before this
       // load. It is stale relative to this authoritative restore (no real edit has
       // happened yet — the body just arrived), and would otherwise persist a caret 0
       // under this draft's key: on a no-caret draft that resurfaces prepend-on-type
       // next open, and on a saved-caret draft it clobbers the position being resumed.
       _persistCaret.cancel();
-      // Replies are exempt (they focus and append); a resume WITH a saved caret keeps
-      // focus so the user continues exactly where they left off. Assign the flag
-      // unconditionally (not just when arming) so a saved-caret restore in the same
-      // mounted view clears a previously-armed suppression instead of leaving it stale.
-      suppressBodyAutoFocusRef.current = !hasSavedCaret && !isReply;
-      if (suppressBodyAutoFocusRef.current) {
+      // Opening a post/draft with no saved caret intentionally lands at position 0.
+      // Do NOT keep an active cursor there: an auto-focused caret at 0 would prepend
+      // on the next keystroke (the concern that reverted the previous fix) and the
+      // keyboard would cover the draft. Blur so the view stays at the top and the
+      // user taps where they want to continue — matching web, which opens drafts
+      // unfocused at the top. The delayed focus effect independently re-derives this
+      // and won't re-focus. Replies focus and append; a saved-caret resume stays
+      // focused so the user continues exactly where they left off.
+      if (!hasSavedCaret && !isReply) {
         inputRef.current?.blur();
       }
     }
@@ -227,12 +211,17 @@ const MarkdownEditorView = ({
     if (isReply || (autoFocusText && inputRef && inputRef.current && draftBtnTooltipRegistered)) {
       // added delay to open keyboard, solves the issue of keyboard not opening
       setTimeout(() => {
-        // Skip focusing when we restored an existing post/draft without a saved
-        // caret: focusing would drop the cursor at the top (prepend-on-type) and
-        // slide the keyboard over the draft. Checked at fire time (1s later) so the
-        // flag the draft-restore effect set synchronously is already in place.
-        // Replies always focus for immediate typing.
-        if (isReply || !suppressBodyAutoFocusRef.current) {
+        // Skip focusing when we restored an existing non-reply body that still has no
+        // saved caret: focusing would drop the cursor at the top (prepend-on-type) and
+        // slide the keyboard over the draft. Re-derived here at fire time (not a stored
+        // flag) so it can't go stale across draft/compose changes in the same mounted
+        // editor: an empty compose (no body) or a draft the user has since edited (a
+        // caret now exists) both focus normally; replies always focus.
+        const restoredWithoutCaret =
+          !isReply &&
+          bodyTextRef.current !== '' &&
+          typeof store.getState().editor.caretMap?.[caretKeyRef.current] !== 'number';
+        if (!restoredWithoutCaret) {
           inputRef?.current?.focus();
         }
       }, 1000);
@@ -303,29 +292,21 @@ const MarkdownEditorView = ({
   const _handleOnSelectionChange = async (event) => {
     const { selection } = event.nativeEvent;
     bodySelectionRef.current = selection;
-    // The first selection event after a programmatic setNativeProps is its echo, not
-    // a user action. Consume the guard on that next event whatever it reports, so a
-    // dropped, coalesced, or mismatched echo cannot leave it armed and later swallow
-    // a genuine user caret that happens to land on the same offset.
-    const programmatic = lastProgrammaticSelectionRef.current;
-    lastProgrammaticSelectionRef.current = null;
-    if (
-      programmatic &&
-      programmatic.start === selection.start &&
-      programmatic.end === selection.end
-    ) {
-      return;
+    // Only persist caret moves the user actually made. A user caret change requires a
+    // focused input, so gating on focus drops the native echo of a selection we set
+    // programmatically while the body is blurred (restoring a no-caret draft at the
+    // top) — which must not become the saved resume position. Programmatic sets while
+    // the input IS focused (inserts, saved-caret restore) echo the position we mean to
+    // keep anyway, so persisting them is harmless.
+    if (inputRef.current?.isFocused?.()) {
+      _persistCaret(selection.start);
     }
-    _persistCaret(selection.start);
   };
 
   const _setTextAndSelection = useCallback(
     ({ selection: _selection, text: _text }) => {
       bodySelectionRef.current = _selection;
       bodyTextRef.current = _text;
-      // Remember this selection so the native echo of it (via onSelectionChange) is
-      // not mistaken for a user caret move and persisted.
-      lastProgrammaticSelectionRef.current = _selection;
       // Programmatic write (snippet/media/link insert, draft restore, reset).
       // Goes straight to native to avoid the controlled-input race.
       inputRef.current?.setNativeProps({ text: _text, selection: _selection });

--- a/src/components/markdownEditor/view/markdownEditorView.tsx
+++ b/src/components/markdownEditor/view/markdownEditorView.tsx
@@ -170,10 +170,18 @@ const MarkdownEditorView = ({
       // keyboard would cover the draft. Blur the body and tell the delayed focus
       // effect to skip, so the view stays at the top and the user taps where they
       // want to continue — matching web, which opens drafts unfocused at the top.
+      // Drop any caret write queued from the empty input's initial focus before this
+      // load. It is stale relative to this authoritative restore (no real edit has
+      // happened yet — the body just arrived), and would otherwise persist a caret 0
+      // under this draft's key: on a no-caret draft that resurfaces prepend-on-type
+      // next open, and on a saved-caret draft it clobbers the position being resumed.
+      _persistCaret.cancel();
       // Replies are exempt (they focus and append); a resume WITH a saved caret keeps
-      // focus so the user continues exactly where they left off.
-      if (!hasSavedCaret && !isReply) {
-        suppressBodyAutoFocusRef.current = true;
+      // focus so the user continues exactly where they left off. Assign the flag
+      // unconditionally (not just when arming) so a saved-caret restore in the same
+      // mounted view clears a previously-armed suppression instead of leaving it stale.
+      suppressBodyAutoFocusRef.current = !hasSavedCaret && !isReply;
+      if (suppressBodyAutoFocusRef.current) {
         inputRef.current?.blur();
       }
     }
@@ -295,15 +303,17 @@ const MarkdownEditorView = ({
   const _handleOnSelectionChange = async (event) => {
     const { selection } = event.nativeEvent;
     bodySelectionRef.current = selection;
-    // Ignore the native echo of a selection we set programmatically: it is not a
-    // user action, so persisting it would clobber the resume position (see the ref).
+    // The first selection event after a programmatic setNativeProps is its echo, not
+    // a user action. Consume the guard on that next event whatever it reports, so a
+    // dropped, coalesced, or mismatched echo cannot leave it armed and later swallow
+    // a genuine user caret that happens to land on the same offset.
     const programmatic = lastProgrammaticSelectionRef.current;
+    lastProgrammaticSelectionRef.current = null;
     if (
       programmatic &&
       programmatic.start === selection.start &&
       programmatic.end === selection.end
     ) {
-      lastProgrammaticSelectionRef.current = null;
       return;
     }
     _persistCaret(selection.start);

--- a/src/components/markdownEditor/view/markdownEditorView.tsx
+++ b/src/components/markdownEditor/view/markdownEditorView.tsx
@@ -37,6 +37,7 @@ import applySnippet from '../children/formats/applySnippet';
 import styles from '../styles/markdownEditorStyles';
 import { DEFAULT_USER_DRAFT_ID } from '../../../redux/constants/constants';
 import { convertToPollMeta } from '../../../utils/editor';
+import { resolveRestoreCaret } from '../../../utils/editorCaret';
 import { PollModes } from '../../postPoll';
 import { SheetNames } from '../../../navigation/sheets';
 
@@ -102,6 +103,19 @@ const MarkdownEditorView = ({
   const tooltipRef = useRef<any>(null);
   const bodyTextRef = useRef('');
   const bodySelectionRef = useRef({ start: 0, end: 0 });
+  // Set when we open an existing post/draft (not a reply) that has no saved caret:
+  // in that case the draft-restore effect lands the cursor at the top and blurs the
+  // body so the view stays at the start and there is no active cursor to prepend
+  // into. The delayed focus effect reads this to skip focusing. Kept as a ref (not
+  // state) so toggling it never re-renders this deliberately-uncontrolled editor.
+  const suppressBodyAutoFocusRef = useRef(false);
+  // Records the selection we last pushed to native via setNativeProps (draft
+  // restore, snippet/link/media insert, reset). Native may echo that programmatic
+  // selection back through onSelectionChange; we must not treat that echo as a user
+  // caret move and persist it — otherwise restoring a no-caret draft at position 0
+  // would save caret 0, and the next open would resume focused at 0 (prepend), the
+  // very behavior this fix removes. Cleared after the matching echo is skipped.
+  const lastProgrammaticSelectionRef = useRef<{ start: number; end: number } | null>(null);
 
   const draftBtnTooltipState = useAppSelector((state) => state.walkthrough.walkthroughMap);
   const draftBtnTooltipRegistered = draftBtnTooltipState.get(walkthrough.EDITOR_DRAFT_BTN);
@@ -136,20 +150,32 @@ const MarkdownEditorView = ({
 
   useEffect(() => {
     if (bodyTextRef.current === '' && draftBody !== '') {
-      // Resume at the user's last caret position instead of jumping to the end
-      // of the body (which scrolls a long draft to the bottom). Clamp to the
-      // current length in case the body shrank since the caret was saved.
-      // When no caret was saved — a legacy draft, one created on another device,
-      // or the first open after this shipped — fall back to the end of the body
-      // (the long-standing behavior). This keeps the feature purely additive and
-      // avoids dropping the auto-focused cursor at position 0 (prepend-on-type).
+      // Resume at the user's last caret position instead of jumping through the
+      // body. Clamp to the current length in case the body shrank since the caret
+      // was saved. When no caret was saved (a legacy draft, one created on another
+      // device, or the first open after this shipped) the fallback depends on the
+      // surface: a post/draft opens at the TOP (0) so a long body opens at its start
+      // instead of scrolling to the bottom; a reply keeps landing at the END so a
+      // cached comment is appended to, not prepended (its body is short, so there is
+      // no scroll problem and immediate typing is expected).
       const savedCaret = store.getState().editor.caretMap?.[_caretKey];
-      const caret =
-        typeof savedCaret === 'number' ? Math.min(savedCaret, draftBody.length) : draftBody.length;
+      const { caret, hasSavedCaret } = resolveRestoreCaret(savedCaret, draftBody.length, isReply);
       _setTextAndSelection({
         selection: { start: caret, end: caret },
         text: draftBody,
       });
+      // Opening a post/draft with no saved caret intentionally lands at position 0.
+      // Do NOT keep an active cursor there: an auto-focused caret at 0 would prepend
+      // on the next keystroke (the concern that reverted the previous fix) and the
+      // keyboard would cover the draft. Blur the body and tell the delayed focus
+      // effect to skip, so the view stays at the top and the user taps where they
+      // want to continue — matching web, which opens drafts unfocused at the top.
+      // Replies are exempt (they focus and append); a resume WITH a saved caret keeps
+      // focus so the user continues exactly where they left off.
+      if (!hasSavedCaret && !isReply) {
+        suppressBodyAutoFocusRef.current = true;
+        inputRef.current?.blur();
+      }
     }
   }, [draftBody]);
 
@@ -193,7 +219,14 @@ const MarkdownEditorView = ({
     if (isReply || (autoFocusText && inputRef && inputRef.current && draftBtnTooltipRegistered)) {
       // added delay to open keyboard, solves the issue of keyboard not opening
       setTimeout(() => {
-        inputRef?.current?.focus();
+        // Skip focusing when we restored an existing post/draft without a saved
+        // caret: focusing would drop the cursor at the top (prepend-on-type) and
+        // slide the keyboard over the draft. Checked at fire time (1s later) so the
+        // flag the draft-restore effect set synchronously is already in place.
+        // Replies always focus for immediate typing.
+        if (isReply || !suppressBodyAutoFocusRef.current) {
+          inputRef?.current?.focus();
+        }
       }, 1000);
     }
   }, [autoFocusText]);
@@ -260,14 +293,29 @@ const MarkdownEditorView = ({
   );
 
   const _handleOnSelectionChange = async (event) => {
-    bodySelectionRef.current = event.nativeEvent.selection;
-    _persistCaret(event.nativeEvent.selection.start);
+    const { selection } = event.nativeEvent;
+    bodySelectionRef.current = selection;
+    // Ignore the native echo of a selection we set programmatically: it is not a
+    // user action, so persisting it would clobber the resume position (see the ref).
+    const programmatic = lastProgrammaticSelectionRef.current;
+    if (
+      programmatic &&
+      programmatic.start === selection.start &&
+      programmatic.end === selection.end
+    ) {
+      lastProgrammaticSelectionRef.current = null;
+      return;
+    }
+    _persistCaret(selection.start);
   };
 
   const _setTextAndSelection = useCallback(
     ({ selection: _selection, text: _text }) => {
       bodySelectionRef.current = _selection;
       bodyTextRef.current = _text;
+      // Remember this selection so the native echo of it (via onSelectionChange) is
+      // not mistaken for a user caret move and persisted.
+      lastProgrammaticSelectionRef.current = _selection;
       // Programmatic write (snippet/media/link insert, draft restore, reset).
       // Goes straight to native to avoid the controlled-input race.
       inputRef.current?.setNativeProps({ text: _text, selection: _selection });

--- a/src/components/markdownEditor/view/markdownEditorView.tsx
+++ b/src/components/markdownEditor/view/markdownEditorView.tsx
@@ -210,7 +210,7 @@ const MarkdownEditorView = ({
   useEffect(() => {
     if (isReply || (autoFocusText && inputRef && inputRef.current && draftBtnTooltipRegistered)) {
       // added delay to open keyboard, solves the issue of keyboard not opening
-      setTimeout(() => {
+      const focusTimer = setTimeout(() => {
         // Skip focusing when we restored an existing non-reply body that still has no
         // saved caret: focusing would drop the cursor at the top (prepend-on-type) and
         // slide the keyboard over the draft. Re-derived here at fire time (not a stored
@@ -225,6 +225,9 @@ const MarkdownEditorView = ({
           inputRef?.current?.focus();
         }
       }, 1000);
+      // Clear the pending focus if the effect re-runs or the editor unmounts within
+      // the delay, so we never fire focus() on a torn-down input or leak a stale timer.
+      return () => clearTimeout(focusTimer);
     }
   }, [autoFocusText]);
 

--- a/src/utils/editorCaret.test.ts
+++ b/src/utils/editorCaret.test.ts
@@ -1,0 +1,44 @@
+import { resolveRestoreCaret } from './editorCaret';
+
+describe('resolveRestoreCaret', () => {
+  describe('no saved caret (legacy / cross-device / first open)', () => {
+    it('falls back to the TOP (0) for a post/draft so a long body opens at its start', () => {
+      // Regression guard for melinda010100: opening a saved draft must NOT land at
+      // the end of the body (which scrolled the editor to the bottom).
+      expect(resolveRestoreCaret(undefined, 5000, false)).toEqual({
+        caret: 0,
+        hasSavedCaret: false,
+      });
+    });
+
+    it('falls back to the END for a reply so a cached comment is appended, not prepended', () => {
+      expect(resolveRestoreCaret(undefined, 320, true)).toEqual({
+        caret: 320,
+        hasSavedCaret: false,
+      });
+    });
+
+    it('top fallback is 0 even for an empty post body', () => {
+      expect(resolveRestoreCaret(undefined, 0, false)).toEqual({ caret: 0, hasSavedCaret: false });
+    });
+  });
+
+  describe('with a saved caret', () => {
+    it('resumes at the saved offset for a post/draft', () => {
+      expect(resolveRestoreCaret(30, 5000, false)).toEqual({ caret: 30, hasSavedCaret: true });
+    });
+
+    it('resumes at the saved offset for a reply', () => {
+      expect(resolveRestoreCaret(12, 320, true)).toEqual({ caret: 12, hasSavedCaret: true });
+    });
+
+    it('clamps a stale saved caret to the current (shrunk) body length', () => {
+      expect(resolveRestoreCaret(99999, 500, false)).toEqual({ caret: 500, hasSavedCaret: true });
+    });
+
+    // A saved caret of 0 must count as present, not fall through to the reply-end fallback.
+    it('treats a saved caret of 0 as present', () => {
+      expect(resolveRestoreCaret(0, 320, true)).toEqual({ caret: 0, hasSavedCaret: true });
+    });
+  });
+});

--- a/src/utils/editorCaret.ts
+++ b/src/utils/editorCaret.ts
@@ -1,0 +1,29 @@
+/**
+ * Decide where the caret goes when a body is first loaded into the editor.
+ *
+ * When a caret was previously saved for this target we resume there, clamped to
+ * the current body length (the body may have shrunk since it was saved). When no
+ * caret was saved (a legacy draft, one created on another device, or the first
+ * open after this shipped) the fallback depends on the surface:
+ *  - a post/draft/edit falls back to the TOP (0) so a long body opens at its
+ *    start instead of scrolling to the bottom (the reported bug), and
+ *  - a reply falls back to the END so a cached comment is appended to rather than
+ *    prepended (reply bodies are short, so there is no scroll problem).
+ *
+ * `hasSavedCaret` is returned so the caller can decide whether to keep the body
+ * focused: with no saved caret on a post/draft we intentionally blur so an
+ * auto-focused caret at 0 can't prepend on the next keystroke.
+ *
+ * Kept dependency-free so it can be unit-tested without the editor's heavy module
+ * graph. This logic has been flipped twice historically; the tests lock it down.
+ */
+export const resolveRestoreCaret = (
+  savedCaret: number | undefined,
+  bodyLength: number,
+  isReply: boolean,
+): { caret: number; hasSavedCaret: boolean } => {
+  const hasSavedCaret = typeof savedCaret === 'number';
+  const fallbackCaret = isReply ? bodyLength : 0;
+  const caret = hasSavedCaret ? Math.min(savedCaret as number, bodyLength) : fallbackCaret;
+  return { caret, hasSavedCaret };
+};


### PR DESCRIPTION
## Problem
Opening a saved draft scrolled the editor to the bottom of the body. When a draft had no locally-saved cursor position (legacy drafts, drafts from another device or web, or the first open after caret-resume shipped), the restore logic placed the caret at the end of the body; the multiline input auto-focuses, and focus with the cursor at the end scrolls a long draft to the bottom.

This was a regression: caret-resume originally fell back to the top; a later follow-up flipped the missing-caret fallback to the end (to avoid prepend-on-type), which reintroduced the bottom-scroll.

## Fix
- New pure, unit-tested helper `resolveRestoreCaret(savedCaret, bodyLength, isReply)`:
  - no saved caret -> top (0) for posts/drafts; end for replies (append a cached comment, not prepend)
  - saved caret -> resume there, clamped to the current body length
- Restoring a post/draft with no saved caret leaves the body unfocused (blur + skip the delayed auto-focus), so it opens at the top with no active cursor to prepend into. Replies and empty new-compose keep auto-focus.
- Ignore the native echo of a programmatically-set selection so it is not persisted as a user caret move (which would make position 0 sticky).

## Behavior
- Saved draft -> opens at the top, unfocused; tap to place the caret and continue.
- Draft edited on this device -> resumes at the last cursor position, focused.
- Reply / new-empty compose -> unchanged (auto-focus).
- Inserting image/link/snippet while editing -> unchanged; inserts at the cursor and keeps the caret after the inserted content.

## Tests
New `src/utils/editorCaret.test.ts` covers the caret fallback matrix. Full jest suite passes; lint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved caret and selection restoration for posts/drafts and replies, including correct fallback behavior when no saved caret exists.
  * Prevented caret persistence from being overwritten during programmatic restore flows.
  * Restored caret positions are now clamped to the current text length to avoid out-of-range placement.

* **Editor Experience**
  * Posts/drafts without a saved caret no longer trigger an extra focus/caret moment at load.
  * Replies continue to open with focus and the cursor positioned at the end.

* **Tests**
  * Added coverage for caret restoration scenarios, including edge cases and clamping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->