### PR TITLE
feat(ios): move purchases to expo-iap, drop react-native-iap

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,15 +8,6 @@
       "./src/assets/Fonts"
     ]
   },
-  "expo": {
-    "autolinking": {
-      "apple": {
-        "exclude": [
-          "expo-iap"
-        ]
-      }
-    }
-  },
   "scripts": {
     "version": "./version-ios.sh",
     "postversion": "react-native-version --never-amend --legacy --skip-expo",
@@ -135,7 +126,6 @@
     "react-native-heic-converter": "^1.3.3",
     "react-native-highlight-words": "^1.0.1",
     "react-native-hyperlink": "^0.1.0",
-    "react-native-iap": "^12.16.2",
     "react-native-image-crop-picker": "^0.51.1",
     "react-native-image-viewing": "^0.2.2",
     "react-native-keyboard-aware-scroll-view": "^0.9.5",

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -1,14 +1,4 @@
 module.exports = {
-  dependencies: {
-    // Android purchases run on expo-iap (Play Billing 9). react-native-iap 12 pins
-    // Billing 7.0.0, which Play rejects for updates from Aug 31, 2026, so keep its
-    // Android module out of the build entirely -- Play reads the classes shipped in
-    // the AAB. iOS still links it, see src/providers/iap.
-    'react-native-iap': {
-      platforms: {
-        android: null,
-      },
-    },
-  },
+  dependencies: {},
   assets: ['react-native-vector-icons', './src/assets/fonts'],
 };

--- a/src/containers/inAppPurchaseContainer.tsx
+++ b/src/containers/inAppPurchaseContainer.tsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { Platform, Alert, EmitterSubscription } from 'react-native';
+import { Platform, Alert } from 'react-native';
 import { injectIntl } from 'react-intl';
 import get from 'lodash/get';
 import AsyncStorage from '@react-native-async-storage/async-storage';
@@ -29,9 +29,9 @@ const PENDING_ACCOUNT_PURCHASE_KEY = 'pendingAccountPurchaseMeta';
 const PURCHASE_ORDER_MAX_ATTEMPTS = 3;
 
 class InAppPurchaseContainer extends Component {
-  purchaseUpdateSubscription: EmitterSubscription | null = null;
+  purchaseUpdateSubscription: IAP.IapSubscription | null = null;
 
-  purchaseErrorSubscription: EmitterSubscription | null = null;
+  purchaseErrorSubscription: IAP.IapSubscription | null = null;
 
   constructor(props) {
     super(props);
@@ -64,9 +64,8 @@ class InAppPurchaseContainer extends Component {
   _initContainer = async () => {
     const { intl, disablePurchaseListenerOnMount } = this.props;
     try {
-      // flushFailedPurchasesCachedAsPendingAndroid is gone with the move to
-      // Billing 9 on Android; openiap has no equivalent. Stale purchases are
-      // picked up by _consumeAvailablePurchases below instead.
+      // OpenIAP has no flushFailedPurchasesCachedAsPendingAndroid equivalent;
+      // stale purchases are picked up by _consumeAvailablePurchases below.
       await IAP.initConnection();
 
       if (!disablePurchaseListenerOnMount) {
@@ -154,15 +153,16 @@ class InAppPurchaseContainer extends Component {
     const data = {};
 
     try {
-      const receipt = get(purchase, 'transactionReceipt');
+      // Play purchase token on Android, StoreKit 2 signed transaction on iOS.
+      // Both are verified by /private-api/purchase-order.
       const token = get(purchase, 'purchaseToken');
 
-      if (receipt) {
+      if (token) {
         const isAccount = purchase.productId === '999accounts';
         const data: PurchaseRequestData = {
           platform: Platform.OS === 'android' ? 'play_store' : 'app_store',
           product: get(purchase, 'productId'),
-          receipt: Platform.OS === 'android' ? token : receipt,
+          receipt: token,
           user: this.props.username || name, // from nav params i-e got from url qr scan
         };
 

--- a/src/containers/inAppPurchaseContainer.tsx
+++ b/src/containers/inAppPurchaseContainer.tsx
@@ -150,7 +150,9 @@ class InAppPurchaseContainer extends Component {
       handleOnPurchaseFailure,
       handleOnPurchaseSuccess,
     } = this.props;
-    const data = {};
+    // Populated below and reported as Sentry context if anything throws, so it
+    // must not be shadowed by a block-scoped copy.
+    let data: Partial<PurchaseRequestData> = {};
 
     try {
       // Play purchase token on Android, StoreKit 2 signed transaction on iOS.
@@ -159,7 +161,7 @@ class InAppPurchaseContainer extends Component {
 
       if (token) {
         const isAccount = purchase.productId === '999accounts';
-        const data: PurchaseRequestData = {
+        data = {
           platform: Platform.OS === 'android' ? 'play_store' : 'app_store',
           product: get(purchase, 'productId'),
           receipt: token,

--- a/src/providers/iap/index.ts
+++ b/src/providers/iap/index.ts
@@ -1,29 +1,24 @@
-import { Platform } from 'react-native';
+import * as iap from 'expo-iap';
 
 /**
- * Single entry point for store purchases, so the rest of the app does not care
- * which library backs a platform.
+ * Single entry point for store purchases.
  *
- * Android runs on expo-iap (Google Play Billing 9). Play requires Billing 8+ for
- * updates from Aug 31, 2026 and react-native-iap 12 pins Billing 7.0.0, with no
- * 12.x/13.x release that ships a newer one.
+ * Both platforms run on expo-iap (OpenIAP): Google Play Billing 9 on Android and
+ * StoreKit 2 on iOS. Play requires Billing 8+ for updates from Aug 31, 2026 and
+ * react-native-iap 12 pinned Billing 7, which is what forced the library change.
  *
- * iOS stays on react-native-iap: expo-iap exposes only the StoreKit 2 JWS token,
- * while /private-api/purchase-order still verifies the legacy base64 App Store
- * receipt. Moving iOS over needs that verification changed first.
+ * The receipt posted to /private-api/purchase-order is `purchaseToken` on both
+ * platforms: the Play purchase token on Android (unchanged), and the StoreKit 2
+ * signed transaction (Transaction.jwsRepresentation) on iOS, which ePoints
+ * verifies with Apple's App Store Server Library. Older app versions keep sending
+ * legacy base64 App Store receipts and are still verified server-side, so this
+ * does not strand anyone who has not updated.
  *
- * Each platform ships exactly one billing implementation: react-native-iap is
- * unlinked from Android in react-native.config.js (so Billing 7 classes stay out
- * of the AAB, which is what Play checks), and expo-iap is excluded from the Apple
- * build via `expo.autolinking` in package.json. The requires below are therefore
- * lazy on purpose -- the module that is not linked is never evaluated.
+ * OpenIAP's product payload is mapped back to the fields the screens render, so
+ * nothing outside this module deals with store shapes.
  */
 
-const IS_ANDROID = Platform.OS === 'android';
-
-const iap = IS_ANDROID ? require('expo-iap') : require('react-native-iap');
-
-// Shape the screens already render (react-native-iap's product shape).
+// Shape the screens render.
 export interface IapProduct {
   productId: string;
   title: string;
@@ -36,16 +31,18 @@ export interface IapProduct {
 export interface IapPurchase {
   productId: string;
   purchaseToken?: string;
-  transactionReceipt?: string;
   [key: string]: any;
 }
 
-// Play BillingResponseCode values, reported as `responseCode` by both libraries.
+export interface IapSubscription {
+  remove: () => void;
+}
+
+// Play BillingResponseCode values, reported as `responseCode` on Android.
 const RESPONSE_CODE_USER_CANCELED = 1;
 const RESPONSE_CODE_BILLING_UNAVAILABLE = 3;
 
-// openiap renamed the product fields (id/displayPrice) and returns price as a
-// number; map them back to what the screens expect.
+// OpenIAP names products id/displayPrice and returns price as a number.
 const _normalizeProduct = (product: any): IapProduct => ({
   ...product,
   productId: product.id,
@@ -56,21 +53,8 @@ const _normalizeProduct = (product: any): IapProduct => ({
   localizedPrice: product.displayPrice,
 });
 
-// openiap drops transactionReceipt. On Android the receipt sent to the backend is
-// the purchase token either way; dataAndroid holds the original purchase JSON and
-// stands in for the receipt so purchase handling can keep gating on it.
-const _normalizePurchase = (purchase: any): IapPurchase => ({
-  ...purchase,
-  transactionReceipt: purchase.dataAndroid || purchase.purchaseToken,
-});
-
-// Error codes differ per library: react-native-iap raises E_-prefixed codes,
-// openiap raises kebab-case ones. Both also carry the numeric Play response code
-// on Android.
 export const isUserCancelledError = (error: any): boolean =>
-  error?.code === 'user-cancelled' ||
-  error?.code === 'E_USER_CANCELLED' ||
-  error?.responseCode === RESPONSE_CODE_USER_CANCELED;
+  error?.code === 'user-cancelled' || error?.responseCode === RESPONSE_CODE_USER_CANCELED;
 
 export const isBillingUnavailableError = (error: any): boolean =>
   error?.code === 'billing-unavailable' ||
@@ -81,26 +65,19 @@ export const initConnection = (): Promise<any> => iap.initConnection();
 export const endConnection = (): Promise<any> => iap.endConnection();
 
 export const getProducts = async (skus: string[]): Promise<IapProduct[]> => {
-  if (IS_ANDROID) {
-    const products = await iap.fetchProducts({ skus, type: 'in-app' });
-    return (products || []).map(_normalizeProduct);
-  }
-
-  return (await iap.getProducts({ skus })) || [];
+  const products = await iap.fetchProducts({ skus, type: 'in-app' });
+  return ((products as any[]) || []).map(_normalizeProduct);
 };
 
-export const getAvailablePurchases = async (): Promise<IapPurchase[]> => {
-  const purchases = (await iap.getAvailablePurchases()) || [];
-  return IS_ANDROID ? purchases.map(_normalizePurchase) : purchases;
-};
+export const getAvailablePurchases = async (): Promise<IapPurchase[]> =>
+  (((await iap.getAvailablePurchases()) as any[]) || []) as IapPurchase[];
 
-export const requestPurchase = (sku: string): Promise<any> => {
-  if (IS_ANDROID) {
-    return iap.requestPurchase({ request: { google: { skus: [sku] } }, type: 'in-app' });
-  }
-
-  return iap.requestPurchase({ sku });
-};
+// The outcome arrives through purchaseUpdatedListener, not this promise.
+export const requestPurchase = (sku: string): Promise<any> =>
+  iap.requestPurchase({
+    request: { apple: { sku }, google: { skus: [sku] } },
+    type: 'in-app',
+  }) as Promise<any>;
 
 export const finishTransaction = ({
   purchase,
@@ -108,12 +85,11 @@ export const finishTransaction = ({
 }: {
   purchase: IapPurchase;
   isConsumable: boolean;
-}): Promise<any> => iap.finishTransaction({ purchase, isConsumable });
+}): Promise<any> => iap.finishTransaction({ purchase: purchase as any, isConsumable });
 
-export const purchaseUpdatedListener = (listener: (purchase: IapPurchase) => void) =>
-  iap.purchaseUpdatedListener(
-    IS_ANDROID ? (purchase: any) => listener(_normalizePurchase(purchase)) : listener,
-  );
+export const purchaseUpdatedListener = (
+  listener: (purchase: IapPurchase) => void,
+): IapSubscription => iap.purchaseUpdatedListener(listener as any);
 
-export const purchaseErrorListener = (listener: (error: any) => void) =>
-  iap.purchaseErrorListener(listener);
+export const purchaseErrorListener = (listener: (error: any) => void): IapSubscription =>
+  iap.purchaseErrorListener(listener as any);

--- a/yarn.lock
+++ b/yarn.lock
@@ -11206,11 +11206,6 @@ react-native-hyperlink@^0.1.0:
     linkify-it "^5.0.0"
     mdurl "^2.0.0"
 
-react-native-iap@^12.16.2:
-  version "12.16.2"
-  resolved "https://registry.npmjs.org/react-native-iap/-/react-native-iap-12.16.2.tgz"
-  integrity sha512-pIyO3eSZkYJYLdgDF90Or2wUsbiiYwa5xgUpaHBqZuVEk5Nz0ZDN4acwoXFfPa/a52MmQOYEeHbYLAQQW0o+rg==
-
 react-native-image-crop-picker@^0.51.1:
   version "0.51.1"
   resolved "https://registry.npmjs.org/react-native-image-crop-picker/-/react-native-image-crop-picker-0.51.1.tgz"


### PR DESCRIPTION
Finishes the billing migration: one library on both platforms. Android already moved in #3360; this moves iOS onto StoreKit 2 through expo-iap and removes react-native-iap along with the per-platform autolinking splits that kept the two libraries apart.

**Do not merge before ePoints#39 is deployed.** iOS purchases now post `purchaseToken` — the StoreKit 2 signed transaction (`Transaction.jwsRepresentation`) — instead of the legacy base64 receipt. ePoints#39 teaches `/private-api/purchase-order` to verify signed transactions with Apple's App Store Server Library. Until it is live, an iOS purchase from this build cannot be verified.

**Older app versions keep working.** ePoints#39 routes on the receipt shape and keeps the legacy `AppStoreValidator` path, so every build already in the wild continues to verify as before. Nothing about Play verification changes: Android still sends the Play purchase token.

Changes:
- `src/providers/iap` imports expo-iap directly, no platform branch. Product normalization (`id`->`productId`, `displayPrice`->`localizedPrice`) now applies on both platforms, so the screens are unchanged.
- `_consumePurchase` gates on `purchaseToken` and sends it as the receipt for both stores; the react-native-iap-only `transactionReceipt` field is gone.
- `react-native.config.js` and the `expo.autolinking.apple.exclude` entry in package.json are back to their defaults; react-native-iap is removed from package.json and yarn.lock.
- Subscription handles are typed off the adapter instead of RN's `EmitterSubscription`.

`ios/Podfile.lock` is left as is: it still lists RNIap and has no ExpoIap entry. CI runs a plain `pod install` before building, so the lock is regenerated on the runner; someone on macOS should commit a refreshed lock.

Verified: lint clean, 660 unit tests pass, expo-iap autolinks on both apple and android, react-native-iap no longer appears in `react-native config` or node_modules. Not verified: a real purchase on either store.

Testing before this ships: an App Store sandbox purchase must verify server-side against ePoints#39 (points, 999accounts, interrupted-purchase recovery, cancel), and Android should be re-checked since the adapter changed under it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Updated in-app purchase flow for more consistent product retrieval and purchase handling across platforms.
  * Streamlined purchase listener behavior and consolidated purchase data handling.
  * Verification now proceeds using the purchase token when available.
* **Bug Fixes**
  * Improved recovery for pending/stale purchases.
  * Refined cancellation detection to better match supported cancellation responses.
* **Chores**
  * Updated iOS/Android in-app purchase integration configuration and removed unused iOS/Android autolinking/package entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->