### PR TITLE
feat(android): move purchases to expo-iap for Play Billing 9

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,15 @@
       "./src/assets/Fonts"
     ]
   },
+  "expo": {
+    "autolinking": {
+      "apple": {
+        "exclude": [
+          "expo-iap"
+        ]
+      }
+    }
+  },
   "scripts": {
     "version": "./version-ios.sh",
     "postversion": "react-native-version --never-amend --legacy --skip-expo",
@@ -78,6 +87,7 @@
     "events": "^1.0.0",
     "expo": "^53.0.20",
     "expo-crypto": "~14.1.5",
+    "expo-iap": "^4.6.0",
     "expo-image": "~2.4.0",
     "expo-image-manipulator": "~13.1.7",
     "expo-linear-gradient": "~14.1.5",

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -1,4 +1,14 @@
 module.exports = {
-  dependencies: {},
+  dependencies: {
+    // Android purchases run on expo-iap (Play Billing 9). react-native-iap 12 pins
+    // Billing 7.0.0, which Play rejects for updates from Aug 31, 2026, so keep its
+    // Android module out of the build entirely -- Play reads the classes shipped in
+    // the AAB. iOS still links it, see src/providers/iap.
+    'react-native-iap': {
+      platforms: {
+        android: null,
+      },
+    },
+  },
   assets: ['react-native-vector-icons', './src/assets/fonts'],
 };

--- a/src/containers/inAppPurchaseContainer.tsx
+++ b/src/containers/inAppPurchaseContainer.tsx
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { Platform, Alert, EmitterSubscription } from 'react-native';
-import * as IAP from 'react-native-iap';
 import { injectIntl } from 'react-intl';
 import get from 'lodash/get';
 import AsyncStorage from '@react-native-async-storage/async-storage';
@@ -12,6 +11,7 @@ import { SheetManager } from 'react-native-actions-sheet';
 import * as Sentry from '@sentry/react-native';
 import { selectCurrentAccount, selectIsLoggedIn } from '../redux/selectors';
 import { purchaseOrder } from '../providers/ecency/ecency';
+import * as IAP from '../providers/iap';
 
 // Utilities
 import { default as ROUTES } from '../constants/routeNames';
@@ -64,10 +64,10 @@ class InAppPurchaseContainer extends Component {
   _initContainer = async () => {
     const { intl, disablePurchaseListenerOnMount } = this.props;
     try {
+      // flushFailedPurchasesCachedAsPendingAndroid is gone with the move to
+      // Billing 9 on Android; openiap has no equivalent. Stale purchases are
+      // picked up by _consumeAvailablePurchases below instead.
       await IAP.initConnection();
-      if (Platform.OS === 'android') {
-        await IAP.flushFailedPurchasesCachedAsPendingAndroid();
-      }
 
       if (!disablePurchaseListenerOnMount) {
         await this._consumeAvailablePurchases();
@@ -292,7 +292,7 @@ class InAppPurchaseContainer extends Component {
       const { intl, handleOnPurchaseFailure } = this.props;
 
       Sentry.captureException(error);
-      if (get(error, 'responseCode') === '3' && Platform.OS === 'android') {
+      if (IAP.isBillingUnavailableError(error) && Platform.OS === 'android') {
         Alert.alert(
           intl.formatMessage({
             id: 'alert.warning',
@@ -301,7 +301,7 @@ class InAppPurchaseContainer extends Component {
             id: 'alert.google_play_version',
           }),
         );
-      } else if (get(error, 'responseCode') !== '2') {
+      } else if (!IAP.isUserCancelledError(error)) {
         console.warn('failed puchase:', error);
         Alert.alert(
           intl.formatMessage({
@@ -336,7 +336,7 @@ class InAppPurchaseContainer extends Component {
   _getItems = async () => {
     const { skus, intl } = this.props;
     try {
-      const products = await IAP.getProducts({ skus });
+      const products = await IAP.getProducts(skus);
       console.log(products);
       products.sort((a, b) => parseFloat(a.price) - parseFloat(b.price)).reverse();
       this.setState({ productList: products });
@@ -417,7 +417,7 @@ class InAppPurchaseContainer extends Component {
       }
 
       try {
-        IAP.requestPurchase(Platform.OS === 'ios' ? { sku } : { skus: [sku] });
+        IAP.requestPurchase(sku);
       } catch (err) {
         Sentry.captureException(err, (scope) => {
           scope.setContext('sku', { sku });
@@ -432,11 +432,11 @@ class InAppPurchaseContainer extends Component {
 
   _handleQrPurchase = async () => {
     const { skus, intl, route } = this.props;
-    const products = await IAP.getProducts({ skus });
+    const products = await IAP.getProducts(skus);
     const productId = route?.param?.productId ?? '';
     const username = route?.param?.username ?? '';
 
-    const product: IAP.Product =
+    const product: IAP.IapProduct =
       productId && products && products.find((product) => product.productId === productId);
 
     if (product) {

--- a/src/providers/iap/index.ts
+++ b/src/providers/iap/index.ts
@@ -1,0 +1,119 @@
+import { Platform } from 'react-native';
+
+/**
+ * Single entry point for store purchases, so the rest of the app does not care
+ * which library backs a platform.
+ *
+ * Android runs on expo-iap (Google Play Billing 9). Play requires Billing 8+ for
+ * updates from Aug 31, 2026 and react-native-iap 12 pins Billing 7.0.0, with no
+ * 12.x/13.x release that ships a newer one.
+ *
+ * iOS stays on react-native-iap: expo-iap exposes only the StoreKit 2 JWS token,
+ * while /private-api/purchase-order still verifies the legacy base64 App Store
+ * receipt. Moving iOS over needs that verification changed first.
+ *
+ * Each platform ships exactly one billing implementation: react-native-iap is
+ * unlinked from Android in react-native.config.js (so Billing 7 classes stay out
+ * of the AAB, which is what Play checks), and expo-iap is excluded from the Apple
+ * build via `expo.autolinking` in package.json. The requires below are therefore
+ * lazy on purpose -- the module that is not linked is never evaluated.
+ */
+
+const IS_ANDROID = Platform.OS === 'android';
+
+const iap = IS_ANDROID ? require('expo-iap') : require('react-native-iap');
+
+// Shape the screens already render (react-native-iap's product shape).
+export interface IapProduct {
+  productId: string;
+  title: string;
+  description?: string;
+  price: string;
+  currency: string;
+  localizedPrice: string;
+}
+
+export interface IapPurchase {
+  productId: string;
+  purchaseToken?: string;
+  transactionReceipt?: string;
+  [key: string]: any;
+}
+
+// Play BillingResponseCode values, reported as `responseCode` by both libraries.
+const RESPONSE_CODE_USER_CANCELED = 1;
+const RESPONSE_CODE_BILLING_UNAVAILABLE = 3;
+
+// openiap renamed the product fields (id/displayPrice) and returns price as a
+// number; map them back to what the screens expect.
+const _normalizeProduct = (product: any): IapProduct => ({
+  ...product,
+  productId: product.id,
+  title: product.title,
+  description: product.description,
+  price: product.price !== null && product.price !== undefined ? String(product.price) : '',
+  currency: product.currency,
+  localizedPrice: product.displayPrice,
+});
+
+// openiap drops transactionReceipt. On Android the receipt sent to the backend is
+// the purchase token either way; dataAndroid holds the original purchase JSON and
+// stands in for the receipt so purchase handling can keep gating on it.
+const _normalizePurchase = (purchase: any): IapPurchase => ({
+  ...purchase,
+  transactionReceipt: purchase.dataAndroid || purchase.purchaseToken,
+});
+
+// Error codes differ per library: react-native-iap raises E_-prefixed codes,
+// openiap raises kebab-case ones. Both also carry the numeric Play response code
+// on Android.
+export const isUserCancelledError = (error: any): boolean =>
+  error?.code === 'user-cancelled' ||
+  error?.code === 'E_USER_CANCELLED' ||
+  error?.responseCode === RESPONSE_CODE_USER_CANCELED;
+
+export const isBillingUnavailableError = (error: any): boolean =>
+  error?.code === 'billing-unavailable' ||
+  error?.responseCode === RESPONSE_CODE_BILLING_UNAVAILABLE;
+
+export const initConnection = (): Promise<any> => iap.initConnection();
+
+export const endConnection = (): Promise<any> => iap.endConnection();
+
+export const getProducts = async (skus: string[]): Promise<IapProduct[]> => {
+  if (IS_ANDROID) {
+    const products = await iap.fetchProducts({ skus, type: 'in-app' });
+    return (products || []).map(_normalizeProduct);
+  }
+
+  return (await iap.getProducts({ skus })) || [];
+};
+
+export const getAvailablePurchases = async (): Promise<IapPurchase[]> => {
+  const purchases = (await iap.getAvailablePurchases()) || [];
+  return IS_ANDROID ? purchases.map(_normalizePurchase) : purchases;
+};
+
+export const requestPurchase = (sku: string): Promise<any> => {
+  if (IS_ANDROID) {
+    return iap.requestPurchase({ request: { google: { skus: [sku] } }, type: 'in-app' });
+  }
+
+  return iap.requestPurchase({ sku });
+};
+
+export const finishTransaction = ({
+  purchase,
+  isConsumable,
+}: {
+  purchase: IapPurchase;
+  isConsumable: boolean;
+}): Promise<any> => iap.finishTransaction({ purchase, isConsumable });
+
+export const purchaseUpdatedListener = (listener: (purchase: IapPurchase) => void) =>
+  iap.purchaseUpdatedListener(
+    IS_ANDROID ? (purchase: any) => listener(_normalizePurchase(purchase)) : listener,
+  );
+
+export const purchaseErrorListener = (listener: (error: any) => void) =>
+  iap.purchaseErrorListener(listener);

--- a/src/screens/register/children/registerAccountModal.tsx
+++ b/src/screens/register/children/registerAccountModal.tsx
@@ -243,10 +243,10 @@ export const RegisterAccountModal = forwardRef(({ username, email, refUsername }
               : intl.formatMessage(
                   { id: 'buy_account.btn_register' },
                   {
-                    price: Platform.select({
-                      ios: product.localizedPrice,
-                      android: product.oneTimePurchaseOfferDetails?.formattedPrice,
-                    }),
+                    // src/providers/iap fills localizedPrice on both platforms;
+                    // the Android-only oneTimePurchaseOfferDetails shape does not
+                    // exist in the Billing 9 product payload.
+                    price: product.localizedPrice,
                   },
                 ),
             onPress: () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6623,6 +6623,11 @@ expo-font@~13.3.2:
   dependencies:
     fontfaceobserver "^2.1.0"
 
+expo-iap@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/expo-iap/-/expo-iap-4.6.0.tgz#de69f3c4db46c9697239afaf791fbe9316d65baa"
+  integrity sha512-M8L/IeEIZr5h9Sqww+VBthOY3qnrejTHq5UfYSAM8mDZar7LwcuXaq6USf3HYajH9XrL32z0lsLFB8Kxi7Q4uQ==
+
 expo-image-loader@~5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/expo-image-loader/-/expo-image-loader-5.1.0.tgz#f7d65f9b9a9714eaaf5d50a406cb34cb25262153"


### PR DESCRIPTION
Play Console: apps must use Billing Library 8+ for updates from Aug 31, 2026. `react-native-iap@12.16.2` pins `billing-ktx:7.0.0` and no 12.x/13.x release ships a newer one, so the library has to change on Android.

Stacked on #3359 (targetSdk 36) because expo-iap builds against SDK 36.

**Android** now uses `expo-iap@4.6.0` (openiap-google 2.4.1 -> Billing 9.1.0), which autolinks through expo-modules-core that the app already ships. react-native-iap is unlinked from Android in `react-native.config.js` so its Billing 7 classes are not in the AAB, which is what Play inspects.

**iOS** stays on react-native-iap. expo-iap purchases expose only `purchaseToken` (a StoreKit 2 JWS on iOS), while ePoints `purchase_order` verifies app_store receipts with `AppStoreValidator` against the legacy base64 receipt. Switching iOS needs App Store Server API verification server-side first. expo-iap is excluded from the Apple build via `expo.autolinking` so only one billing implementation ships per platform.

`src/providers/iap` is the single entry point and maps openiap back to the shapes the screens already render (`productId`, `localizedPrice`, `transactionReceipt`), so no screen changes. Play verification server-side is unaffected: the receipt sent for play_store is still the purchase token.

Two behaviour notes:
- `flushFailedPurchasesCachedAsPendingAndroid` has no openiap equivalent and is dropped; `_consumeAvailablePurchases` already recovers unfinished purchases on init.
- The purchase error branches compared `responseCode` against strings while both libraries report it as a number, so the "update Google Play" alert never fired and cancelling the Play sheet raised a generic alert. They now go through `isBillingUnavailableError` / `isUserCancelledError`.

Verified: lint clean, 660 unit tests pass, `react-native config` shows no react-native-iap Android entry, `expo-modules-autolinking search -p apple` shows no expo-iap. Not yet exercised against a real purchase.

Needs an internal-testing pass on Android before merge: buy points, buy a paid account (999accounts), recovery of an unfinished purchase, and cancel-flow. iOS should be smoke-tested too since the container changed.