### PR TITLE
Show a thumbnail on payout notifications

### DIFF
--- a/src/utils/notificationImage.test.ts
+++ b/src/utils/notificationImage.test.ts
@@ -17,7 +17,7 @@ describe('getNotificationImageUrl', () => {
     expect(url).toBe(`proxy(96x96):${IMG}`);
   });
 
-  it.each(['mention', 'reblog', 'scheduled_published', 'favorites'])(
+  it.each(['mention', 'reblog', 'scheduled_published', 'favorites', 'payouts'])(
     'uses img_url for a %s',
     (type) => {
       expect(getNotificationImageUrl({ type, img_url: IMG })).toBe(`proxy(96x96):${IMG}`);

--- a/src/utils/notificationImage.ts
+++ b/src/utils/notificationImage.ts
@@ -9,7 +9,7 @@ const THUMB_SIZE = 96;
 // Vote notifications also carry img_url, but they are by far the highest-volume
 // type and every thumbnail would be a repeat of the user's own post, so they are
 // deliberately left text-only.
-const IMAGE_TYPES = ['mention', 'reblog', 'scheduled_published', 'favorites'];
+const IMAGE_TYPES = ['mention', 'reblog', 'scheduled_published', 'favorites', 'payouts'];
 
 // Types whose image hangs off the PARENT post, because the notification itself is
 // about a comment: your post that was replied to, or the post you bookmarked that


### PR DESCRIPTION
## Problem

`payouts` ("your post paid out") carries `img_url` and the api has always sent it, but the type was missing from the image mapper, so those rows render text-only.

It is live and not rare: roughly **1,500 rows a day, about half of them with an image**.

## Why it was missed

I derived the original type list from the sdk types, and **there is no `ApiPayoutNotification` type at all** — even though the api emits `payouts` and the row already renders. An incomplete source produced an incomplete list.

Verified against the backend instead this time: `endpoints.py` has an `ACTIVITY_TYPE_PAYOUT` branch that serializes `img_url`, `convert_source_row_payouts` populates it via `get_post()`, and the live table confirms the rows carry real image urls.

## Change

Adds `payouts` to `IMAGE_TYPES` (the `img_url` group). Still gated on "Show Images", like the other notification thumbnails. Votes remain the only image-carrying type left text-only, as agreed: highest-volume, and every thumbnail would repeat the user's own post.

The matching web change is ecency/vision-next#1144.

## Tests

650 pass; lint and typecheck clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Payout notifications now display their provided image in 96×96 thumbnails.
  * Added coverage to ensure payout notification images are handled consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->