### PR TITLE
Record check-in on content open instead of app startup

### DIFF
--- a/src/components/postView/view/postDisplayView.tsx
+++ b/src/components/postView/view/postDisplayView.tsx
@@ -92,12 +92,15 @@ const PostDisplayView = ({
   );
 
   // Component Life Cycles
+  // Reading a post, comment or reply (incl. opened from notifications) is a check-in.
+  // Not mount-only: a cold start from a deep link can render this before persisted
+  // auth is restored, and `recordCheckIn` changes identity once the account lands,
+  // so the check-in still gets recorded. Its own throttle keeps repeats cheap.
   useEffect(() => {
-    // reading a post, comment or reply (incl. opened from notifications) is a check-in
     if (!isNewPost) {
       recordCheckIn();
     }
-  }, []);
+  }, [isNewPost, recordCheckIn]);
 
   const processedTags = useMemo(() => {
     if (!post) return [];

--- a/src/components/postView/view/postDisplayView.tsx
+++ b/src/components/postView/view/postDisplayView.tsx
@@ -25,8 +25,7 @@ import styles from './postDisplayStyles';
 import { EcencySourceBadge } from '../../ecencySourceBadge';
 import { WritePostButton } from '../../atoms';
 import { PostTypes } from '../../../constants/postTypes';
-import { useUserActivityMutation } from '../../../providers/queries/pointQueries';
-import { PointActivityIds } from '../../../providers/ecency/ecency.types';
+import { useCheckIn } from '../../../providers/queries/pointQueries';
 import { PostComments } from '../../postComments';
 import { SimilarEntries } from '../../similarEntries';
 import { UpvoteButton } from '../../postCard/children/upvoteButton';
@@ -59,7 +58,7 @@ const PostDisplayView = ({
   const insets = useSafeAreaInsets();
 
   const queryClient = useQueryClient();
-  const userActivityMutation = useUserActivityMutation();
+  const recordCheckIn = useCheckIn();
   const dims = useWindowDimensions();
   // Per-render (not memoized on `created`) so the `to` bound stays current if the
   // post screen lives across midnight; react-query value-hashes the range in the
@@ -94,11 +93,9 @@ const PostDisplayView = ({
 
   // Component Life Cycles
   useEffect(() => {
-    if (isLoggedIn && get(currentAccount, 'name') && !isNewPost) {
-      // record a check-in (type 10) for reading a post
-      userActivityMutation.mutate({
-        pointsTy: PointActivityIds.CHECKIN,
-      });
+    // reading a post, comment or reply (incl. opened from notifications) is a check-in
+    if (!isNewPost) {
+      recordCheckIn();
     }
   }, []);
 

--- a/src/providers/queries/pointQueries.ts
+++ b/src/providers/queries/pointQueries.ts
@@ -131,7 +131,19 @@ export const useCheckIn = () => {
       return;
     }
 
+    // Claim the window before firing so parallel opens don't double-post, then
+    // release it if the request ends up failing: the activity is queued for
+    // replay, but a rejected call shouldn't also mute the next 15 minutes.
     lastCheckinAt[username] = now;
-    mutate({ pointsTy: PointActivityIds.CHECKIN });
+    mutate(
+      { pointsTy: PointActivityIds.CHECKIN },
+      {
+        onError: () => {
+          if (lastCheckinAt[username] === now) {
+            delete lastCheckinAt[username];
+          }
+        },
+      },
+    );
   }, [isLoggedIn, username, mutate]);
 };

--- a/src/providers/queries/pointQueries.ts
+++ b/src/providers/queries/pointQueries.ts
@@ -1,3 +1,4 @@
+import { useCallback } from 'react';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { getPointsQueryOptions, getQuestsQueryOptions } from '@ecency/sdk';
 import { useAppSelector, useAppDispatch } from '../../hooks';
@@ -8,7 +9,7 @@ import {
 import { generateRndStr } from '../../utils/editor';
 import { PointActivity, PointActivityIds } from '../ecency/ecency.types';
 import { userActivity } from '../ecency/ePoint';
-import { selectCurrentAccount } from '../../redux/selectors';
+import { selectCurrentAccount, selectIsLoggedIn } from '../../redux/selectors';
 
 interface UserActivityMutationVars {
   pointsTy: PointActivityIds;
@@ -98,4 +99,39 @@ export const useUserActivityMutation = () => {
     ...mutation,
     lazyMutatePendingActivities,
   };
+};
+
+// The backend records at most one check-in per ~15 min window and drops
+// anything closer, so repeated content opens inside a window would only burn
+// requests. Kept at module scope so the spacing survives screen remounts, and
+// keyed by account so switching users still checks in.
+const CHECKIN_THROTTLE_MS = 15 * 60 * 1000;
+const lastCheckinAt: Record<string, number> = {};
+
+/**
+ * Records a daily check-in (point activity type 10) when the user actually
+ * reads something: opening a post/comment/reply, including from notifications,
+ * or browsing waves. Deliberately not wired to app startup, which already has
+ * plenty to do on launch.
+ */
+export const useCheckIn = () => {
+  const isLoggedIn = useAppSelector(selectIsLoggedIn);
+  const currentAccount = useAppSelector(selectCurrentAccount);
+  const { mutate } = useUserActivityMutation();
+
+  const username = currentAccount?.name;
+
+  return useCallback(() => {
+    if (!isLoggedIn || !username) {
+      return;
+    }
+
+    const now = Date.now();
+    if (now - (lastCheckinAt[username] || 0) < CHECKIN_THROTTLE_MS) {
+      return;
+    }
+
+    lastCheckinAt[username] = now;
+    mutate({ pointsTy: PointActivityIds.CHECKIN });
+  }, [isLoggedIn, username, mutate]);
 };

--- a/src/screens/application/hook/useInitApplication.tsx
+++ b/src/screens/application/hook/useInitApplication.tsx
@@ -35,12 +35,7 @@ import {
 } from '../../../redux/actions/applicationActions';
 import RootNavigation from '../../../navigation/rootNavigation';
 import ROUTES from '../../../constants/routeNames';
-import { selectCurrentAccount, selectIsLoggedIn } from '../../../redux/selectors';
-import { PointActivityIds } from '../../../providers/ecency/ecency.types';
-
-// Client-side spacing for app open/resume check-ins; the backend enforces
-// ~15 min between check-ins anyway and cancels anything closer.
-const CHECKIN_THROTTLE_MS = 15 * 60 * 1000;
+import { selectCurrentAccount } from '../../../redux/selectors';
 
 export const useInitApplication = () => {
   const dispatch = useAppDispatch();
@@ -50,19 +45,11 @@ export const useInitApplication = () => {
     (state) => state.application,
   );
   const currentAccount = useAppSelector(selectCurrentAccount);
-  const isLoggedIn = useAppSelector(selectIsLoggedIn);
   const systemColorScheme = useColorScheme();
 
   const appState = useRef(AppState.currentState);
   const appStateSubRef = useRef<NativeEventSubscription | null>(null);
   const lowMemSubRef = useRef<NativeEventSubscription | null>(null);
-  const lastCheckinAtRef = useRef<Record<string, number>>({});
-
-  // Fresh auth snapshot for _recordCheckin: the AppState listener re-registers
-  // only when currentAccount.name changes, so it must not rely on captured
-  // isLoggedIn (stale if auth flips without a name change).
-  const authRef = useRef({ isLoggedIn, username: currentAccount?.name });
-  authRef.current = { isLoggedIn, username: currentAccount?.name };
 
   const notifeeEventRef = useRef<any>(null);
   const messagingEventRef = useRef<any>(null);
@@ -117,7 +104,6 @@ export const useInitApplication = () => {
     });
 
     userActivityMutation.lazyMutatePendingActivities();
-    _recordCheckin();
 
     // update fiat currency rate usd:fiat
     dispatch(setCurrency(currency.currency));
@@ -203,29 +189,9 @@ export const useInitApplication = () => {
     // }
   };
 
-  // Daily-quest check-in (type 10) on app open and foreground return, so users
-  // active only in feed/waves still check in; opening a post records one too.
-  // Fires only for a logged in account brought to the foreground, never from
-  // background wakeups, and is throttled per account to match the backend spacing.
-  const _recordCheckin = () => {
-    const { isLoggedIn: loggedIn, username } = authRef.current;
-    if (!loggedIn || !username) {
-      return;
-    }
-
-    const lastAt = lastCheckinAtRef.current[username] || 0;
-    if (Date.now() - lastAt < CHECKIN_THROTTLE_MS) {
-      return;
-    }
-
-    lastCheckinAtRef.current[username] = Date.now();
-    userActivityMutation.mutate({ pointsTy: PointActivityIds.CHECKIN });
-  };
-
   const _handleAppStateChange = (nextAppState) => {
     if (appState.current.match(/inactive|background/) && nextAppState === 'active') {
       userActivityMutation.lazyMutatePendingActivities();
-      _recordCheckin();
       dispatch(recordAppSession());
     }
 

--- a/src/screens/waves/screen/wavesScreen.tsx
+++ b/src/screens/waves/screen/wavesScreen.tsx
@@ -26,7 +26,7 @@ import {
 import WavesTabBar from '../../../components/wavesTabBar/wavesTabBar';
 import { renderPillTabLabel } from '../../../components/tabbedPosts/view/renderPillTabLabel';
 import styles from '../styles/wavesScreen.styles';
-import { wavesQueries } from '../../../providers/queries';
+import { useCheckIn, wavesQueries } from '../../../providers/queries';
 import { useAppSelector } from '../../../hooks';
 import { WavesHeader } from '../children/wavesHeader';
 import WavesOnboardingChecklist from '../children/wavesOnboardingChecklist';
@@ -222,6 +222,15 @@ const WavesScreen = () => {
   // bottom tab / pushed screen). Combined with the active waves tab below to
   // decide if the Shorts reels should actually be playing.
   const isScreenFocused = useIsFocused();
+
+  // Browsing waves is reading too, so it records a check-in like opening a post
+  // does; users who only ever scroll waves still complete the daily quest.
+  const recordCheckIn = useCheckIn();
+  useEffect(() => {
+    if (isScreenFocused) {
+      recordCheckIn();
+    }
+  }, [isScreenFocused, recordCheckIn]);
 
   const isLoggedIn = useAppSelector(selectIsLoggedIn);
   const currentAccount = useAppSelector(selectCurrentAccount);


### PR DESCRIPTION
Moves the daily check-in (point activity type 10) off app startup, where it competed with everything else the app does on launch, back to the moments that indicate the user is actually reading.

Check-in now fires when:
- a post, comment or reply is opened, including from the notifications screen (all go through the post screen)
- the waves feed is focused

A shared `useCheckIn` hook holds the 15 minute client-side spacing that matches the backend, so repeated opens send at most one request per window per account. The app open and foreground-return calls in `useInitApplication` are removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic check-ins when opening an existing post and when the Waves screen is focused.
  - Check-ins now require an authenticated account with a username.
  - Repeated check-ins are limited to once every 15 minutes.

- **Bug Fixes**
  - Reduced duplicate check-ins by throttling repeated attempts.
  - If a check-in fails, the throttling window is cleared to allow retries.
  - Continued updating pending activities on app foreground return (without triggering check-ins during app initialization).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->