### PR TITLE
feat(wallet): add dedicated HP withdraw routes action

### DIFF
--- a/src/config/locales/en-US.json
+++ b/src/config/locales/en-US.json
@@ -1237,6 +1237,7 @@
     "tokens_updatePrecision": "Tokens Update Precision",
     "tokens_transferOwnership": "Token Ownership Transferred",
     "withdraw_vesting": "Unstake",
+    "set_withdraw_vesting_route": "Withdraw Accounts",
     "delegate_engine": "Delegate",
     "market_close": "Order Closed",
     "nftmarket_transferFee": "Buy Order Fee",

--- a/src/constants/transferTypes.ts
+++ b/src/constants/transferTypes.ts
@@ -15,6 +15,7 @@ const TransferTypes = {
   DELEGATE_VESTING_SHARES: 'delegate_vesting_shares',
   RECURRENT_TRANSFER: 'recurrent_transfer',
   WITHDRAW_VESTING: 'withdraw_vesting',
+  SET_WITHDRAW_VESTING_ROUTE: 'set_withdraw_vesting_route',
   UNSTAKE: 'unstake',
   STAKE: 'stake',
   DELEGATE: 'delegate',

--- a/src/screens/transfer/index.tsx
+++ b/src/screens/transfer/index.tsx
@@ -61,6 +61,7 @@ const Transfer = ({ navigation, route }) => {
               />
             );
           case TransferTypes.WITHDRAW_VESTING:
+          case TransferTypes.SET_WITHDRAW_VESTING_ROUTE:
             return (
               <PowerDownView
                 accounts={accounts}

--- a/src/screens/transfer/screen/powerDownScreen.tsx
+++ b/src/screens/transfer/screen/powerDownScreen.tsx
@@ -22,6 +22,7 @@ import parseToken from '../../../utils/parseToken';
 import parseDate from '../../../utils/parseDate';
 import { hpToVests, vestsToHp } from '../../../utils/conversions';
 import { isEmptyDate, daysTillDate } from '../../../utils/time';
+import TransferTypes from '../../../constants/transferTypes';
 
 import styles from './transferStyles';
 import { OptionsModal } from '../../../components/atoms';
@@ -38,6 +39,11 @@ const PowerDownScreen = ({
 }) => {
   const intl = useIntl();
   const queryClient = useQueryClient();
+
+  // Reached from the dedicated HP "withdraw routes" action rather than the power down
+  // action. Only the destination accounts section applies, and unlike the power down
+  // flow it stays available while a power down is already running.
+  const isRoutesOnly = transferType === TransferTypes.SET_WITHDRAW_VESTING_ROUTE;
 
   const [amount, setAmount] = useState(0);
   const [hp, setHp] = useState(0.0);
@@ -406,10 +412,10 @@ const PowerDownScreen = ({
           style={styles.scroll}
           contentContainerStyle={styles.scrollContentContainer}
         >
-          {!poweringDown && renderBeneficiarySelectionContent()}
-          {!poweringDown && renderMiddleContent()}
-          {poweringDown && renderPowerDownInfo()}
-          {renderBottomContent()}
+          {(isRoutesOnly || !poweringDown) && renderBeneficiarySelectionContent()}
+          {!isRoutesOnly && !poweringDown && renderMiddleContent()}
+          {!isRoutesOnly && poweringDown && renderPowerDownInfo()}
+          {!isRoutesOnly && renderBottomContent()}
         </ScrollView>
       </KeyboardAvoidingView>
       <OptionsModal


### PR DESCRIPTION
Withdraw routes are already implemented in `powerDownScreen.tsx` (fetch via `getWithdrawRoutesQueryOptions`, add/remove via `setWithdrawVestingRoute`), but the section is only reachable by opening power down, and it is skipped entirely when `poweringDown` is true.

This handles a dedicated `set_withdraw_vesting_route` action so the portfolio can link straight to it. The action id matches the chain operation name and the id vision-api will emit in the HP action list.

- `transferTypes.ts`: add `SET_WITHDRAW_VESTING_ROUTE`
- `transfer/index.tsx`: route it to the existing `PowerDownView`
- `powerDownScreen.tsx`: routes-only mode, renders just the destination accounts section and stays available while a power down is running
- `en-US.json`: `wallet.set_withdraw_vesting_route` label, used for both the action button and the screen header

No new screen or mutation, the existing add/remove path is unchanged.

Needs to ship before vision-api adds the action to `HP_ACTIONS`, otherwise the unrecognised id renders a button labelled with the raw key that lands on the generic transfer screen.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting withdrawal accounts for vesting routes.
  * Added a dedicated “Withdraw Accounts” transfer option.
  * The withdrawal account flow now focuses solely on choosing beneficiary or destination accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->