### PR TITLE
chore(deps): bump @ecency/sdk to 2.3.51

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@babel/preset-typescript": "^7.26.0",
     "@babel/runtime": "^7.26.7",
     "@ecency/render-helper": "^2.5.17",
-    "@ecency/sdk": "^2.3.48",
+    "@ecency/sdk": "^2.3.51",
     "@esteemapp/react-native-autocomplete-input": "^4.2.1",
     "@esteemapp/react-native-multi-slider": "^1.1.0",
     "@native-html/iframe-plugin": "^2.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1211,10 +1211,10 @@
     url "^0.11.0"
     xss "^1.0.9"
 
-"@ecency/sdk@^2.3.48":
-  version "2.3.48"
-  resolved "https://registry.yarnpkg.com/@ecency/sdk/-/sdk-2.3.48.tgz#c44a2a7c7342bf2955b47a5196b66c162b2d5086"
-  integrity sha512-/qUpfDDUaASlWEwi5r1IU9NDDOEjVZEgxlnhp4LUqWCZ40b3XBKzfYPx+qQZPhN6T1XFjZaPPnRVQGr8loV77g==
+"@ecency/sdk@^2.3.51":
+  version "2.3.51"
+  resolved "https://registry.yarnpkg.com/@ecency/sdk/-/sdk-2.3.51.tgz#2ba8ebb1df224e4d84816d5be625a621c9b70f6f"
+  integrity sha512-P4b9r165oQLA0LrBNm1d5dQPfrAiE7L4a02gkY35oHAh/yscLZ6bhhyokJ5+qxh/bJhZz6An6nsNK+9HlEqC8g==
   dependencies:
     "@noble/ciphers" "^2.1.1"
     "@noble/curves" "^2.0.1"


### PR DESCRIPTION
Bumps @ecency/sdk from 2.3.48 to 2.3.51.

Changes absorbed from the SDK:
- Notification types: new `payouts` notification interfaces and `img_url`/`parent_img_url` fields on favorite/bookmark notifications (app already renders these).
- `AccountRelationship`: field set aligned with the bridge response (`is_blacklisted` -> `blacklists`, adds `follows_muted`) plus a null-response fallback in the relationship query. App only reads `follows`/`ignores`, so no changes needed.
- `useMarkNotificationsRead`: no-ops instead of throwing when auth is missing. App uses its own mark-read mutation, unaffected.

No app code changes required. Full jest suite and lint pass locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Ecency SDK dependency to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->