### PR TITLE
Make "Show Images" work: suppress content images, tap-to-load, and notification thumbnails

### DIFF
--- a/src/components/autoHeightImage/autoHeightImage.test.tsx
+++ b/src/components/autoHeightImage/autoHeightImage.test.tsx
@@ -1,0 +1,107 @@
+import React from 'react';
+import TestRenderer from 'react-test-renderer';
+
+// The point of "Show Images" is that no bytes move. These tests assert on the
+// rendered tree rather than on a flag, because rendering ExpoImage at all --
+// even hidden, zero-sized, or transparent -- would fetch the image.
+
+jest.mock('react-native-reanimated', () => ({
+  useSharedValue: jest.fn(() => ({ value: 0 })),
+  withTiming: jest.fn((v) => v),
+}));
+
+jest.mock('react-native-extended-stylesheet', () => ({
+  create: (styles: any) => styles,
+  value: jest.fn(() => '#000000'),
+}));
+
+// Icon pulls in react-native-vector-icons' native font loading.
+jest.mock('../icon', () => ({ Icon: 'Icon' }));
+
+jest.mock('react-intl', () => ({
+  useIntl: () => ({ formatMessage: ({ id }: { id: string }) => id }),
+}));
+
+const mockUseSelector = jest.fn();
+jest.mock('react-redux', () => ({
+  useSelector: (selector: any) => mockUseSelector(selector),
+}));
+
+// eslint-disable-next-line import/first
+import { AutoHeightImage } from './autoHeightImage';
+// eslint-disable-next-line import/first
+import { clearRevealedImages } from '../../utils/revealedImages';
+
+const IMG_URL = 'https://images.ecency.com/p/big-photo.jpg';
+
+const setHideImages = (hide: boolean) => mockUseSelector.mockReturnValue(hide);
+
+const render = (imgUrl = IMG_URL) => {
+  let tree!: TestRenderer.ReactTestRenderer;
+  TestRenderer.act(() => {
+    tree = TestRenderer.create(
+      <AutoHeightImage contentWidth={300} imgUrl={imgUrl} isAnchored={false} onPress={jest.fn()} />,
+    );
+  });
+  return tree;
+};
+
+// expo-image is globally mocked to the host component 'Image' (see jest.setup).
+const imageCount = (tree: TestRenderer.ReactTestRenderer) =>
+  tree.root.findAllByType('Image').length;
+
+describe('AutoHeightImage — "Show Images" gating', () => {
+  beforeEach(() => {
+    clearRevealedImages();
+    mockUseSelector.mockReset();
+  });
+
+  it('renders the image when "Show Images" is on', () => {
+    setHideImages(false);
+    expect(imageCount(render())).toBe(1);
+  });
+
+  it('mounts no image at all when "Show Images" is off', () => {
+    setHideImages(true);
+    expect(imageCount(render())).toBe(0);
+  });
+
+  it('renders a tappable placeholder in place of the hidden image', () => {
+    setHideImages(true);
+    const tree = render();
+    expect(tree.root.findAllByType('Icon').length).toBe(1);
+  });
+
+  it('loads the image once its placeholder is tapped', () => {
+    setHideImages(true);
+    const tree = render();
+    expect(imageCount(tree)).toBe(0);
+
+    TestRenderer.act(() => {
+      tree.root.findByProps({ accessibilityRole: 'button' }).props.onPress();
+    });
+
+    expect(imageCount(tree)).toBe(1);
+  });
+
+  it('keeps a revealed image loaded across remounts, so one tap is enough', () => {
+    setHideImages(true);
+    const first = render();
+    TestRenderer.act(() => {
+      first.root.findByProps({ accessibilityRole: 'button' }).props.onPress();
+    });
+
+    // Same url mounted elsewhere (feed card -> post detail, or a recycled cell).
+    expect(imageCount(render())).toBe(1);
+  });
+
+  it('does not reveal unrelated images when one is tapped', () => {
+    setHideImages(true);
+    const tree = render();
+    TestRenderer.act(() => {
+      tree.root.findByProps({ accessibilityRole: 'button' }).props.onPress();
+    });
+
+    expect(imageCount(render('https://images.ecency.com/p/other-photo.jpg'))).toBe(0);
+  });
+});

--- a/src/components/autoHeightImage/autoHeightImage.tsx
+++ b/src/components/autoHeightImage/autoHeightImage.tsx
@@ -5,6 +5,8 @@ import EStyleSheet from 'react-native-extended-stylesheet';
 import { Image as ExpoImage } from 'expo-image';
 import { useSharedValue, withTiming } from 'react-native-reanimated';
 import { useViewabilityTracker } from '../../hooks/useViewabilityTracker';
