### PR TITLE
fix(upload): stop sending "undefined" as the image upload signature

### DIFF
--- a/src/components/uploadsGalleryModal/container/uploadsGalleryModal.tsx
+++ b/src/components/uploadsGalleryModal/container/uploadsGalleryModal.tsx
@@ -19,6 +19,7 @@ import { MediaItem } from '../../../providers/ecency/ecency.types';
 import { SpeakUploaderModal } from '../children/speakUploaderModal';
 import { SheetNames } from '../../../navigation/sheets';
 import { selectIsLoggedIn } from '../../../redux/selectors';
+import { isSignImageUnavailable } from '../../../constants/imageUpload';
 
 export interface UploadsGalleryModalRef {
   showModal: () => void;
@@ -396,7 +397,13 @@ export const UploadsGalleryModal = forwardRef(
           const errorMessages = new Set<string>();
           failures.forEach((failure) => {
             const error = failure.status === 'rejected' ? failure.reason : failure;
-            if (error.toString().includes('code 413')) {
+            if (isSignImageUnavailable(error)) {
+              errorMessages.add(
+                intl.formatMessage({
+                  id: 'alert.decrypt_fail_alert',
+                }),
+              );
+            } else if (error.toString().includes('code 413')) {
               errorMessages.add(
                 intl.formatMessage({
                   id: 'alert.payloadTooLarge',

--- a/src/config/imageApi.test.ts
+++ b/src/config/imageApi.test.ts
@@ -1,0 +1,48 @@
+import axios from 'axios';
+import { upload } from './imageApi';
+import { SIGN_IMAGE_UNAVAILABLE } from '../constants/imageUpload';
+
+jest.mock('axios');
+jest.mock('react-native-config', () => ({
+  __esModule: true,
+  default: { NEW_IMAGE_API: 'https://images.example.com' },
+}));
+
+const mockedCreate = axios.create as unknown as jest.Mock;
+const mockPost = jest.fn();
+
+describe('imageApi upload', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockPost.mockResolvedValue({ data: { url: 'https://images.example.com/DQmHash' } });
+    mockedCreate.mockReturnValue({
+      post: mockPost,
+      interceptors: {
+        request: { use: jest.fn() },
+        response: { use: jest.fn() },
+      },
+    });
+  });
+
+  it.each([
+    ['undefined', undefined],
+    ['empty', ''],
+  ])('rejects without issuing a request when the signature is %s', async (_label, signature) => {
+    await expect(upload({} as FormData, 'foo', signature)).rejects.toThrow(SIGN_IMAGE_UNAVAILABLE);
+
+    // The point of the guard: no request is built at all, so the literal string
+    // "undefined" can never reach the image server as an upload signature.
+    expect(mockedCreate).not.toHaveBeenCalled();
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  it('posts to a signature-scoped url when the signature is present', async () => {
+    await upload({} as FormData, 'foo', 'signed-token');
+
+    expect(mockedCreate).toHaveBeenCalledTimes(1);
+    const { baseURL } = mockedCreate.mock.calls[0][0];
+    expect(baseURL).toBe('https://images.example.com/hs/signed-token');
+    expect(baseURL).not.toContain('undefined');
+    expect(mockPost).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/config/imageApi.ts
+++ b/src/config/imageApi.ts
@@ -1,12 +1,19 @@
 import axios, { AxiosProgressEvent, AxiosResponse } from 'axios';
 import Config from 'react-native-config';
+import { SIGN_IMAGE_UNAVAILABLE } from '../constants/imageUpload';
 
 export function upload(
   fd: FormData,
   username: string,
-  signature: string,
+  signature: string | undefined,
   uploadProgress?: (progressEvent: AxiosProgressEvent) => void,
 ): Promise<AxiosResponse> {
+  // Without this the URL interpolates to /hs/undefined and the server answers
+  // 400 for every upload the account attempts.
+  if (!signature) {
+    return Promise.reject(new Error(SIGN_IMAGE_UNAVAILABLE));
+  }
+
   const image = axios.create({
     timeout: 120000,
     baseURL: `${Config.NEW_IMAGE_API}/hs/${signature}`,

--- a/src/constants/imageUpload.ts
+++ b/src/constants/imageUpload.ts
@@ -1,0 +1,7 @@
+// Thrown when an upload signature cannot be produced: the stored posting key or
+// access token could not be decrypted with the current PIN, or the account has
+// neither. Callers should ask the user to re-login rather than attempt the upload.
+export const SIGN_IMAGE_UNAVAILABLE = 'SIGN_IMAGE_UNAVAILABLE';
+
+export const isSignImageUnavailable = (error: unknown): boolean =>
+  (error as { message?: string })?.message === SIGN_IMAGE_UNAVAILABLE;

--- a/src/containers/profileEditContainer.tsx
+++ b/src/containers/profileEditContainer.tsx
@@ -10,6 +10,7 @@ import { selectCurrentAccount, selectIsDarkTheme, selectPin } from '../redux/sel
 import { uploadImage } from '../providers/ecency/ecency';
 
 import { signImage } from '../providers/hive/hive';
+import { isSignImageUnavailable } from '../constants/imageUpload';
 import { useAccountUpdateMutation } from '../providers/sdk/mutations';
 import { updateCurrentAccount } from '../redux/actions/accountAction';
 import { setAvatarCacheStamp } from '../redux/actions/uiAction';
@@ -80,7 +81,19 @@ class ProfileEditContainer extends Component {
 
     this.setState({ isUploading: true });
 
-    const sign = await signImage(media, currentAccount, pinCode);
+    let sign;
+    try {
+      sign = await signImage(media, currentAccount, pinCode);
+    } catch (error) {
+      this.setState({ isUploading: false });
+      Alert.alert(
+        intl.formatMessage({ id: 'alert.fail' }),
+        intl.formatMessage({
+          id: isSignImageUnavailable(error) ? 'alert.decrypt_fail_alert' : 'alert.unknow_error',
+        }),
+      );
+      return;
+    }
 
     uploadImage(media, currentAccount.name, sign)
       .then((res) => {

--- a/src/providers/hive/hive.ts
+++ b/src/providers/hive/hive.ts
@@ -34,6 +34,7 @@ import { resolveTxRequiredAuthority } from '../../utils/hiveOperationAuthority';
 // Constant
 import AUTH_TYPE from '../../constants/authType';
 import { SERVER_LIST } from '../../constants/options/api';
+import { SIGN_IMAGE_UNAVAILABLE } from '../../constants/imageUpload';
 import { b64uEnc } from '../../utils/b64';
 import { delay } from '../../utils/editor';
 
@@ -540,7 +541,11 @@ export const signImage = async (file, currentAccount, pin) => {
   const key = getPostingKey(currentAccount.local, digitPinCode);
 
   if (isHsClientSupported(currentAccount.local.authType)) {
-    return decryptKey(currentAccount.local.accessToken, digitPinCode);
+    const accessToken = decryptKey(currentAccount.local.accessToken, digitPinCode);
+    if (!accessToken) {
+      throw new Error(SIGN_IMAGE_UNAVAILABLE);
+    }
+    return accessToken;
   }
   if (key) {
     const message = {
@@ -555,6 +560,11 @@ export const signImage = async (file, currentAccount, pin) => {
     message.signatures = [signature];
     return b64uEnc(JSON.stringify(message));
   }
+
+  // No posting key on file and no token-based auth to fall back on. Returning
+  // undefined here used to send the literal string "undefined" as the upload
+  // signature, so every upload failed with an opaque error.
+  throw new Error(SIGN_IMAGE_UNAVAILABLE);
 };
 
 // HELPERS

--- a/src/providers/queries/editorQueries/editorQueries.ts
+++ b/src/providers/queries/editorQueries/editorQueries.ts
@@ -22,6 +22,7 @@ import { uploadImage } from '../../ecency/ecency';
 import { MediaItem, Snippet } from '../../ecency/ecency.types';
 import { signImage } from '../../hive/hive';
 import { selectCurrentAccount, selectPin } from '../../../redux/selectors';
+import { isSignImageUnavailable } from '../../../constants/imageUpload';
 
 /**
  * EDITOR QUERIES - SDK MIGRATION STATUS
@@ -269,7 +270,13 @@ export const useMediaUploadMutation = () => {
       Sentry.captureException(err, (scope) => {
         scope.setContext('info', { message: 'Media upload failed' });
       });
-      dispatch(toastNotification(intl.formatMessage({ id: 'alert.fail' })));
+      dispatch(
+        toastNotification(
+          intl.formatMessage({
+            id: isSignImageUnavailable(err) ? 'alert.decrypt_fail_alert' : 'alert.fail',
+          }),
+        ),
+      );
     },
   });
 };

--- a/src/screens/chats/container/chatThreadContainer.tsx
+++ b/src/screens/chats/container/chatThreadContainer.tsx
@@ -50,6 +50,7 @@ import {
 } from '../../../providers/chat/mattermost';
 import { uploadImage } from '../../../providers/ecency/ecency';
 import { signImage } from '../../../providers/hive/hive';
+import { isSignImageUnavailable } from '../../../constants/imageUpload';
 import { chatThreadStyles as styles } from '../styles/chatThread.styles';
 import { emojifyMessage } from '../../../utils/emoji';
 import { extractImageUrls, extractUrls } from '../../../utils/editor';
@@ -1421,6 +1422,12 @@ export const ChatThreadContainer: React.FC<ChatThreadContainerProps> = ({
       }
     } catch (err: any) {
       if (isMediaPickerCancellation(err)) {
+        return;
+      }
+      // Not a picker failure — the account cannot produce an upload signature,
+      // so report it as itself and tell the user how to recover.
+      if (isSignImageUnavailable(err)) {
+        setError(intl.formatMessage({ id: 'alert.decrypt_fail_alert' }));
         return;
       }
       reportMediaPickerError(err, {

--- a/src/screens/chats/container/chatThreadContainer.tsx
+++ b/src/screens/chats/container/chatThreadContainer.tsx
@@ -1425,9 +1425,13 @@ export const ChatThreadContainer: React.FC<ChatThreadContainerProps> = ({
         return;
       }
       // Not a picker failure — the account cannot produce an upload signature,
-      // so report it as itself and tell the user how to recover.
+      // so report it as itself and tell the user how to recover. This goes to an
+      // alert rather than `error`, which only renders in the empty-thread view.
       if (isSignImageUnavailable(err)) {
-        setError(intl.formatMessage({ id: 'alert.decrypt_fail_alert' }));
+        Alert.alert(
+          intl.formatMessage({ id: 'alert.fail' }),
+          intl.formatMessage({ id: 'alert.decrypt_fail_alert' }),
+        );
         return;
       }
       reportMediaPickerError(err, {
@@ -1439,7 +1443,7 @@ export const ChatThreadContainer: React.FC<ChatThreadContainerProps> = ({
     } finally {
       setIsUploadingImage(false);
     }
-  }, [currentAccount, pinCode, _updateMentionState]);
+  }, [currentAccount, pinCode, intl, _updateMentionState]);
 
   // Render helpers
   const _showUserProfile = useCallback((username?: string | null) => {


### PR DESCRIPTION
Origin logs on the image server show `POST /hs/undefined` from `okhttp/4.12.0`, answered `400 {"error":{"name":"bad_request"}}` — 21 requests across 7 distinct clients over Jul 21-22. Affected accounts fail every upload; unaffected ones are fine (371 successful uploads from the same client on the same day).

`signImage()` can return `undefined` two ways:

- `isHsClientSupported(authType)` is true and `decryptKey()` returns undefined (it is typed `string | undefined` and swallows the failure)
- neither branch matches — no stored `postingKey`, and authType is not STEEM_CONNECT/HIVE_AUTH/ACTIVE_KEY — so the function falls off the end

No caller checked the result, and `imageApi.upload()` interpolated it straight into `baseURL: ${NEW_IMAGE_API}/hs/${signature}`.

## Changes

- `signImage()` throws `SIGN_IMAGE_UNAVAILABLE` instead of returning `undefined`
- `upload()` rejects on a falsy signature, so the placeholder cannot reach the server regardless of caller
- Callers map the error to the existing `alert.decrypt_fail_alert` copy ("Corrupt app state, please relogin to reset state.") rather than a generic failure. `profileEditContainer` also had the `signImage` call outside its `try`/`catch`, so a throw there would have left the upload spinner running; chat no longer reports these through `reportMediaPickerError`.

The retry in `useMediaUploadMutation` no longer re-sends a request that cannot succeed — a thrown error has no `response.status`, so it is not retried.

## Testing

`src/config/imageApi.test.ts` asserts no request is built for an absent signature, and that a present one produces a signature-scoped URL. Verified the guard test fails against the unpatched `upload()` and passes with it. Full suite: 660 passed, 1 skipped. Lint clean on touched files (existing warnings only).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved image upload reliability when signing credentials are unavailable.
  - Prevented uploads from being attempted without a valid image signature.
  - Added clearer, localized alerts for credential or decryption-related failures.
  - Preserved existing handling for canceled image selections while providing more specific errors for signing failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->