### PR TITLE
Rename AI Summarize label to Recap

### DIFF
--- a/src/config/locales/en-US.json
+++ b/src/config/locales/en-US.json
@@ -728,7 +728,7 @@
     "action_suggest_tags_desc": "Get relevant tags for your post",
     "action_generate_title": "Generate Title",
     "action_generate_title_desc": "Create compelling title options",
-    "action_summarize": "Summarize",
+    "action_summarize": "Recap",
     "action_summarize_desc": "Create a concise summary",
     "action_check_grammar": "Check Grammar",
     "action_check_grammar_desc": "Fix grammar and spelling issues",


### PR DESCRIPTION
Renames the AI "Summarize" button to "Recap" so it fits its container on the post reading view, where the longer word was overflowing on smaller screens.

Single string change in `en-US.json` (`ai_assist.action_summarize`). This key is shared, so the AI Assist editor action list also shows "Recap". Descriptions are unchanged; other locales regenerate via Crowdin.