### PR TITLE
chore(deps): bump @ecency/sdk to 2.3.54 and @ecency/render-helper to 2.5.19

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
   "dependencies": {
     "@babel/preset-typescript": "^7.26.0",
     "@babel/runtime": "^7.26.7",
-    "@ecency/render-helper": "^2.5.17",
-    "@ecency/sdk": "^2.3.52",
+    "@ecency/render-helper": "^2.5.19",
+    "@ecency/sdk": "^2.3.54",
     "@esteemapp/react-native-autocomplete-input": "^4.2.1",
     "@esteemapp/react-native-multi-slider": "^1.1.0",
     "@native-html/iframe-plugin": "^2.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1192,10 +1192,10 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@ecency/render-helper@^2.5.17":
-  version "2.5.17"
-  resolved "https://registry.yarnpkg.com/@ecency/render-helper/-/render-helper-2.5.17.tgz#4ccc36c3045a33110e674dda62f1f873b80d445a"
-  integrity sha512-kBfeme113RSFjIstD8DUvoewCn/Vj0SbkLIQO8WIzVUh4mlwSr6n6SX6rSPVGdcQFt9mvJoj2LgZUFysOVbijQ==
+"@ecency/render-helper@^2.5.19":
+  version "2.5.19"
+  resolved "https://registry.yarnpkg.com/@ecency/render-helper/-/render-helper-2.5.19.tgz#5ce8456b1599cdc63f7c6e916240d5cf5a5c250c"
+  integrity sha512-LXRd+IopOueZ47gBboSrBQp8rLSY4VB9Cr5rEMqUjY9OkzM3PZMgJfoau6pErDtP4xvPaX/VGXNbNdazHItduQ==
   dependencies:
     "@xmldom/xmldom" "^0.9.10"
     dom-serializer "^2.0.0"
@@ -1211,10 +1211,10 @@
     url "^0.11.0"
     xss "^1.0.9"
 
-"@ecency/sdk@^2.3.52":
-  version "2.3.52"
-  resolved "https://registry.yarnpkg.com/@ecency/sdk/-/sdk-2.3.52.tgz#bd749edfec2835618ae24190d66815ed5657b66c"
-  integrity sha512-feRbng4X8pHZIbf168/eBoahTB2dTVHGHjZR2DI7gLXtNPdP7S4gTyTF1RD4eFuaEfksgQ5rKF6eFySc0fOihw==
+"@ecency/sdk@^2.3.54":
+  version "2.3.54"
+  resolved "https://registry.yarnpkg.com/@ecency/sdk/-/sdk-2.3.54.tgz#35db14cffacaa25e1cf644d46e1f5cd016ee8cd6"
+  integrity sha512-WRdWMiif8MmC09t+jm+GnC2HAdwyRJnrgnrakarhEB3672lCMB7Je089wpGYaDFtt8iP+TtgRTJclTBWKa87Mg==
   dependencies:
     "@noble/ciphers" "^2.1.1"
     "@noble/curves" "^2.0.1"


### PR DESCRIPTION
Bumps the two Ecency packages the app consumes to pick up recently published fixes:

- **@ecency/sdk** `2.3.52 → 2.3.54` — the fragment/recovery mutations now throw on non-ok HTTP responses instead of silently running `onSuccess` (add / edit / remove snippet). The app's snippet mutations (`useSnippetsMutation`, `useSnippetDeleteMutation`) already wrap these with `onError`, so this is a behavior improvement — failed ops now surface instead of a false success — not a breaking change.
- **@ecency/render-helper** `2.5.17 → 2.5.19` — fixes a quadratic-runtime (ReDoS) regex in the markdown image/link scan (`catchPostImage` / `getEntryImageRawUrl`) that runs on untrusted post content, and corrects first-image selection for URLs containing a literal `[` (array-style query params) or exceeding the length bound.

Lockfile updated via `yarn install`; no app code changes. Worth a smoke-test of snippet add/edit/delete on the next build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated rendering and SDK components to newer versions.
  * Includes the latest available improvements and fixes from these components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->