### PR TITLE
chore(deps): bump @ecency/sdk to 2.3.66

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@babel/preset-typescript": "^7.26.0",
     "@babel/runtime": "^7.26.7",
     "@ecency/render-helper": "^2.5.22",
-    "@ecency/sdk": "^2.3.61",
+    "@ecency/sdk": "^2.3.66",
     "@esteemapp/react-native-autocomplete-input": "^4.2.1",
     "@esteemapp/react-native-multi-slider": "^1.1.0",
     "@native-html/iframe-plugin": "^2.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1210,10 +1210,10 @@
     url "^0.11.0"
     xss "^1.0.9"
 
-"@ecency/sdk@^2.3.61":
-  version "2.3.61"
-  resolved "https://registry.yarnpkg.com/@ecency/sdk/-/sdk-2.3.61.tgz#ccac611e512576aad2c1d617c14ccd805be179e4"
-  integrity sha512-NIonDqIgDqsoZ5TcG5EDlG1GqBdqEHPsRHUcibxTCHN+xpmo+JnOHFFv8b56oIV+Sl09oZ0xnpmchvYaNUttcQ==
+"@ecency/sdk@^2.3.66":
+  version "2.3.66"
+  resolved "https://registry.yarnpkg.com/@ecency/sdk/-/sdk-2.3.66.tgz#237a574476aa2c9947fd4f85981ad405c2d9f3ed"
+  integrity sha512-y8B01WVaS9WwwYHA7c9L4FcIyD7CQO7L1CX9fEWNf6yZ0bSCDnmx04r3GsQGkdb1u6od/xFyS/6zrjX7gzXd9Q==
   dependencies:
     "@noble/ciphers" "^2.1.1"
     "@noble/curves" "^2.0.1"


### PR DESCRIPTION
Bumps `@ecency/sdk` from 2.3.61 to 2.3.66. Two of the five releases in that span change behaviour this app depends on.

## Why it matters here

**2.3.66 — the mute list is no longer truncated at 100.** `getMutedUsersQueryOptions` used to make a single `get_following` request capped at 100 rows. `providers/hive/auth.ts` stores that result as `account.mutes`, so any user who has muted more than 100 accounts has been carrying a silently short list, with muted accounts treated as though they were never muted. Real accounts already exceed the cap (`acidyo` has 208, `azircon` 116). The query now pages until the list is exhausted.

That release also **drops the query's `limit` parameter**. All eight call sites in this repo already pass only a username, so nothing needs changing:

```
src/screens/application/container/applicationContainer.tsx:672,1244
src/utils/migrationHelpers.ts:192
src/providers/hive/auth.ts:148,216,287,366
src/components/accountsBottomSheet/container/accountsBottomSheetContainer.tsx:185
```

**2.3.64 — anonymous bridge reads use the `ecency` observer.** Reads without a logged-in user previously sent an empty observer, or the post author for discussions. They now fall back to the shared moderation account, so logged-out content gets the same mute marking as the web client.

The remaining three are incidental: 2.3.62 validates bridge responses as arrays before resolving posts, while 2.3.63 and 2.3.65 bound SSR query state and are inert in React Native.

## render-helper

No bump needed. `@ecency/render-helper` is pinned at `^2.5.22`, the lockfile already resolves 2.5.22, and 2.5.22 is both the latest published version and the version in the vision-next monorepo. Nothing is pending release.

## Lockfile

`@ecency/sdk`'s dependency and peerDependency sets are byte-identical between 2.3.61 and 2.3.66, so the lock change is one entry with no transitive churn. The recorded hashes were verified against the published tarball rather than assumed:

```
sha1      237a574476aa2c9947fd4f85981ad405c2d9f3ed   matches
sha512    y8B01WVaS9WwwYHA7c9L4FcIyD7CQO7L1CX9fEWNf6yZ0bSCDnmx04r3GsQGkdb1u6od/xFyS/6zrjX7gzXd9Q==   matches
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Ecency SDK dependency to the latest supported version, providing access to its newest fixes and improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->