### PR TITLE
fix(android): align Kotlin with expo-iap and stop cross-PR build cancels

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -9,7 +9,9 @@ on:
       - development
 
 concurrency:
-  group: android-build
+  # Keyed by ref so a PR build cannot cancel the development build, which is the
+  # one that publishes the alpha release.
+  group: android-build-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,7 +38,10 @@ buildscript {
         classpath("com.android.tools.build:gradle:8.9.2")
         classpath 'com.google.gms:google-services:4.4.3'
         classpath("com.facebook.react:react-native-gradle-plugin")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin")
+        // Unversioned, this resolves to 2.0.21 from React Native's version
+        // catalog, which is the compiler that fails on openiap's 2.2 metadata.
+        // The kotlinVersion ext above only changes what libraries declare.
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:2.2.0")
     }
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -19,7 +19,10 @@ buildscript {
         compileSdkVersion = 36
         targetSdkVersion = 36
         ndkVersion = "28.1.13356709"
-        kotlinVersion = "2.0.21"
+        // expo-iap pulls openiap-google, built with Kotlin 2.2, and the Kotlin
+        // compiler refuses metadata newer than its own -- 2.0.21 fails
+        // :expo:compileReleaseKotlin. Newer compilers read older metadata fine.
+        kotlinVersion = "2.2.0"
         googlePlayServicesVisionVersion = "17.0.2"
         googlePlayServicesVersion = "16.+"
         firebaseVersion = "17.3.4"


### PR DESCRIPTION
**development does not build for Android right now.** #3359 and #3360 were merged on a green Lint & Test, but their Android builds were never green — every one of them was cancelled by the repo-global concurrency group before finishing. The first run that actually completed (on #3361) failed:

```
e: ...jetified-kotlin-stdlib-2.2.0.jar!/META-INF/kotlin-stdlib.kotlin_module
   Module was compiled with an incompatible version of Kotlin.
   The binary version of its metadata is 2.2.0, expected version is 2.0.0.
> Task :expo:compileReleaseKotlin FAILED
   > Internal compiler error.
```

`openiap-google:2.4.1`, which expo-iap depends on, is built against `kotlin-stdlib:2.2.0`, and the Kotlin compiler refuses to read metadata newer than itself. So this is not specific to #3361 — it applies to the Billing 9 work already on development.

Two changes:
- `kotlinVersion` 2.0.21 -> 2.2.0. Bumping up is the safe direction: a newer compiler reads older metadata, the reverse is what fails. AGP 8.9.2 and Gradle 8.13 are unaffected.
- The Android Build `concurrency.group` was the constant `android-build`, so any branch's build cancelled any other's, including the development build that publishes the alpha release — which is why no alpha AAB exists for the merged work. Now keyed by `github.ref`.

Verification is this PR's own Android build; it is the point of the change. Modules that assert a Kotlin version (react-native-video logs `Kotlin version is correct`) are the thing to watch in the log.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Build & Reliability**
  * Improved Android build workflow isolation so pull request and development branch builds no longer cancel each other unexpectedly.
  * Updated the Android build’s Kotlin toolchain and Gradle plugin version for improved compatibility with in-app purchase components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->