### PR TITLE
fix(ci): key the iOS build concurrency group by ref

### DIFF
--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -8,7 +8,9 @@ on:
       - development
 
 concurrency:
-  group: ios-build
+  # Keyed by ref so a PR build cannot cancel the development build, which is the
+  # one that uploads to TestFlight.
+  group: ios-build-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Mirror of the Android half of #3362, which only fixed `build-android.yml`.

`build-ios.yml` still uses the constant group `ios-build` with `cancel-in-progress`, so any branch's iOS build cancels any other's. That includes the `development` build, whose `ios-deploy` job uploads to TestFlight on push — so a PR opened at the wrong moment silently costs a TestFlight build. It just happened: the development iOS build for the Billing 9 merge (run 29948419542) was cancelled by a PR build.

One line, same shape as the Android fix.