### PR TITLE
Record daily check-in on app open and foreground return

### DIFF
--- a/src/components/postView/view/postDisplayView.tsx
+++ b/src/components/postView/view/postDisplayView.tsx
@@ -94,9 +94,9 @@ const PostDisplayView = ({
   // Component Life Cycles
   useEffect(() => {
     if (isLoggedIn && get(currentAccount, 'name') && !isNewPost) {
-      // track user activity for view post
+      // record a check-in (type 10) for reading a post
       userActivityMutation.mutate({
-        pointsTy: PointActivityIds.VIEW_POST,
+        pointsTy: PointActivityIds.CHECKIN,
       });
     }
   }, []);

--- a/src/providers/ecency/ecency.types.ts
+++ b/src/providers/ecency/ecency.types.ts
@@ -188,7 +188,7 @@ export enum NotificationFilters {
 }
 
 export enum PointActivityIds {
-  VIEW_POST = 10,
+  CHECKIN = 10,
   LOGIN = 20,
   POST = 100,
   COMMENT = 110,

--- a/src/screens/application/hook/useInitApplication.tsx
+++ b/src/screens/application/hook/useInitApplication.tsx
@@ -58,6 +58,12 @@ export const useInitApplication = () => {
   const lowMemSubRef = useRef<NativeEventSubscription | null>(null);
   const lastCheckinAtRef = useRef<Record<string, number>>({});
 
+  // Fresh auth snapshot for _recordCheckin: the AppState listener re-registers
+  // only when currentAccount.name changes, so it must not rely on captured
+  // isLoggedIn (stale if auth flips without a name change).
+  const authRef = useRef({ isLoggedIn, username: currentAccount?.name });
+  authRef.current = { isLoggedIn, username: currentAccount?.name };
+
   const notifeeEventRef = useRef<any>(null);
   const messagingEventRef = useRef<any>(null);
 
@@ -202,8 +208,8 @@ export const useInitApplication = () => {
   // Fires only for a logged in account brought to the foreground, never from
   // background wakeups, and is throttled per account to match the backend spacing.
   const _recordCheckin = () => {
-    const username = currentAccount?.name;
-    if (!isLoggedIn || !username) {
+    const { isLoggedIn: loggedIn, username } = authRef.current;
+    if (!loggedIn || !username) {
       return;
     }
 

--- a/src/screens/application/hook/useInitApplication.tsx
+++ b/src/screens/application/hook/useInitApplication.tsx
@@ -35,7 +35,12 @@ import {
 } from '../../../redux/actions/applicationActions';
 import RootNavigation from '../../../navigation/rootNavigation';
 import ROUTES from '../../../constants/routeNames';
-import { selectCurrentAccount } from '../../../redux/selectors';
+import { selectCurrentAccount, selectIsLoggedIn } from '../../../redux/selectors';
+import { PointActivityIds } from '../../../providers/ecency/ecency.types';
+
+// Client-side spacing for app open/resume check-ins; the backend enforces
+// ~15 min between check-ins anyway and cancels anything closer.
+const CHECKIN_THROTTLE_MS = 15 * 60 * 1000;
 
 export const useInitApplication = () => {
   const dispatch = useAppDispatch();
@@ -45,11 +50,13 @@ export const useInitApplication = () => {
     (state) => state.application,
   );
   const currentAccount = useAppSelector(selectCurrentAccount);
+  const isLoggedIn = useAppSelector(selectIsLoggedIn);
   const systemColorScheme = useColorScheme();
 
   const appState = useRef(AppState.currentState);
   const appStateSubRef = useRef<NativeEventSubscription | null>(null);
   const lowMemSubRef = useRef<NativeEventSubscription | null>(null);
+  const lastCheckinAtRef = useRef<Record<string, number>>({});
 
   const notifeeEventRef = useRef<any>(null);
   const messagingEventRef = useRef<any>(null);
@@ -104,6 +111,7 @@ export const useInitApplication = () => {
     });
 
     userActivityMutation.lazyMutatePendingActivities();
+    _recordCheckin();
 
     // update fiat currency rate usd:fiat
     dispatch(setCurrency(currency.currency));
@@ -189,9 +197,29 @@ export const useInitApplication = () => {
     // }
   };
 
+  // Daily-quest check-in (type 10) on app open and foreground return, so users
+  // active only in feed/waves still check in; opening a post records one too.
+  // Fires only for a logged in account brought to the foreground, never from
+  // background wakeups, and is throttled per account to match the backend spacing.
+  const _recordCheckin = () => {
+    const username = currentAccount?.name;
+    if (!isLoggedIn || !username) {
+      return;
+    }
+
+    const lastAt = lastCheckinAtRef.current[username] || 0;
+    if (Date.now() - lastAt < CHECKIN_THROTTLE_MS) {
+      return;
+    }
+
+    lastCheckinAtRef.current[username] = Date.now();
+    userActivityMutation.mutate({ pointsTy: PointActivityIds.CHECKIN });
+  };
+
   const _handleAppStateChange = (nextAppState) => {
     if (appState.current.match(/inactive|background/) && nextAppState === 'active') {
       userActivityMutation.lazyMutatePendingActivities();
+      _recordCheckin();
       dispatch(recordAppSession());
     }
 


### PR DESCRIPTION
### What

- Records the daily check-in activity when the app is opened or returns to foreground, for a logged in account only, throttled client side to once per 15 minutes per account (backend enforces the same spacing and cancels anything closer)
- Renames `PointActivityIds.VIEW_POST` to `CHECKIN` since type 10 is the check-in activity; opening a post still records one as before

### Why

Check-in previously fired only when opening a full post view. Users active in feed or waves (voting, reblogging, wave replies) without opening a regular post never checked in, so the "Check in" daily quest stayed at 0/1, streaks broke and the leaderboard quests badge could not be earned even on active days. Web already records check-ins passively on page load plus a 15 minute interval; this brings mobile in line while still only counting real foreground usage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic daily check-in activity tracking when the app starts or returns to the foreground.
  * Opening a post now records a check-in activity for eligible logged-in users.
* **Improvements**
  * Check-in activity is limited to once every 15 minutes to prevent duplicate activity records.
  * Check-in tracking now reliably reflects the current login state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->