### PR TITLE
Show Ecency Pro checkmark on remaining username surfaces; mute the source badge

### DIFF
--- a/src/components/basicUIElements/view/userListItem/userListItem.tsx
+++ b/src/components/basicUIElements/view/userListItem/userListItem.tsx
@@ -5,6 +5,7 @@ import Highlighter from 'react-native-highlight-words';
 
 import EStyleSheet from 'react-native-extended-stylesheet';
 import { UserAvatar } from '../../../userAvatar';
+import { ProBadge } from '../../../proBadge';
 import styles from './userListItemStyles';
 
 const UserListItem = ({
@@ -55,17 +56,25 @@ const UserListItem = ({
         {!!itemIndex && <Text style={styles.itemIndex}>{itemIndex}</Text>}
         <UserAvatar noAction={true} style={styles.avatar} username={username} />
         <View style={styles.userDescription}>
-          {!searchValue && <Text style={styles.name}>{text || username}</Text>}
+          {!searchValue && (
+            <View style={styles.nameRow}>
+              <Text style={styles.name}>{text || username}</Text>
+              <ProBadge username={username} />
+            </View>
+          )}
           {!!searchValue && !!text && (
-            <Highlighter
-              highlightStyle={{
-                backgroundColor: EStyleSheet.value('$darkGrayBackground'),
-                color: EStyleSheet.value('$white'),
-              }}
-              searchWords={[searchValue]}
-              textToHighlight={text || username}
-              style={styles.name}
-            />
+            <View style={styles.nameRow}>
+              <Highlighter
+                highlightStyle={{
+                  backgroundColor: EStyleSheet.value('$darkGrayBackground'),
+                  color: EStyleSheet.value('$white'),
+                }}
+                searchWords={[searchValue]}
+                textToHighlight={text || username}
+                style={styles.name}
+              />
+              <ProBadge username={username} />
+            </View>
           )}
           {!!searchValue && !!description && (
             <Highlighter

--- a/src/components/basicUIElements/view/userListItem/userListItem.tsx
+++ b/src/components/basicUIElements/view/userListItem/userListItem.tsx
@@ -70,7 +70,7 @@ const UserListItem = ({
                   color: EStyleSheet.value('$white'),
                 }}
                 searchWords={[searchValue]}
-                textToHighlight={text || username}
+                textToHighlight={text}
                 style={styles.name}
               />
               <ProBadge username={username} />

--- a/src/components/basicUIElements/view/userListItem/userListItemStyles.ts
+++ b/src/components/basicUIElements/view/userListItem/userListItemStyles.ts
@@ -31,6 +31,12 @@ export default EStyleSheet.create({
     fontWeight: 'bold',
     fontFamily: '$primaryFont',
   },
+  // Keeps the Pro checkmark on the same baseline as the name. RTL-aware like
+  // userDescription so the badge stays on the trailing side of the handle.
+  nameRow: {
+    flexDirection: isRTL() ? 'row-reverse' : 'row',
+    alignItems: 'center',
+  },
   reputation: {
     fontWeight: 'normal',
     fontFamily: '$primaryFont',

--- a/src/components/ecencySourceBadge/ecencySourceBadgeView.tsx
+++ b/src/components/ecencySourceBadge/ecencySourceBadgeView.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { StyleProp, ViewStyle } from 'react-native';
+import { useIntl } from 'react-intl';
+import EStyleSheet from 'react-native-extended-stylesheet';
+import Svg, { Path } from 'react-native-svg';
+
+// A soft, recessed gray so the mark reads as a faint hint, not a status badge.
+// Same values as the web badge (Tailwind gray-300 / gray-700): light on a light
+// ground, dark on a dark ground, both a step quieter than $iconColor. Kept as
+// literals because there is no matching theme token, mirroring the web classes.
+const MARK_COLOR_LIGHT = '#d1d5db';
+const MARK_COLOR_DARK = '#374151';
+
+// The bare Ecency "e" mark, cropped tight to the glyph. Same path and viewBox
+// as the web badge so both clients render an identical shape.
+const MARK_PATH =
+  'M88.27,105.71c-9,.08-30.35.27-35.13-.29-3.88-.46-11-3-11.11-12.81C42,87,41.66,64,42.46,59,44.13,48.4,47,41.77,59.05,36.33c10.26-4.44,32.17-.78,34.54,16.93.45,3.37,1.25,3.74,2.49,4,19.61,4.13,24,26.26,14.6,38.32C104.73,103.26,98.31,104.76,88.27,105.71ZM84.71,59.25c.68-11.52-11-19.82-22.82-13.66-8.42,4.39-9.15,10.76-9.68,18-.67,9.2-.25,15.91-.09,25.13.07,4.13,1.27,6.64,5.7,7,1.14.1,17,0,25.22.06,10.74.06,24.06-4.89,21.93-18a12.68,12.68,0,0,0-10.8-10.22,2.12,2.12,0,0,0-2.21,1C85,83,69.66,82.31,63.41,74.46c-5.61-7.06-2.7-18.73,4.68-21.2,2.78-.94,5.11-.11,6.25,1.86,1.84,3.18.11,6.06-2.49,7.65s-2.45,3.92-1.36,5.46c2.56,3.59,7.6,2.88,10.79-.28C83.87,65.4,84.52,62.47,84.71,59.25Z';
+
+interface Props {
+  size?: number;
+  color?: string;
+  style?: StyleProp<ViewStyle>;
+}
+
+/**
+ * Marks content published from an Ecency client. Deliberately low-emphasis: the
+ * bare mark in a soft gray rather than the blue round logo, which read as a
+ * status badge and competed with the blue Pro checkmark sitting beside it. One
+ * means "this account pays for Pro", the other only "posted from Ecency".
+ */
+export const EcencySourceBadge = ({ size = 12, color, style }: Props) => {
+  const intl = useIntl();
+  const isDark = EStyleSheet.value('$theme') === 'darkTheme';
+
+  return (
+    <Svg
+      width={size}
+      height={size}
+      viewBox="40.6 28.7 80.4 80.4"
+      style={style}
+      accessibilityRole="image"
+      accessibilityLabel={intl.formatMessage({
+        id: 'post.source_ecency',
+        defaultMessage: 'Published with Ecency',
+      })}
+    >
+      <Path d={MARK_PATH} fill={color ?? (isDark ? MARK_COLOR_DARK : MARK_COLOR_LIGHT)} />
+    </Svg>
+  );
+};
+
+export default EcencySourceBadge;

--- a/src/components/ecencySourceBadge/index.ts
+++ b/src/components/ecencySourceBadge/index.ts
@@ -1,0 +1,4 @@
+import EcencySourceBadge from './ecencySourceBadgeView';
+
+export { EcencySourceBadge };
+export default EcencySourceBadge;

--- a/src/components/notificationLine/view/notificationLineView.tsx
+++ b/src/components/notificationLine/view/notificationLineView.tsx
@@ -5,6 +5,7 @@ import get from 'lodash/get';
 
 // Components
 import { UserAvatar } from '../../userAvatar';
+import { ProBadge } from '../../proBadge';
 
 import { rcFormatter, vestsToHp } from '../../../utils/conversions';
 import { formatNotificationTimestamp } from '../../../utils/time';
@@ -167,8 +168,8 @@ const NotificationLineView = ({
 
         <View style={styles.body}>
           <Text style={styles.title} numberOfLines={3} ellipsizeMode="tail">
-            <Text style={styles.name}>{notification.source} </Text>
-            {_title}
+            <Text style={styles.name}>{notification.source}</Text>
+            <ProBadge username={notification.source} size={13} /> {_title}
           </Text>
           {_moreinfo ? (
             <Text style={styles.moreinfo} numberOfLines={1} ellipsizeMode="tail">

--- a/src/components/organisms/quickProfileModal/children/profileBasic.tsx
+++ b/src/components/organisms/quickProfileModal/children/profileBasic.tsx
@@ -5,6 +5,7 @@ import EStyleSheet from 'react-native-extended-stylesheet';
 import { useIntl } from 'react-intl';
 import styles from './quickProfileStyles';
 import { UserAvatar } from '../../..';
+import { ProBadge } from '../../../proBadge';
 
 interface Props {
   username: string;
@@ -54,7 +55,10 @@ export const ProfileBasic = ({
           </View>
         </View>
 
-        <Text style={styles.title}>{`@${username}`}</Text>
+        <Text style={styles.title}>
+          {`@${username}`}
+          <ProBadge username={username} size={16} />
+        </Text>
         {!!about && (
           <Text style={styles.bodyText} numberOfLines={2}>
             {about}

--- a/src/components/postElements/headerDescription/view/postHeaderDescription.tsx
+++ b/src/components/postElements/headerDescription/view/postHeaderDescription.tsx
@@ -1,11 +1,12 @@
 import React, { PureComponent } from 'react';
-import { View, Text, TouchableOpacity, Image } from 'react-native';
+import { View, Text, TouchableOpacity } from 'react-native';
 import { injectIntl } from 'react-intl';
 
 // Components
 import { Tag } from '../../../basicUIElements';
 import { Icon } from '../../../icon';
 import { ProBadge } from '../../../proBadge';
+import { EcencySourceBadge } from '../../../ecencySourceBadge';
 import { UserAvatar } from '../../../userAvatar';
 // Styles
 import styles from './postHeaderDescriptionStyles';
@@ -16,7 +17,6 @@ import RootNavigation from '../../../../navigation/rootNavigation';
 
 // Constants
 import DEFAULT_IMAGE from '../../../../assets/ecency.png';
-import ECENCY_LOGO from '../../../../assets/ecency-logo-round.png';
 
 class PostHeaderDescription extends PureComponent {
   // Component Life Cycles
@@ -168,9 +168,7 @@ class PostHeaderDescription extends PureComponent {
 
               {inlineTime && <Text style={styles.date}>{date}</Text>}
 
-              {inlineTime && isFromEcency && (
-                <Image source={ECENCY_LOGO} style={styles.ecencySourceBadge} />
-              )}
+              {inlineTime && isFromEcency && <EcencySourceBadge style={styles.ecencySourceBadge} />}
 
               {inlineTime && hasAiTools && (
                 <Icon
@@ -241,7 +239,7 @@ class PostHeaderDescription extends PureComponent {
               {!inlineTime && <Text style={styles.date}>{date}</Text>}
 
               {!inlineTime && isFromEcency && (
-                <Image source={ECENCY_LOGO} style={styles.ecencySourceBadge} />
+                <EcencySourceBadge style={styles.ecencySourceBadge} />
               )}
 
               {!inlineTime && hasAiTools && (

--- a/src/components/postView/view/postDisplayView.tsx
+++ b/src/components/postView/view/postDisplayView.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { View, Text, Image, useWindowDimensions } from 'react-native';
+import { View, Text, useWindowDimensions } from 'react-native';
 import { injectIntl } from 'react-intl';
 import get from 'lodash/get';
 import isEqual from 'lodash/isEqual';
@@ -22,7 +22,7 @@ import { PostTranslateInline } from '../children/postTranslateInline';
 
 // Styles
 import styles from './postDisplayStyles';
-import ECENCY_LOGO from '../../../assets/ecency-logo-round.png';
+import { EcencySourceBadge } from '../../ecencySourceBadge';
 import { WritePostButton } from '../../atoms';
 import { PostTypes } from '../../../constants/postTypes';
 import { useUserActivityMutation } from '../../../providers/queries/pointQueries';
@@ -516,9 +516,7 @@ const PostDisplayView = ({
                       )}
                       {formatedTime}
                     </Text>
-                    {isFromEcency && (
-                      <Image source={ECENCY_LOGO} style={styles.ecencySourceBadge} />
-                    )}
+                    {isFromEcency && <EcencySourceBadge style={styles.ecencySourceBadge} />}
                     {hasAiTools && (
                       <Icon
                         name="robot-outline"

--- a/src/components/profileSummary/view/profileSummaryStyles.ts
+++ b/src/components/profileSummary/view/profileSummaryStyles.ts
@@ -47,10 +47,15 @@ export default EStyleSheet.create({
     paddingHorizontal: 16,
     marginTop: 8,
   },
+  displayNameRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
   displayName: {
     fontSize: 20,
     fontWeight: 'bold',
     color: '$primaryDarkText',
+    flexShrink: 1,
   },
   username: {
     fontSize: 14,

--- a/src/components/profileSummary/view/profileSummaryView.tsx
+++ b/src/components/profileSummary/view/profileSummaryView.tsx
@@ -14,6 +14,7 @@ import { TextWithIcon } from '../../basicUIElements';
 import { PercentBar } from '../../percentBar';
 import { DropdownButton } from '../../dropdownButton';
 import { UserAvatar } from '../../userAvatar';
+import { ProBadge } from '../../proBadge';
 
 // Utils
 import { makeCountFriendly } from '../../../utils/formatter';
@@ -193,9 +194,12 @@ class ProfileSummaryView extends PureComponent {
 
     return (
       <View style={styles.identitySection}>
-        <Text style={styles.displayName} numberOfLines={1}>
-          {displayName || username}
-        </Text>
+        <View style={styles.displayNameRow}>
+          <Text style={styles.displayName} numberOfLines={1}>
+            {displayName || username}
+          </Text>
+          <ProBadge username={username} size={18} />
+        </View>
         <Text style={styles.username}>
           {`@${username}`}
           {reputation ? ` (${reputation})` : ''}

--- a/src/components/similarEntries/children/similarEntryItem.tsx
+++ b/src/components/similarEntries/children/similarEntryItem.tsx
@@ -7,6 +7,7 @@ import { catchPostImage } from '@ecency/render-helper';
 import ROUTES from '../../../constants/routeNames';
 import { getTimeFromNow } from '../../../utils/time';
 import { Icon } from '../../icon';
+import { ProBadge } from '../../proBadge';
 import { HiddenImagePlaceholder } from '../../hiddenImagePlaceholder';
 import { useImageReveal } from '../../../hooks/useImageReveal';
 import styles from '../styles/similarEntries.styles';
@@ -72,6 +73,7 @@ const SimilarEntryItem = ({ entry }: Props) => {
         <View style={styles.meta}>
           <Text numberOfLines={1} style={styles.author}>
             @{entry.author}
+            <ProBadge username={entry.author} size={11} />
           </Text>
           {!!relativeDate && <Text style={styles.date}>{relativeDate}</Text>}
         </View>

--- a/src/config/locales/en-US.json
+++ b/src/config/locales/en-US.json
@@ -953,6 +953,7 @@
     "a11y_hide_replies": "Hide replies",
     "a11y_post_options": "Post options",
     "a11y_views": "{count, plural, one {# view} other {# views}}",
+    "source_ecency": "Published with Ecency",
     "a11y_stats_hint": "View post stats",
     "image": "Image",
     "reveal_muted": "MUTED\nTap to reveal content",

--- a/src/screens/waves/children/wavesReelItem.tsx
+++ b/src/screens/waves/children/wavesReelItem.tsx
@@ -4,6 +4,7 @@ import { useIntl } from 'react-intl';
 import { ShortsFeedEntry } from '@ecency/sdk';
 
 import { FormattedCurrency, Icon, UserAvatar } from '../../../components';
+import { ProBadge } from '../../../components/proBadge';
 import WavesReelVideo from './wavesReelVideo';
 import styles from '../styles/wavesReels.styles';
 
@@ -106,6 +107,7 @@ const WavesReelItem = ({
         <View style={styles.authorRow}>
           <UserAvatar username={item.author} />
           <Text style={styles.authorName}>@{item.author}</Text>
+          <ProBadge username={item.author} />
         </View>
         {!!caption && (
           <Text style={styles.caption} numberOfLines={2}>


### PR DESCRIPTION
## What

Two related changes to badges shown next to usernames, matching the web app.

### 1. Pro checkmark on the remaining username surfaces
The `ProBadge` already covered post cards, comments, waves and post detail via `PostHeaderDescription`. Added it everywhere else a username renders:

- `UserListItem` (backs followers/following, people search, voters, leaderboard, reblogs, bookmarks, referrals, account list)
- Profile summary header, notifications, waves reels, quick-profile modal, similar-entry items

Where the surrounding layout is constrained (the notification line's wrapping `Text`, the space-between meta row, the centered modal title) the badge nests inside the `Text` rather than adding a sibling `View`, so spacing is unchanged for non-Pro users.

### 2. Mute the "published with Ecency" source badge
It was the round blue logo, sitting next to the blue Pro checkmark. Added an `EcencySourceBadge` component that draws just the bare "e" glyph (react-native-svg, same path/viewBox as web) in soft gray (`#d1d5db` / `#374151`, matching web's `gray-300` / `gray-700`), and used it in the post header and post detail in place of the round logo image. Now only Pro keeps a filled blue badge on a name.

## Tests
- `yarn lint` clean on changed files; `yarn test:ci` green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Pro badges next to verified creator names across profiles, notifications, user lists, similar entries, and video reels.
  * Added consistent Ecency source badges with theme-aware colors and accessibility labels.
  * Improved name and profile layouts to align badges and handle constrained screen widths.

* **Documentation**
  * Added the “Published with Ecency” localization text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->