### PR TITLE
Show thumbnails on bookmark and favorite notifications

### DIFF
--- a/src/utils/notificationImage.test.ts
+++ b/src/utils/notificationImage.test.ts
@@ -17,8 +17,23 @@ describe('getNotificationImageUrl', () => {
     expect(url).toBe(`proxy(96x96):${IMG}`);
   });
 
-  it.each(['mention', 'reblog', 'scheduled_published'])('uses img_url for a %s', (type) => {
-    expect(getNotificationImageUrl({ type, img_url: IMG })).toBe(`proxy(96x96):${IMG}`);
+  it.each(['mention', 'reblog', 'scheduled_published', 'favorites'])(
+    'uses img_url for a %s',
+    (type) => {
+      expect(getNotificationImageUrl({ type, img_url: IMG })).toBe(`proxy(96x96):${IMG}`);
+    },
+  );
+
+  it('uses the parent post image for a bookmark, i.e. the post that was bookmarked', () => {
+    // A bookmarks notification fires when someone comments on a post you saved,
+    // so the useful image is the saved post's, not the comment's.
+    const url = getNotificationImageUrl({
+      type: 'bookmarks',
+      parent_img_url: IMG,
+      img_url: 'https://images.ecency.com/p/the-comment.jpg',
+    });
+
+    expect(url).toBe(`proxy(96x96):${IMG}`);
   });
 
   it('shows no thumbnail for votes, which would just repeat the user own post', () => {

--- a/src/utils/notificationImage.ts
+++ b/src/utils/notificationImage.ts
@@ -3,10 +3,18 @@ import { proxifyImageSrc } from '@ecency/render-helper';
 // The 32pt slot in the notification row, at up to 3x pixel density.
 const THUMB_SIZE = 96;
 
+// Types whose image is the post the notification is about: the post you were
+// mentioned in, the one that was reblogged, the one that just went live.
+//
 // Vote notifications also carry img_url, but they are by far the highest-volume
 // type and every thumbnail would be a repeat of the user's own post, so they are
 // deliberately left text-only.
-const IMAGE_TYPES = ['mention', 'reblog', 'scheduled_published'];
+const IMAGE_TYPES = ['mention', 'reblog', 'scheduled_published', 'favorites'];
+
+// Types whose image hangs off the PARENT post, because the notification itself is
+// about a comment: your post that was replied to, or the post you bookmarked that
+// someone has now commented on. Either way the parent is the useful context.
+const PARENT_IMAGE_TYPES = ['reply', 'bookmarks'];
 
 /**
  * Thumbnail for a notification row, or null when the notification has no post
@@ -16,14 +24,11 @@ const IMAGE_TYPES = ['mention', 'reblog', 'scheduled_published'];
  * full-size original, so it is proxied down to the size actually rendered.
  */
 export const getNotificationImageUrl = (notification: any): string | null => {
-  // A reply points at the parent post, i.e. the user's own post that was replied
-  // to, which is the context that makes the row readable.
-  const rawUrl =
-    notification?.type === 'reply'
-      ? notification?.parent_img_url
-      : IMAGE_TYPES.includes(notification?.type)
-      ? notification?.img_url
-      : null;
+  const rawUrl = PARENT_IMAGE_TYPES.includes(notification?.type)
+    ? notification?.parent_img_url
+    : IMAGE_TYPES.includes(notification?.type)
+    ? notification?.img_url
+    : null;
 
   if (!rawUrl || typeof rawUrl !== 'string') {
     return null;


### PR DESCRIPTION
## Problem

Two notification types that should show a post thumbnail do not.

**Bookmarks** — the data is already flowing and we were dropping it. enotify populates `parent_img_url` (the bookmarked post that someone has now commented on) and the api serializes it, but the image mapper only knew about `reply`. No backend change needed.

**Favorites** — the backend genuinely never sent it. `convert_source_row_favorites` never put `img_url` into `extra`, so the api always serialized `img_url: null`. Fixed in ecency/enotify-py#16.

## Change

`getNotificationImageUrl` now splits the types by *where the image lives*:

- `img_url` (the post the notification is about): mention, reblog, scheduled_published, **favorites**
- `parent_img_url` (the parent post, because the notification is about a comment): reply, **bookmarks**

Votes stay text-only, as before: highest-volume type, and every thumbnail would repeat the user's own post. Still gated on "Show Images", like the other notification thumbnails.

## Sequencing

Bookmarks light up as soon as this ships. Favorites stay text-only until enotify-py#16 deploys — the field is simply absent, the mapper returns null, and the row renders exactly as it does today. No coupling, no broken intermediate state.

The matching web change is ecency/vision-next#1142.

## Tests

Extended the notificationImage suite to cover favorites (`img_url`) and bookmarks (`parent_img_url`, asserting it prefers the parent over the comment's own image). 649 tests pass; lint and typecheck clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected notification image selection for bookmarks to display the saved post’s image.
  * Added support for favorite notifications to use their associated image.
  * Improved image handling across supported notification types for more accurate previews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->