### PR TITLE
Show drafts pull-to-refresh spinner only on explicit pull

### DIFF
--- a/src/screens/drafts/container/draftsContainer.tsx
+++ b/src/screens/drafts/container/draftsContainer.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useMemo, useRef, useState } from 'react';
 import { connect } from 'react-redux';
 import { injectIntl } from 'react-intl';
 
@@ -67,14 +67,22 @@ const DraftsContainer = ({ currentAccount, navigation, route }) => {
 
   // Spinner state for an explicit pull only; background refetches (stale mount,
   // next-page, invalidations) must not drop the RefreshControl down on their own.
+  // The ref guards against overlapping pulls so a faster call can't clear the
+  // spinner while another refresh is still running.
   const [refreshing, setRefreshing] = useState(false);
+  const isRefreshingRef = useRef(false);
 
   // Component Functions
   const _onRefresh = async () => {
+    if (isRefreshingRef.current) {
+      return;
+    }
+    isRefreshingRef.current = true;
     setRefreshing(true);
     try {
       await Promise.all([refetchDrafts(), refetchSchedules()]);
     } finally {
+      isRefreshingRef.current = false;
       setRefreshing(false);
     }
   };

--- a/src/screens/drafts/container/draftsContainer.tsx
+++ b/src/screens/drafts/container/draftsContainer.tsx
@@ -40,7 +40,6 @@ const DraftsContainer = ({ currentAccount, navigation, route }) => {
   const {
     isLoading: isLoadingDrafts,
     data: allDrafts = [],
-    isFetching: isFetchingDrafts,
     refetch: refetchDrafts,
     fetchNextPage: fetchNextDraftsPage,
     hasNextPage: hasNextDraftsPage,
@@ -55,7 +54,6 @@ const DraftsContainer = ({ currentAccount, navigation, route }) => {
   const {
     isLoading: isLoadingSchedules,
     data: schedules = [],
-    isFetching: isFetchingSchedules,
     refetch: refetchSchedules,
     fetchNextPage: fetchNextSchedulesPage,
     hasNextPage: hasNextSchedulesPage,
@@ -67,10 +65,18 @@ const DraftsContainer = ({ currentAccount, navigation, route }) => {
   const [batchSelectedSchedules, setBatchSelectedSchedules] = useState<string[]>([]);
   // const [selectedTabIndex, setSelectedTabIndex] = useState(route.params?.showSchedules ? 1 : 0);
 
+  // Spinner state for an explicit pull only; background refetches (stale mount,
+  // next-page, invalidations) must not drop the RefreshControl down on their own.
+  const [refreshing, setRefreshing] = useState(false);
+
   // Component Functions
-  const _onRefresh = () => {
-    refetchDrafts();
-    refetchSchedules();
+  const _onRefresh = async () => {
+    setRefreshing(true);
+    try {
+      await Promise.all([refetchDrafts(), refetchSchedules()]);
+    } finally {
+      setRefreshing(false);
+    }
   };
 
   const _editDraft = (id: string) => {
@@ -94,8 +100,8 @@ const DraftsContainer = ({ currentAccount, navigation, route }) => {
     });
   };
 
-  const _isLoading =
-    isLoadingDrafts || isLoadingSchedules || isFetchingDrafts || isFetchingSchedules;
+  // initial load only — used for list placeholders, not the pull spinner
+  const _isLoading = isLoadingDrafts || isLoadingSchedules;
 
   const _isDeleting = isDeletingDraft || isDeletingSchedule || isMovingToDrafts;
 
@@ -154,6 +160,7 @@ const DraftsContainer = ({ currentAccount, navigation, route }) => {
   return (
     <DraftsScreen
       isLoading={_isLoading}
+      refreshing={refreshing}
       isDeleting={_isDeleting}
       isBatchDeleting={
         draftsBatchDeleteMutation.isLoading || schedulesBatchDeleteMutation.isLoading

--- a/src/screens/drafts/screen/draftsScreen.tsx
+++ b/src/screens/drafts/screen/draftsScreen.tsx
@@ -39,6 +39,7 @@ const DraftsScreen = ({
   applyTemplate,
   removeSchedule,
   isLoading,
+  refreshing,
   isDeleting,
   isBatchDeleting,
   onRefresh,
@@ -369,7 +370,7 @@ const DraftsScreen = ({
             ListFooterComponent={isFetchingNextPage ? <PostCardPlaceHolder /> : null}
             refreshControl={
               <RefreshControl
-                refreshing={isLoading}
+                refreshing={refreshing}
                 onRefresh={onRefresh}
                 progressBackgroundColor="#357CE6"
                 tintColor={!isDarkTheme ? '#357ce6' : '#96c0ff'}
@@ -392,7 +393,7 @@ const DraftsScreen = ({
       _renderHeader,
       _renderEmptyContent,
       processedIdLessDraft,
-      isLoading,
+      refreshing,
       onRefresh,
       isDarkTheme,
     ],
@@ -457,6 +458,7 @@ const DraftsScreen = ({
         />
 
         <TabView
+          lazy
           navigationState={{ index, routes }}
           style={globalStyles.tabView}
           onIndexChange={setIndex}


### PR DESCRIPTION
### What

- The RefreshControl spinner on the drafts, schedules and templates tabs now shows only during an explicit pull; a local `refreshing` state wraps the pull handler and awaits both refetches
- Background activity (stale refetch on mount, next page loads, cache invalidations after mutations) no longer drops the spinner down on its own; next page loads keep their footer placeholder as before
- List placeholders now key off the initial load only instead of any in-flight fetch
- Tab scenes mount lazily, so a hidden tab list no longer mounts and prefetches pages while another tab is being viewed

### Why

Visiting the drafts or schedules screen showed the pull-to-refresh spinner appearing several times without any user action. The spinner was wired to the combined fetching state of both infinite queries, so every automatic background refetch and auto page load pulled it down, and all three tab lists mounted eagerly which multiplied the fetches.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull-to-refresh for drafts and schedules using a dedicated refresh indicator and safer refresh handling.
  * Prevented background data updates from triggering the main loading UI.
  * Adjusted tab refresh behavior to align with the new refresh state.
* **Performance**
  * Improved tab loading efficiency by deferring rendering of inactive tab content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->