+import { useImageReveal } from '../../hooks/useImageReveal';
+import { HiddenImagePlaceholder } from '../hiddenImagePlaceholder';
 // import { InView } from 'react-native-intersection-observer';
 
 interface AutoHeightImageProps {
@@ -33,6 +35,8 @@ export const AutoHeightImage = ({
   onPress,
 }: AutoHeightImageProps) => {
   const imgRef = useRef<ExpoImage>(null);
+
+  const { isHidden, reveal } = useImageReveal(imgUrl);
 
   const { ref, key, visible, handleIfViewable } = useViewabilityTracker(!enableViewabilityTracker);
 
@@ -142,6 +146,12 @@ export const AutoHeightImage = ({
   useEffect(() => {
     hasSetBounds.current = false;
     setIsLoaded(false);
+    // The rows hosting these are recycled, so the same instance can be handed a
+    // different image. Drop the previous image's measured box: a hidden image
+    // never loads, so nothing would otherwise correct a stale height.
+    setHeight(_initialHeight);
+    setImgWidth(contentWidth);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [imgUrl]);
 
   const handlePress = () => {
@@ -157,6 +167,17 @@ export const AutoHeightImage = ({
       imgRef.current?.[inView ? 'startAnimating' : 'stopAnimating']();
     }
   };
+
+  // "Show Images" is off and this image has not been tapped yet. Return before
+  // ExpoImage is mounted so the bytes are never requested; the placeholder holds
+  // the estimated layout box so revealing does not jolt the surrounding text.
+  if (isHidden) {
+    return (
+      <View style={styles.placeholderWrapper}>
+        <HiddenImagePlaceholder width={imgWidth} height={height} onPress={reveal} />
+      </View>
+    );
+  }
 
   return (
     <TouchableOpacity
@@ -185,6 +206,9 @@ export const AutoHeightImage = ({
 };
 
 const styles = EStyleSheet.create({
+  placeholderWrapper: {
+    marginVertical: 4,
+  },
   gifBadge: {
     position: 'absolute',
     left: 6,

--- a/src/components/comment/view/commentView.tsx
+++ b/src/components/comment/view/commentView.tsx
@@ -16,11 +16,7 @@ import { TextWithIcon } from '../../basicUIElements';
 // Styles
 import styles from './commentStyles';
 import { useAppSelector } from '../../../hooks';
-import {
-  selectCurrentAccount,
-  selectIsLoggedIn,
-  selectHidePostsThumbnails,
-} from '../../../redux/selectors';
+import { selectCurrentAccount, selectIsLoggedIn } from '../../../redux/selectors';
 import { PostTypes } from '../../../constants/postTypes';
 import { UpvoteButton } from '../../postCard/children/upvoteButton';
 import { PostPoll } from '../../postPoll';
@@ -57,7 +53,6 @@ const CommentView = ({
 
   const currentAccount = useAppSelector(selectCurrentAccount);
   const isLoggedIn = useAppSelector(selectIsLoggedIn);
-  const isHideImage = useAppSelector(selectHidePostsThumbnails);
 
   const isMuted = useMemo(
     () => currentAccount.mutes?.indexOf(comment.author) > -1,
@@ -398,7 +393,6 @@ const CommentView = ({
           isShowOwnerIndicator={mainAuthor === comment.author}
           isShowPinnedIndicator={isPinned}
           isShowPromotedIndicator={comment.is_promoted}
-          isHideImage={isHideImage}
           inlineTime={true}
           isFromEcency={isFromEcency}
           customStyle={{ alignItems: 'flex-start', paddingLeft: 12 }}

--- a/src/components/comments/container/commentsContainer.tsx
+++ b/src/components/comments/container/commentsContainer.tsx
@@ -41,7 +41,6 @@ const CommentsContainer = ({
   mainAuthor,
   handleOnOptionsPress,
   selectedPermlink,
-  isHideImage,
   isShowSubComments,
   hasManyComments,
   showAllComments,
@@ -323,7 +322,6 @@ const CommentsContainer = ({
       handleOnOptionsPress={handleOnOptionsPress}
       handleOnUserPress={_handleOnUserPress}
       isOwnProfile={isOwnProfile}
-      isHideImage={isHideImage}
       handleOnVotersPress={_handleOnVotersPress}
       isShowSubComments={isShowSubComments}
       showAllComments={showAllComments}

--- a/src/components/comments/view/commentsView.tsx
+++ b/src/components/comments/view/commentsView.tsx
@@ -29,7 +29,6 @@ const CommentsView = ({
   handleOnUserPress,
   handleOnVotersPress,
   hasManyComments,
-  isHideImage,
   isLoggedIn,
   isShowSubComments,
   mainAuthor,
@@ -132,7 +131,6 @@ const CommentsView = ({
         handleVideoPress={postInteractionRef.current?.handleVideoPress}
         handleYoutubePress={postInteractionRef.current?.handleYoutubePress}
         handleParaSelection={postInteractionRef.current?.handleParaSelection}
-        isHideImage={isHideImage}
         isLoggedIn={isLoggedIn}
         showAllComments={showAllComments}
         isShowSubComments={isShowSubComments}

--- a/src/components/hiddenImagePlaceholder/hiddenImagePlaceholder.tsx
+++ b/src/components/hiddenImagePlaceholder/hiddenImagePlaceholder.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { DimensionValue, Text, TouchableOpacity } from 'react-native';
+import { useIntl } from 'react-intl';
+import EStyleSheet from 'react-native-extended-stylesheet';
+import { Icon } from '../icon';
+
+interface Props {
+  width: DimensionValue;
+  height: DimensionValue;
+  // Compact variant drops the label, for tight spots like grid cells.
+  compact?: boolean;
+  onPress: () => void;
+}
+
+/**
+ * Stand-in for a content image while the "Show Images" setting is off.
+ * Reserves the image's layout box and loads the real image only on tap,
+ * so nothing is fetched until the user asks for it.
+ */
+export const HiddenImagePlaceholder = ({ width, height, compact, onPress }: Props) => {
+  const intl = useIntl();
+
+  // Very short boxes cannot fit the icon and label without clipping.
+  const _compact = compact || (typeof height === 'number' && height < 72);
+
+  return (
+    <TouchableOpacity
+      activeOpacity={0.7}
+      onPress={onPress}
+      style={[styles.container, { width, height }]}
+      accessibilityRole="button"
+      accessibilityLabel={intl.formatMessage({ id: 'post.tap_to_load_image' })}
+    >
+      <Icon
+        iconType="MaterialCommunityIcons"
+        name="image-outline"
+        size={_compact ? 20 : 28}
+        color={EStyleSheet.value('$iconColor')}
+      />
+      {!_compact && (
+        <Text style={styles.label}>{intl.formatMessage({ id: 'post.tap_to_load_image' })}</Text>
+      )}
+    </TouchableOpacity>
+  );
+};
+
+const styles = EStyleSheet.create({
+  container: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: 8,
+    backgroundColor: '$primaryLightBackground',
+    borderWidth: 1,
+    borderColor: '$borderTopColor',
+    borderStyle: 'dashed',
+  },
+  label: {
+    marginTop: 6,
+    color: '$iconColor',
+    fontSize: 12,
+    textAlign: 'center',
+    paddingHorizontal: 8,
+  },
+});
+
+export default HiddenImagePlaceholder;

--- a/src/components/hiddenImagePlaceholder/index.ts
+++ b/src/components/hiddenImagePlaceholder/index.ts
@@ -1,0 +1,1 @@
+export { HiddenImagePlaceholder, default } from './hiddenImagePlaceholder';

--- a/src/components/imageViewer/imageViewer.tsx
+++ b/src/components/imageViewer/imageViewer.tsx
@@ -9,6 +9,8 @@ import RNFetchBlob from 'rn-fetch-blob';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import IconButton from '../iconButton';
 import styles from './imageViewer.styles';
+import { shouldPrefetchImages } from '../../utils/image';
+import { isImageRevealed } from '../../utils/revealedImages';
 
 // eslint-disable-next-line no-empty-pattern
 export const ImageViewer = forwardRef(({}, ref) => {
@@ -24,12 +26,20 @@ export const ImageViewer = forwardRef(({}, ref) => {
 
   useImperativeHandle(ref, () => ({
     show(selectedUrl: string, _imageUrls: string[]) {
-      setImageUrls(_imageUrls);
-      setSelectedIndex(_imageUrls.indexOf(selectedUrl));
+      // The viewer is a swipeable gallery, so it mounts (and therefore fetches)
+      // the neighbours of whatever is on screen. With "Show Images" off, limit it
+      // to the images the user has actually loaded; swiping then moves between
+      // those rather than pulling in the rest of the post behind one tap.
+      const _urls = shouldPrefetchImages()
+        ? _imageUrls
+        : _imageUrls.filter((url) => url === selectedUrl || isImageRevealed(url));
+
+      setImageUrls(_urls);
+      setSelectedIndex(_urls.indexOf(selectedUrl));
       setVisible(true);
 
       if (Platform.OS === 'ios') {
-        ExpoImage.prefetch(_imageUrls, 'memory');
+        ExpoImage.prefetch(_urls, 'memory');
       }
     },
   }));

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -112,6 +112,7 @@ import HiveSignerModal from './hiveSignerModal/hiveSignerModal';
 import OrDivider from './orDivider/orDividerView';
 import PostTranslationModal from './post-translation-modal/postTranslationModal';
 import { ImageViewer } from './imageViewer';
+import { HiddenImagePlaceholder } from './hiddenImagePlaceholder';
 import { WalkthroughMarker } from './walkthroughMarker';
 import { LinkPreview, HiveLinkPreview } from './linkPreview';
 import { CrossPostModal } from './crossPostModal';
@@ -291,6 +292,7 @@ export {
   ProposalVoteRequest,
   FeatureSpotlightCard,
   HiveAuthModal,
+  HiddenImagePlaceholder,
   LinkPreview,
   HiveLinkPreview,
   CrossPostModal,

--- a/src/components/linkPreview/container/linkPreview.tsx
+++ b/src/components/linkPreview/container/linkPreview.tsx
@@ -5,6 +5,7 @@ import EStyleSheet from 'react-native-extended-stylesheet';
 import { Image as ExpoImage } from 'expo-image';
 import { useGetPostQuery } from '../../../providers/queries/postQueries/postQueries';
 import { LinkPreviewPlaceHolder } from '../../basicUIElements';
+import { useImageReveal } from '../../../hooks/useImageReveal';
 import styles from '../styles/linkPreview.styles';
 
 interface LinkPreviewProps {
@@ -29,6 +30,11 @@ export const LinkPreview = ({
   isLoading = false,
 }: LinkPreviewProps) => {
   const _containerStyle = { ...styles.container, width: contentWidth };
+
+  // This 56px thumbnail is the linked post's full-size cover, so it is worth
+  // suppressing. No tap-to-load here: the whole card is a link, and a nested tap
+  // target would steal the tap that should open the post.
+  const { isHidden } = useImageReveal(imageUrl);
 
   // Extract domain name from URL if label is not provided
   const getDomainLabel = (): string => {
@@ -59,7 +65,7 @@ export const LinkPreview = ({
   return (
     <TouchableOpacity onPress={onPress}>
       <View style={_containerStyle}>
-        {imageUrl ? (
+        {imageUrl && !isHidden ? (
           <ExpoImage source={{ uri: imageUrl }} style={styles.thumbnail} />
         ) : (
           <View style={styles.thumbnail} />

--- a/src/components/notificationLine/view/notificationLineView.tsx
+++ b/src/components/notificationLine/view/notificationLineView.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { View, Text, Image, TouchableHighlight, TouchableOpacity } from 'react-native';
 import { useIntl } from 'react-intl';
 import get from 'lodash/get';
@@ -8,6 +8,9 @@ import { UserAvatar } from '../../userAvatar';
 
 import { rcFormatter, vestsToHp } from '../../../utils/conversions';
 import { formatNotificationTimestamp } from '../../../utils/time';
+import { getNotificationImageUrl } from '../../../utils/notificationImage';
+import { useAppSelector } from '../../../hooks';
+import { selectHidePostsThumbnails } from '../../../redux/selectors';
 
 // Styles
 import styles from './notificationLineStyles';
@@ -20,6 +23,11 @@ const NotificationLineView = ({
 }) => {
   const [isRead, setIsRead] = useState(notification.read);
   const intl = useIntl();
+
+  // A post thumbnail is enrichment, not content the user came for, so "Show
+  // Images" simply drops it rather than offering a tap-to-load placeholder.
+  const isHideImages = useAppSelector(selectHidePostsThumbnails);
+  const _imageUrl = useMemo(() => getNotificationImageUrl(notification), [notification]);
   let titleExtra = '';
   let _moreinfo = '';
   const _getMessageValues = () => {
@@ -179,10 +187,10 @@ const NotificationLineView = ({
           )}
         </View>
 
-        {get(notification, 'image', null) && (
+        {!isHideImages && !!_imageUrl && (
           <Image
             style={styles.image}
-            source={{ uri: notification.image }}
+            source={{ uri: _imageUrl }}
             defaultSource={require('../../../assets/no_image.png')}
           />
         )}

--- a/src/components/postCard/children/postCardContent.test.tsx
+++ b/src/components/postCard/children/postCardContent.test.tsx
@@ -1,0 +1,142 @@
+import React from 'react';
+import TestRenderer from 'react-test-renderer';
+
+jest.mock('react-native-extended-stylesheet', () => ({
+  create: (styles: any) => styles,
+  value: jest.fn(() => '#000000'),
+}));
+
+jest.mock('../../icon', () => ({ Icon: 'Icon' }));
+
+jest.mock('react-intl', () => ({
+  useIntl: () => ({ formatMessage: ({ id }: { id: string }) => id }),
+}));
+
+jest.mock('@shopify/flash-list', () => ({
+  useLayoutState: (initial: any) => [initial, jest.fn()],
+}));
+
+jest.mock('@ecency/render-helper', () => ({
+  proxifyImageSrc: jest.fn((url: string) => url),
+}));
+
+// The postCard container re-exports through the component barrel, which drags in
+// the store -> navigation -> native-module chain. Only the enum is needed here.
+jest.mock('../container/postCard', () => ({
+  PostCardActionIds: { NAVIGATE: 'NAVIGATE' },
+}));
+
+const mockUseSelector = jest.fn();
+jest.mock('react-redux', () => ({
+  useSelector: (selector: any) => mockUseSelector(selector),
+}));
+
+// eslint-disable-next-line import/first
+import { PostCardContent } from './postCardContent';
+// eslint-disable-next-line import/first
+import { clearRevealedImages } from '../../../utils/revealedImages';
+
+const setHideImages = (hide: boolean) => mockUseSelector.mockReturnValue(hide);
+
+const render = (content: any) => {
+  let tree!: TestRenderer.ReactTestRenderer;
+  TestRenderer.act(() => {
+    tree = TestRenderer.create(
+      <PostCardContent content={content} nsfw="1" handleCardInteraction={jest.fn()} />,
+    );
+  });
+  return tree;
+};
+
+const withImage = {
+  author: 'a',
+  permlink: 'p',
+  title: 'A post with a photo',
+  summary: 's',
+  image: 'https://images.ecency.com/p/cover.jpg',
+  thumbnail: 'https://images.ecency.com/p/thumb.jpg',
+};
+
+// A text-only post: parsePost leaves thumbnail unset, so postCardContent falls
+// back to the remote "no image" graphic.
+const textOnly = { author: 'a', permlink: 'p2', title: 'Text only', summary: 's' };
+
+const nsfwPost = { ...withImage, permlink: 'p3', nsfw: true };
+
+const imageCount = (tree: TestRenderer.ReactTestRenderer) =>
+  tree.root.findAllByType('Image').length;
+const placeholderCount = (tree: TestRenderer.ReactTestRenderer) =>
+  tree.root.findAllByType('Icon').length;
+
+describe('PostCardContent — "Show Images" gating', () => {
+  beforeEach(() => {
+    clearRevealedImages();
+    mockUseSelector.mockReset();
+  });
+
+  it('renders the thumbnail when "Show Images" is on', () => {
+    setHideImages(false);
+    expect(imageCount(render(withImage))).toBe(1);
+  });
+
+  it('offers a tap-to-load placeholder instead of the thumbnail when off', () => {
+    setHideImages(true);
+    const tree = render(withImage);
+
+    expect(imageCount(tree)).toBe(0);
+    expect(placeholderCount(tree)).toBe(1);
+  });
+
+  it('loads the thumbnail once the placeholder is tapped', () => {
+    setHideImages(true);
+    const tree = render(withImage);
+
+    TestRenderer.act(() => {
+      tree.root.findByProps({ accessibilityRole: 'button' }).props.onPress();
+    });
+
+    expect(imageCount(tree)).toBe(1);
+  });
+
+  it('offers no placeholder on a post that has no image', () => {
+    setHideImages(true);
+    const tree = render(textOnly);
+
+    // Nothing to load, so nothing to fetch and nothing to tap.
+    expect(imageCount(tree)).toBe(0);
+    expect(placeholderCount(tree)).toBe(0);
+  });
+
+  it('offers no placeholder for the NSFW graphic, which is moderation not content', () => {
+    setHideImages(true);
+    const tree = render(nsfwPost);
+
+    expect(imageCount(tree)).toBe(0);
+    expect(placeholderCount(tree)).toBe(0);
+  });
+
+  it('still shows the NSFW graphic when "Show Images" is on', () => {
+    setHideImages(false);
+    expect(imageCount(render(nsfwPost))).toBe(1);
+  });
+
+  it('keeps a GIF revealed across a rotation, despite the width-stamped proxy url', () => {
+    setHideImages(true);
+    // The GIF branch builds imageUri via proxifyImageSrc(original, imgWidth, ...),
+    // so the rendered url changes with the viewport. The reveal must not.
+    const gifPost = {
+      ...withImage,
+      permlink: 'p4',
+      json_metadata: { image: ['https://images.ecency.com/p/anim.gif'] },
+    };
+
+    const tree = render(gifPost);
+    TestRenderer.act(() => {
+      tree.root.findByProps({ accessibilityRole: 'button' }).props.onPress();
+    });
+    expect(imageCount(tree)).toBe(1);
+
+    // Remount as if the device rotated: a new proxy width, same source gif.
+    expect(imageCount(render(gifPost))).toBe(1);
+  });
+});

--- a/src/components/postCard/children/postCardContent.tsx
+++ b/src/components/postCard/children/postCardContent.tsx
@@ -15,6 +15,8 @@ import { PostCardActionIds } from '../container/postCard';
 import ROUTES from '../../../constants/routeNames';
 import { ContentType } from '../../../providers/hive/hive.types';
 import { isCommunity } from '../../../utils/communityValidation';
+import { useImageReveal } from '../../../hooks/useImageReveal';
+import { HiddenImagePlaceholder } from '../../hiddenImagePlaceholder';
 
 // i.ecency.com: same imagehoster backend as images.ecency.com on an
 // SNI-resilient hostname. These constants render directly (they do not pass
@@ -50,12 +52,11 @@ const getStableContentKey = (content?: any) => {
 
 interface Props {
   content: any;
-  isHideImage: boolean;
   nsfw: string;
   handleCardInteraction: (id: PostCardActionIds, payload?: any) => void;
 }
 
-const PostCardContentComponent = ({ content, isHideImage, nsfw, handleCardInteraction }: Props) => {
+const PostCardContentComponent = ({ content, nsfw, handleCardInteraction }: Props) => {
   const intl = useIntl();
   const dim = useWindowDimensions();
   const imgRef = useRef<ExpoImage>(null);
@@ -140,6 +141,16 @@ const PostCardContentComponent = ({ content, isHideImage, nsfw, handleCardIntera
     return images.image;
   }, [isGif, original, images.image, imgWidth]);
 
+  // Key the reveal on the source image rather than imageUri: the GIF branch stamps
+  // the viewport width into the proxy url, so rotating the device would otherwise
+  // re-hide an image the user had already loaded.
+  const { isHidden, reveal } = useImageReveal(original || imageUri);
+
+  // DEFAULT_IMAGE and NSFW_IMAGE are empty-state and moderation graphics, not post
+  // content. There is nothing for the user to "load", so offer no placeholder for
+  // them (and do not fetch them either while the setting is off).
+  const hasContentImage = imageUri !== DEFAULT_IMAGE && imageUri !== NSFW_IMAGE;
+
   // const _toggleGif = (inView: boolean) => {
   //   if (Platform.OS === 'ios') {
   //     setAutoplay(inView);
@@ -151,7 +162,17 @@ const PostCardContentComponent = ({ content, isHideImage, nsfw, handleCardIntera
   return (
     <View style={styles.postBodyWrapper}>
       <TouchableOpacity activeOpacity={0.8} style={styles.hiddenImages} onPress={_onPress}>
-        {!isHideImage && (
+        {isHidden ? (
+          hasContentImage && (
+            <View style={styles.imageWrapper}>
+              <HiddenImagePlaceholder
+                width={imgWidth}
+                height={Math.min(imgHeight, dim.height)}
+                onPress={reveal}
+              />
+            </View>
+          )
+        ) : (
           <View style={styles.imageWrapper}>
             <ExpoImage
               ref={imgRef}
@@ -217,7 +238,6 @@ const PostCardContentComponent = ({ content, isHideImage, nsfw, handleCardIntera
 export const PostCardContent = React.memo(PostCardContentComponent, (prevProps, nextProps) => {
   return (
     prevProps.content === nextProps.content &&
-    prevProps.isHideImage === nextProps.isHideImage &&
     prevProps.nsfw === nextProps.nsfw &&
     prevProps.handleCardInteraction === nextProps.handleCardInteraction
   );

--- a/src/components/postCard/children/postCardHeader.tsx
+++ b/src/components/postCard/children/postCardHeader.tsx
@@ -20,18 +20,11 @@ import { useMinuteTicker } from '../../../hooks/useMinuteTicker';
 interface Props {
   intl: IntlShape;
   content: any;
-  isHideImage: boolean;
   pageType?: 'main' | 'community' | 'profile' | 'ownProfile';
   handleCardInteraction: (id: PostCardActionIds, payload?: any) => void;
 }
 
-const PostCardHeaderComponent = ({
-  intl,
-  content,
-  pageType,
-  isHideImage,
-  handleCardInteraction,
-}: Props) => {
+const PostCardHeaderComponent = ({ intl, content, pageType, handleCardInteraction }: Props) => {
   const rebloggedBy = get(content, 'reblogged_by[0]', null);
 
   // Single shared timer across all PostCards (no per-card interval)
@@ -89,7 +82,6 @@ const PostCardHeaderComponent = ({
       <View style={styles.bodyHeader}>
         <PostHeaderDescription
           date={dateString}
-          isHideImage={isHideImage}
           name={get(content, 'author')}
           profileOnPress={() => handleCardInteraction(PostCardActionIds.USER, content.author)}
           handleOnTagPress={_handleOnTagPress}
@@ -138,7 +130,6 @@ const PostCardHeaderComponent = ({
 export const PostCardHeader = React.memo(PostCardHeaderComponent, (prevProps, nextProps) => {
   return (
     prevProps.content === nextProps.content &&
-    prevProps.isHideImage === nextProps.isHideImage &&
     prevProps.pageType === nextProps.pageType &&
     prevProps.intl === nextProps.intl &&
     prevProps.handleCardInteraction === nextProps.handleCardInteraction

--- a/src/components/postCard/container/postCard.tsx
+++ b/src/components/postCard/container/postCard.tsx
@@ -23,7 +23,7 @@ export enum PostCardActionIds {
   TIP = 'TIP',
 }
 
-const PostCard = ({ intl, content, isHideImage, nsfw, pageType, handleCardInteraction }) => {
+const PostCard = ({ intl, content, nsfw, pageType, handleCardInteraction }) => {
   // Inject this card's `content` into the (stable) parent handler so children
   // receive a referentially-stable callback. The list passes a stable
   // handleCardInteraction; wrapping it here (instead of a fresh inline arrow in
@@ -41,15 +41,9 @@ const PostCard = ({ intl, content, isHideImage, nsfw, pageType, handleCardIntera
         intl={intl}
         content={content}
         pageType={pageType}
-        isHideImage={isHideImage}
         handleCardInteraction={handleInteraction}
       />
-      <PostCardContent
-        content={content}
-        isHideImage={isHideImage}
-        nsfw={nsfw}
-        handleCardInteraction={handleInteraction}
-      />
+      <PostCardContent content={content} nsfw={nsfw} handleCardInteraction={handleInteraction} />
       <PostCardActionsPanel content={content} handleCardInteraction={handleInteraction} />
     </View>
   );
@@ -60,7 +54,6 @@ const PostCard = ({ intl, content, isHideImage, nsfw, pageType, handleCardIntera
 const MemoizedPostCard = React.memo(PostCard, (prevProps, nextProps) => {
   return (
     prevProps.content === nextProps.content &&
-    prevProps.isHideImage === nextProps.isHideImage &&
     prevProps.nsfw === nextProps.nsfw &&
     prevProps.pageType === nextProps.pageType &&
     prevProps.intl === nextProps.intl &&

--- a/src/components/postElements/headerDescription/view/postHeaderDescription.tsx
+++ b/src/components/postElements/headerDescription/view/postHeaderDescription.tsx
@@ -114,7 +114,6 @@ class PostHeaderDescription extends PureComponent {
   render() {
     const {
       date,
-      isHideImage,
       name,
       size,
       tag,
@@ -140,15 +139,15 @@ class PostHeaderDescription extends PureComponent {
             style={styles.avatarNameWrapper}
             onPress={() => this._handleOnAvatarPress(name)}
           >
-            {!isHideImage && (
-              <UserAvatar
-                style={[styles.avatar, { width: size, height: size, borderRadius: size / 2 }]}
-                disableSize
-                username={name}
-                defaultSource={DEFAULT_IMAGE}
-                noAction
-              />
-            )}
+            {/* Avatars are deliberately not gated on "Show Images": they are tiny,
+                cached, and part of identity. The setting suppresses content images. */}
+            <UserAvatar
+              style={[styles.avatar, { width: size, height: size, borderRadius: size / 2 }]}
+              disableSize
+              username={name}
+              defaultSource={DEFAULT_IMAGE}
+              noAction
+            />
           </TouchableOpacity>
 
           <View style={styles.leftContainer}>

--- a/src/components/postHtmlRenderer/videoThumb.tsx
+++ b/src/components/postHtmlRenderer/videoThumb.tsx
@@ -3,6 +3,7 @@ import { View, ImageBackground, TouchableHighlight } from 'react-native';
 import EStyleSheet from 'react-native-extended-stylesheet';
 import { IconButton } from '..';
 import styles from './postHtmlRendererStyles';
+import { useImageReveal } from '../../hooks/useImageReveal';
 
 interface Props {
   contentWidth: number;
@@ -19,11 +20,15 @@ const VideoThumb = ({
   heightRatio = 9 / 16,
   resizeMode = 'cover',
 }: Props) => {
+  const { isHidden } = useImageReveal(uri);
+
   return (
     <TouchableHighlight onPress={onPress} disabled={!onPress}>
       <View pointerEvents="none">
         <ImageBackground
-          source={{ uri }}
+          // The poster is a content image, so "Show Images" suppresses it. The
+          // styled box keeps its play button, so a tap still opens the video.
+          source={isHidden ? undefined : { uri }}
           style={{
             ...styles.videoThumb,
             width: contentWidth,

--- a/src/components/postsList/container/postsListContainer.tsx
+++ b/src/components/postsList/container/postsListContainer.tsx
@@ -25,12 +25,7 @@ import { Separator, UpvotePopover } from '../..';
 import { PostTypes } from '../../../constants/postTypes';
 import { PostOptionsModal } from '../../postOptionsModal';
 import { PostCardActionIds } from '../../postCard/container/postCard';
-import {
-  selectHidePostsThumbnails,
-  selectIsDarkTheme,
-  selectCurrentAccount,
-  selectNsfw,
-} from '../../../redux/selectors';
+import { selectIsDarkTheme, selectCurrentAccount, selectNsfw } from '../../../redux/selectors';
 import { useAppSelector } from '../../../hooks';
 
 export interface PostsListRef {
@@ -77,7 +72,6 @@ const postsListContainer = (
   const postDropdownRef = useRef(null);
 
   // Use memoized selectors to prevent unnecessary re-renders
-  const isHideImages = useAppSelector(selectHidePostsThumbnails);
   const nsfw = useAppSelector(selectNsfw);
   const isDarkTheme = useAppSelector(selectIsDarkTheme);
 
@@ -244,13 +238,12 @@ const postsListContainer = (
   // cells without forcing a full FlashList remount on every dimension tick.
   const listExtraData = useMemo(
     () => ({
-      isHideImages,
       listWidth,
       nsfw,
       pageType,
       propsExtraData,
     }),
-    [isHideImages, listWidth, nsfw, pageType, propsExtraData],
+    [listWidth, nsfw, pageType, propsExtraData],
   );
 
   const _renderItem = useCallback(
@@ -261,13 +254,12 @@ const postsListContainer = (
           key={`${item.author}-${item.permlink}`}
           content={item}
           pageType={pageType}
-          isHideImage={isHideImages}
           nsfw={nsfw}
           handleCardInteraction={_handleCardInteraction}
         />
       );
     },
-    [intl, pageType, isHideImages, nsfw, _handleCardInteraction],
+    [intl, pageType, nsfw, _handleCardInteraction],
   );
 
   return (

--- a/src/components/profile/children/commentsTabContent.tsx
+++ b/src/components/profile/children/commentsTabContent.tsx
@@ -6,8 +6,6 @@ import EStyleSheet from 'react-native-extended-stylesheet';
 import { getAccountPostsQueryOptions } from '@ecency/sdk';
 import { useQueryClient } from '@tanstack/react-query';
 import { Comments, NoPost } from '../..';
-import { useAppSelector } from '../../../hooks';
-import { selectHidePostsThumbnails } from '../../../redux/selectors';
 import styles from '../profileStyles';
 
 interface CommentsTabContentProps {
@@ -27,8 +25,6 @@ const CommentsTabContent = ({
 }: CommentsTabContentProps) => {
   const intl = useIntl();
   const queryClient = useQueryClient();
-
-  const isHideImage = useAppSelector(selectHidePostsThumbnails);
 
   const [data, setData] = useState([]);
   const [lastAuthor, setLastAuthor] = useState('');
@@ -118,7 +114,6 @@ const CommentsTabContent = ({
           console.log('implement fetch if required');
         }}
         isOwnProfile={isOwnProfile}
-        isHideImage={isHideImage}
         flatListProps={{
           onEndReached: _fetchData,
           onScrollEndDrag: onScroll,

--- a/src/components/profile/children/wavesTabContent.tsx
+++ b/src/components/profile/children/wavesTabContent.tsx
@@ -4,8 +4,6 @@ import { useIntl } from 'react-intl';
 import EStyleSheet from 'react-native-extended-stylesheet';
 import { getWavesFeedQueryOptions } from '@ecency/sdk';
 import { Comments, NoPost } from '../..';
-import { useAppSelector } from '../../../hooks';
-import { selectHidePostsThumbnails } from '../../../redux/selectors';
 import { wavesQueries } from '../../../providers/queries';
 import { PostTypes } from '../../../constants/postTypes';
 import styles from '../profileStyles';
@@ -18,7 +16,6 @@ interface WavesTabContentProps {
 
 const WavesTabContent = ({ username, isOwnProfile, onScroll }: WavesTabContentProps) => {
   const intl = useIntl();
-  const isHideImage = useAppSelector(selectHidePostsThumbnails);
 
   // The per-author feed is the same combined endpoint scoped to one author
   // (across every container). No observer is passed: you're deliberately
@@ -60,7 +57,6 @@ const WavesTabContent = ({ username, isOwnProfile, onScroll }: WavesTabContentPr
         comments={wavesQuery.data}
         handleCommentDelete={wavesQuery.deleteWave}
         isOwnProfile={isOwnProfile}
-        isHideImage={isHideImage}
         flatListProps={{
           onEndReached: () => {
             if (wavesQuery.hasNextPage && !wavesQuery.isFetchingNextPage) {

--- a/src/components/similarEntries/children/similarEntryItem.tsx
+++ b/src/components/similarEntries/children/similarEntryItem.tsx
@@ -7,6 +7,8 @@ import { catchPostImage } from '@ecency/render-helper';
 import ROUTES from '../../../constants/routeNames';
 import { getTimeFromNow } from '../../../utils/time';
 import { Icon } from '../../icon';
+import { HiddenImagePlaceholder } from '../../hiddenImagePlaceholder';
+import { useImageReveal } from '../../../hooks/useImageReveal';
 import styles from '../styles/similarEntries.styles';
 
 interface SimilarEntry {
@@ -29,6 +31,8 @@ const SimilarEntryItem = ({ entry }: Props) => {
     return catchPostImage(entry.img_url, 400, 200, 'match');
   }, [entry.img_url]);
 
+  const { isHidden, reveal } = useImageReveal(thumbnail || undefined);
+
   const relativeDate = useMemo(
     () => (entry.created_at ? getTimeFromNow(entry.created_at) : ''),
     [entry.created_at],
@@ -47,7 +51,9 @@ const SimilarEntryItem = ({ entry }: Props) => {
 
   return (
     <TouchableOpacity activeOpacity={0.8} onPress={_onPress} style={styles.card}>
-      {thumbnail ? (
+      {isHidden ? (
+        <HiddenImagePlaceholder width="100%" height={100} onPress={reveal} />
+      ) : thumbnail ? (
         <ExpoImage
           source={{ uri: thumbnail }}
           style={styles.image}

--- a/src/config/locales/en-US.json
+++ b/src/config/locales/en-US.json
@@ -953,6 +953,7 @@
     "a11y_stats_hint": "View post stats",
     "image": "Image",
     "reveal_muted": "MUTED\nTap to reveal content",
+    "tap_to_load_image": "Tap to load image",
     "in": "in",
     "poll": "POLL",
     "copy_link": "Copy link",

--- a/src/containers/profileContainer.tsx
+++ b/src/containers/profileContainer.tsx
@@ -22,7 +22,6 @@ import {
   selectCurrency,
   selectPin,
   selectIsConnected,
-  selectHidePostsThumbnails,
 } from '../redux/selectors';
 import { getDigitPinCode } from '../providers/hive/hive';
 import {
@@ -605,7 +604,7 @@ class ProfileContainer extends Component {
       reverseHeader,
       deepLinkFilter,
     } = this.state;
-    const { currency, isDarkTheme, isLoggedIn, children, isHideImage, route } = this.props;
+    const { currency, isDarkTheme, isLoggedIn, children, route } = this.props;
 
     const activePage = route.params?.state ?? 0;
     const { currencyRate, currencySymbol } = currency;
@@ -647,7 +646,6 @@ class ProfileContainer extends Component {
         isDarkTheme,
         isFavorite,
         isFollowing,
-        isHideImage,
         isLoggedIn,
         isMuted,
         isOwnProfile,
@@ -670,7 +668,6 @@ const mapStateToProps = (state) => ({
   pinCode: selectPin(state),
   activeBottomTab: state.ui.activeBottomTab,
   currentAccount: selectCurrentAccount(state),
-  isHideImage: selectHidePostsThumbnails(state),
 });
 
 const mapHooksToProps = (props) => {

--- a/src/hooks/useImageReveal.ts
+++ b/src/hooks/useImageReveal.ts
@@ -1,0 +1,27 @@
+import { useCallback, useSyncExternalStore } from 'react';
+import { useSelector } from 'react-redux';
+import { selectHidePostsThumbnails } from '../redux/selectors';
+import { isImageRevealed, revealImage, subscribeToRevealedImages } from '../utils/revealedImages';
+
+/**
+ * Gates a single content image behind the "Show Images" setting.
+ *
+ * `isHidden` is true when the setting is off and the user has not tapped this
+ * particular image yet. Callers must not mount the image component at all while
+ * it is true, otherwise the bytes are fetched despite the setting.
+ */
+export const useImageReveal = (imgUrl?: string) => {
+  const isHideImages = useSelector(selectHidePostsThumbnails);
+
+  const isRevealed = useSyncExternalStore(
+    subscribeToRevealedImages,
+    // Snapshot is a boolean scoped to this url, so revealing one image does not
+    // re-render every other image on screen.
+    () => isImageRevealed(imgUrl),
+  );
+
+  const reveal = useCallback(() => revealImage(imgUrl), [imgUrl]);
+
+  // Nothing to hide (and nothing to reveal) without a url.
+  return { isHidden: !!imgUrl && isHideImages && !isRevealed, reveal };
+};

--- a/src/screens/profile/screen/profileScreen.tsx
+++ b/src/screens/profile/screen/profileScreen.tsx
@@ -31,7 +31,6 @@ const ProfileScreen = ({ route }) => (
       isDarkTheme,
       isFavorite,
       isFollowing,
-      isHideImage,
       isLoggedIn,
       isMuted,
       isOwnProfile,
@@ -80,7 +79,6 @@ const ProfileScreen = ({ route }) => (
         selectedUser={selectedUser}
         username={username}
         votingPower={votingPower || 0}
-        isHideImage={isHideImage}
         reverseHeader={reverseHeader}
         deepLinkFilter={deepLinkFilter}
       />

--- a/src/utils/image.ts
+++ b/src/utils/image.ts
@@ -13,6 +13,19 @@ const getImageBaseUrl = () => {
   }
 };
 
+/**
+ * False while the "Show Images" setting is off, so callers can skip speculative
+ * downloads. Lives here because this module already owns store-backed image
+ * concerns; importing the store into leaf utils pulls in the whole app graph.
+ */
+export const shouldPrefetchImages = () => {
+  try {
+    return !store.getState().application.hidePostsThumbnails;
+  } catch {
+    return true;
+  }
+};
+
 export const generateSignature = (media, privateKey) => {
   const STRING = 'ImageSigningChallenge';
   const prefix = Buffer.from(STRING);

--- a/src/utils/notificationImage.test.ts
+++ b/src/utils/notificationImage.test.ts
@@ -1,0 +1,51 @@
+import { getNotificationImageUrl } from './notificationImage';
+
+jest.mock('@ecency/render-helper', () => ({
+  proxifyImageSrc: jest.fn((url: string, w: number, h: number) => `proxy(${w}x${h}):${url}`),
+}));
+
+const IMG = 'https://images.ecency.com/p/original.jpg';
+
+describe('getNotificationImageUrl', () => {
+  it('uses the parent post image for a reply, which is the post that was replied to', () => {
+    const url = getNotificationImageUrl({
+      type: 'reply',
+      parent_img_url: IMG,
+      img_url: 'https://images.ecency.com/p/the-reply-itself.jpg',
+    });
+
+    expect(url).toBe(`proxy(96x96):${IMG}`);
+  });
+
+  it.each(['mention', 'reblog', 'scheduled_published'])('uses img_url for a %s', (type) => {
+    expect(getNotificationImageUrl({ type, img_url: IMG })).toBe(`proxy(96x96):${IMG}`);
+  });
+
+  it('shows no thumbnail for votes, which would just repeat the user own post', () => {
+    expect(getNotificationImageUrl({ type: 'vote', img_url: IMG })).toBeNull();
+    expect(getNotificationImageUrl({ type: 'unvote', img_url: IMG })).toBeNull();
+  });
+
+  it('shows no thumbnail for types that carry no post image', () => {
+    expect(getNotificationImageUrl({ type: 'follow' })).toBeNull();
+    expect(getNotificationImageUrl({ type: 'transfer', amount: '1.000 HIVE' })).toBeNull();
+  });
+
+  it('handles a missing or null image, which the API allows on every type', () => {
+    expect(getNotificationImageUrl({ type: 'mention', img_url: null })).toBeNull();
+    expect(getNotificationImageUrl({ type: 'reply', parent_img_url: null })).toBeNull();
+    expect(getNotificationImageUrl({ type: 'mention' })).toBeNull();
+  });
+
+  it('proxies the raw url down rather than fetching the full-size original', () => {
+    // The API returns the post's json_metadata image, which can be many MB.
+    expect(getNotificationImageUrl({ type: 'mention', img_url: IMG })).toContain('proxy(96x96)');
+  });
+
+  it('survives a malformed notification', () => {
+    expect(getNotificationImageUrl(null)).toBeNull();
+    expect(getNotificationImageUrl(undefined)).toBeNull();
+    expect(getNotificationImageUrl({})).toBeNull();
+    expect(getNotificationImageUrl({ type: 'mention', img_url: { nested: 'object' } })).toBeNull();
+  });
+});

--- a/src/utils/notificationImage.ts
+++ b/src/utils/notificationImage.ts
@@ -1,0 +1,33 @@
+import { proxifyImageSrc } from '@ecency/render-helper';
+
+// The 32pt slot in the notification row, at up to 3x pixel density.
+const THUMB_SIZE = 96;
+
+// Vote notifications also carry img_url, but they are by far the highest-volume
+// type and every thumbnail would be a repeat of the user's own post, so they are
+// deliberately left text-only.
+const IMAGE_TYPES = ['mention', 'reblog', 'scheduled_published'];
+
+/**
+ * Thumbnail for a notification row, or null when the notification has no post
+ * image to show.
+ *
+ * The API hands back the post's raw `json_metadata` image, which can be a
+ * full-size original, so it is proxied down to the size actually rendered.
+ */
+export const getNotificationImageUrl = (notification: any): string | null => {
+  // A reply points at the parent post, i.e. the user's own post that was replied
+  // to, which is the context that makes the row readable.
+  const rawUrl =
+    notification?.type === 'reply'
+      ? notification?.parent_img_url
+      : IMAGE_TYPES.includes(notification?.type)
+      ? notification?.img_url
+      : null;
+
+  if (!rawUrl || typeof rawUrl !== 'string') {
+    return null;
+  }
+
+  return proxifyImageSrc(rawUrl, THUMB_SIZE, THUMB_SIZE, 'match');
+};

--- a/src/utils/postParser.test.ts
+++ b/src/utils/postParser.test.ts
@@ -25,6 +25,7 @@ jest.mock('expo-image', () => ({
 
 jest.mock('./image', () => ({
   getResizedAvatar: jest.fn((author) => `https://i.ecency.com/u/${author}/avatar`),
+  shouldPrefetchImages: jest.fn(() => true),
 }));
 
 jest.mock('./user', () => ({
@@ -108,6 +109,29 @@ describe('parsePost', () => {
   it('returns null for null/undefined input', () => {
     expect(parsePost(null, 'user', false)).toBeNull();
     expect(parsePost(undefined, 'user', false)).toBeNull();
+  });
+
+  describe('cover image prefetch', () => {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { Image: MockExpoImage } = require('expo-image');
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { shouldPrefetchImages } = require('./image');
+
+    beforeEach(() => {
+      MockExpoImage.prefetch.mockClear();
+      shouldPrefetchImages.mockReturnValue(true);
+    });
+
+    it('prefetches the cover image while "Show Images" is on', () => {
+      parsePost(makePost(), 'viewer', false);
+      expect(MockExpoImage.prefetch).toHaveBeenCalledWith(['https://img.com/cover.jpg']);
+    });
+
+    it('does not prefetch the cover image while "Show Images" is off', () => {
+      shouldPrefetchImages.mockReturnValue(false);
+      parsePost(makePost(), 'viewer', false);
+      expect(MockExpoImage.prefetch).not.toHaveBeenCalled();
+    });
   });
 
   it('parses JSON string metadata', () => {

--- a/src/utils/postParser.tsx
+++ b/src/utils/postParser.tsx
@@ -5,7 +5,7 @@ import { Image as ExpoImage } from 'expo-image';
 
 // Utils
 import parseAsset from './parseAsset';
-import { getResizedAvatar } from './image';
+import { getResizedAvatar, shouldPrefetchImages } from './image';
 import { parseReputation } from './user';
 import { calculateVoteReward } from './vote';
 
@@ -150,7 +150,10 @@ export const parsePost = (
   }
 
   // cache image
-  if (post.image) {
+  // Prefetching pulls the full-size cover of every post in the feed, which is
+  // exactly the traffic "Show Images" is meant to avoid. A revealed image still
+  // loads on demand when the user taps its placeholder.
+  if (post.image && shouldPrefetchImages()) {
     ExpoImage.prefetch([post.image]);
   }
 

--- a/src/utils/revealedImages.test.ts
+++ b/src/utils/revealedImages.test.ts
@@ -1,0 +1,59 @@
+import {
+  clearRevealedImages,
+  isImageRevealed,
+  revealImage,
+  subscribeToRevealedImages,
+} from './revealedImages';
+
+const URL_A = 'https://images.ecency.com/p/a.jpg';
+const URL_B = 'https://images.ecency.com/p/b.jpg';
+
+describe('revealedImages', () => {
+  beforeEach(() => clearRevealedImages());
+
+  it('tracks reveals per url', () => {
+    expect(isImageRevealed(URL_A)).toBe(false);
+    revealImage(URL_A);
+    expect(isImageRevealed(URL_A)).toBe(true);
+    expect(isImageRevealed(URL_B)).toBe(false);
+  });
+
+  it('treats a missing url as never revealed', () => {
+    revealImage(undefined);
+    expect(isImageRevealed(undefined)).toBe(false);
+    expect(isImageRevealed('')).toBe(false);
+  });
+
+  it('notifies subscribers when an image is revealed', () => {
+    const listener = jest.fn();
+    subscribeToRevealedImages(listener);
+
+    revealImage(URL_A);
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not notify when revealing an already-revealed image', () => {
+    revealImage(URL_A);
+
+    const listener = jest.fn();
+    subscribeToRevealedImages(listener);
+    revealImage(URL_A);
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('stops notifying after unsubscribe', () => {
+    const listener = jest.fn();
+    const unsubscribe = subscribeToRevealedImages(listener);
+    unsubscribe();
+
+    revealImage(URL_A);
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('forgets everything on clear, so a fresh session downloads nothing unasked', () => {
+    revealImage(URL_A);
+    clearRevealedImages();
+    expect(isImageRevealed(URL_A)).toBe(false);
+  });
+});

--- a/src/utils/revealedImages.ts
+++ b/src/utils/revealedImages.ts
@@ -1,0 +1,33 @@
+/**
+ * Session-scoped record of images the user explicitly tapped to load while the
+ * "Show Images" setting is off.
+ *
+ * Deliberately not persisted: the point of the setting is that a fresh session
+ * downloads nothing the user did not ask for. Keeping it in memory (rather than
+ * in component state) means an image revealed in the feed stays revealed when
+ * the same post is opened, and survives FlashList cell recycling.
+ */
+const revealedUrls = new Set<string>();
+const listeners = new Set<() => void>();
+
+export const revealImage = (imgUrl?: string) => {
+  if (!imgUrl || revealedUrls.has(imgUrl)) {
+    return;
+  }
+  revealedUrls.add(imgUrl);
+  listeners.forEach((listener) => listener());
+};
+
+export const isImageRevealed = (imgUrl?: string) => !!imgUrl && revealedUrls.has(imgUrl);
+
+export const subscribeToRevealedImages = (listener: () => void) => {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+};
+
+export const clearRevealedImages = () => {
+  revealedUrls.clear();
+  listeners.forEach((listener) => listener());
+};


### PR DESCRIPTION
Two commits, both about making the "Show Images" setting mean something.

## 1. The setting never suppressed content images

It reached only two render sites: the feed card thumbnail and the **author avatar**.

Post bodies, waves and comments render through `PostHtmlRenderer`, which has no hide-image prop and never received one from either of its two callers. So with the setting off, a wave hid its 40px avatar while still downloading every full-size body image. The cheap image was suppressed and the expensive one was not.

Two prefetches made the saving close to zero even on the feed card that appeared to work:
- `parsePost` prefetched the full-size cover of every parsed post, unconditionally.
- The iOS image viewer prefetched a post's entire image list when opened.

### Change

Gate at the leaf via redux (`useImageReveal`) rather than prop-drilling: `PostHtmlRenderer` and `CommentView` both memo on an explicit prop list, so a new drilled prop would be silently swallowed and the body would not re-render on toggle.

Because `renderers.img` overrides the HTML renderer's default image element, one gate in `AutoHeightImage` covers every inline image path: post detail, comments, the waves feed, wave detail, the profile waves tab, the 2-up wave grid, and anchored images. Video posters go through `VideoThumb`, which drops the poster but keeps the play button tappable.

A hidden image is not mounted at all, so no request is made. Tapping the placeholder loads that image; the reveal is remembered per url for the session, so it survives row recycling and carries from the feed into the post.

Also gated: feed card thumbnails (previously blank with no way to load), the similar-posts strip, and quoted-post / link preview cards. The link preview keeps no tap-to-load, since the whole card is a link and a nested tap target would steal the tap that opens the post.

Avatars are no longer suppressed, which retires the `isHideImage` prop chain across 11 files.

### Notes

- Text-only, muted and NSFW posts fall back to a placeholder graphic rather than a real image, so they get no "tap to load" affordance and fetch nothing.
- `AutoHeightImage` now resets its measured box when the image changes; a hidden image never loads, so nothing would otherwise correct a stale height on a recycled row.

## 2. Notification thumbnails

The notification row already had a thumbnail slot, but it read `notification.image`, a field the API never returns. Replies carry `parent_img_url` (the post that was replied to) and mentions, reblogs and scheduled_published carry `img_url`, so the slot has been empty since it was written.

Those fields are mapped through and the url is proxied down, since the API hands back the post's raw `json_metadata` image. Votes are left text-only on purpose: highest-volume type, and every thumbnail would repeat the user's own post.

This honours the same setting, in the other direction: with "Show Images" off the list stays text-only, and with it on the list gains context.

The matching web change is ecency/vision-next#1140.

## Tests

The image suites assert on the rendered tree rather than a flag, since rendering an image at zero opacity or zero height would still fetch it. 647 tests pass; lint and typecheck clean.