### PR TITLE
Fix video thumbnail generation and post editor passthrough

### DIFF
--- a/src/components/markdownEditor/children/editorToolbar.tsx
+++ b/src/components/markdownEditor/children/editorToolbar.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import {
+  Alert,
   AppState,
   Keyboard,
   View,
@@ -43,6 +44,7 @@ import ROUTES from '../../../constants/routeNames';
 import { DEFAULT_USER_DRAFT_ID } from '../../../redux/constants/constants';
 import { TextFormatModal } from './textFormatModal';
 import { selectCurrentAccount } from '../../../redux/selectors';
+import { hasThreeSpeakEmbed } from '../../../providers/speak/beneficiary';
 
 // Per-account session dismissals for the quest chip; once closed it stays
 // hidden for that account until the app restarts.
@@ -60,6 +62,8 @@ type Props = {
   setIsUploading: (isUploading: boolean) => void;
   handleMediaInsert: (data: MediaInsertData[]) => void;
   handleVideoThumb?: (embedUrl: string, thumbUrl: string) => void;
+  /** Reads the live body. `postBody` is only as fresh as the last render. */
+  getPostBody?: () => string;
   handleOnAddLinkPress: () => void;
   handleOnClearPress: () => void;
   handleOnMarkupButtonPress: (item) => void;
@@ -81,6 +85,7 @@ export const EditorToolbar = ({
   setIsUploading,
   handleMediaInsert,
   handleVideoThumb,
+  getPostBody,
   handleAiToolUsed,
   handleOnAddLinkPress,
   handleOnClearPress,
@@ -247,6 +252,15 @@ export const EditorToolbar = ({
   };
 
   const _showVideoUploads = () => {
+    // One 3Speak video per post, matching web. The threespeakfund beneficiary is a single
+    // flat share on the post, so a second video would publish without its own payout route.
+    if (hasThreeSpeakEmbed(getPostBody?.() ?? postBody ?? '')) {
+      Alert.alert(
+        intl.formatMessage({ id: 'alert.notice' }),
+        intl.formatMessage({ id: 'video-upload.error-one-per-post' }),
+      );
+      return;
+    }
     _showUploadsExtension(Modes.MODE_VIDEO);
   };
 

--- a/src/components/markdownEditor/children/editorToolbar.tsx
+++ b/src/components/markdownEditor/children/editorToolbar.tsx
@@ -59,6 +59,7 @@ type Props = {
   suggestedPrompt?: string;
   setIsUploading: (isUploading: boolean) => void;
   handleMediaInsert: (data: MediaInsertData[]) => void;
+  handleVideoThumbUrl?: (url: string) => void;
   handleOnAddLinkPress: () => void;
   handleOnClearPress: () => void;
   handleOnMarkupButtonPress: (item) => void;
@@ -79,6 +80,7 @@ export const EditorToolbar = ({
   suggestedPrompt,
   setIsUploading,
   handleMediaInsert,
+  handleVideoThumbUrl,
   handleAiToolUsed,
   handleOnAddLinkPress,
   handleOnClearPress,
@@ -355,6 +357,7 @@ export const EditorToolbar = ({
               username={currentAccount.name}
               hideToolbarExtension={_hideExtension}
               handleMediaInsert={handleMediaInsert}
+              onVideoThumbUrl={handleVideoThumbUrl}
               setIsUploading={setIsUploading}
             />
             <TextFormatModal

--- a/src/components/markdownEditor/children/editorToolbar.tsx
+++ b/src/components/markdownEditor/children/editorToolbar.tsx
@@ -59,7 +59,7 @@ type Props = {
   suggestedPrompt?: string;
   setIsUploading: (isUploading: boolean) => void;
   handleMediaInsert: (data: MediaInsertData[]) => void;
-  handleVideoThumbUrl?: (url: string) => void;
+  handleVideoThumb?: (embedUrl: string, thumbUrl: string) => void;
   handleOnAddLinkPress: () => void;
   handleOnClearPress: () => void;
   handleOnMarkupButtonPress: (item) => void;
@@ -80,7 +80,7 @@ export const EditorToolbar = ({
   suggestedPrompt,
   setIsUploading,
   handleMediaInsert,
-  handleVideoThumbUrl,
+  handleVideoThumb,
   handleAiToolUsed,
   handleOnAddLinkPress,
   handleOnClearPress,
@@ -357,7 +357,7 @@ export const EditorToolbar = ({
               username={currentAccount.name}
               hideToolbarExtension={_hideExtension}
               handleMediaInsert={handleMediaInsert}
-              onVideoThumbUrl={handleVideoThumbUrl}
+              onVideoThumb={handleVideoThumb}
               setIsUploading={setIsUploading}
             />
             <TextFormatModal

--- a/src/components/markdownEditor/view/markdownEditorView.tsx
+++ b/src/components/markdownEditor/view/markdownEditorView.tsx
@@ -573,6 +573,9 @@ const MarkdownEditorView = ({
           setIsUploading={setIsUploading}
           handleMediaInsert={_handleMediaInsert}
           handleVideoThumb={handleVideoThumb}
+          // The editor is uncontrolled, so `postBody` above is only as fresh as the last
+          // render. Reads that must see the current text go through this.
+          getPostBody={() => bodyTextRef.current}
           handleAiToolUsed={handleAiToolUsed}
           handleOnAddLinkPress={_handleOnAddLinkPress}
           handleShowSnippets={() => setIsSnippetsOpen(true)}

--- a/src/components/markdownEditor/view/markdownEditorView.tsx
+++ b/src/components/markdownEditor/view/markdownEditorView.tsx
@@ -66,7 +66,7 @@ const MarkdownEditorView = ({
   sharedSnippetText,
   onLoadDraftPress,
   setIsUploading,
-  handleVideoThumbUrl,
+  handleVideoThumb,
 }) => {
   const isDarkTheme = useAppSelector(selectIsDarkTheme);
   const pollDraft = useAppSelector(
@@ -572,7 +572,7 @@ const MarkdownEditorView = ({
           suggestedPrompt={fields?.title?.trim() || undefined}
           setIsUploading={setIsUploading}
           handleMediaInsert={_handleMediaInsert}
-          handleVideoThumbUrl={handleVideoThumbUrl}
+          handleVideoThumb={handleVideoThumb}
           handleAiToolUsed={handleAiToolUsed}
           handleOnAddLinkPress={_handleOnAddLinkPress}
           handleShowSnippets={() => setIsSnippetsOpen(true)}

--- a/src/components/markdownEditor/view/markdownEditorView.tsx
+++ b/src/components/markdownEditor/view/markdownEditorView.tsx
@@ -66,6 +66,7 @@ const MarkdownEditorView = ({
   sharedSnippetText,
   onLoadDraftPress,
   setIsUploading,
+  handleVideoThumbUrl,
 }) => {
   const isDarkTheme = useAppSelector(selectIsDarkTheme);
   const pollDraft = useAppSelector(
@@ -571,6 +572,7 @@ const MarkdownEditorView = ({
           suggestedPrompt={fields?.title?.trim() || undefined}
           setIsUploading={setIsUploading}
           handleMediaInsert={_handleMediaInsert}
+          handleVideoThumbUrl={handleVideoThumbUrl}
           handleAiToolUsed={handleAiToolUsed}
           handleOnAddLinkPress={_handleOnAddLinkPress}
           handleShowSnippets={() => setIsSnippetsOpen(true)}

--- a/src/components/uploadsGalleryModal/children/speakUploaderModal.tsx
+++ b/src/components/uploadsGalleryModal/children/speakUploaderModal.tsx
@@ -42,6 +42,42 @@ interface Props {
   isShort?: boolean;
 }
 
+const THUMBS_COUNT = 5;
+// react-native-image-crop-picker omits duration on some Android paths, fall back so
+// timestamps never end up NaN
+const FALLBACK_DURATION_MS = 10000;
+
+/**
+ * Samples THUMBS_COUNT evenly spread frames from the video. Frames are taken at the middle
+ * of each slice rather than at its start, so the very first frame (often black) is skipped.
+ * Individual failures are tolerated, a partial strip is better than none.
+ */
+const _generateThumbs = async (_video: VideoType): Promise<Thumbnail[]> => {
+  const _duration =
+    typeof _video.duration === 'number' && Number.isFinite(_video.duration) && _video.duration > 0
+      ? _video.duration
+      : FALLBACK_DURATION_MS;
+
+  const _url = _video.sourceURL || _video.path;
+  const _step = _duration / THUMBS_COUNT;
+  const _thumbs: Thumbnail[] = [];
+
+  for (let i = 0; i < THUMBS_COUNT; i++) {
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      const _thumb = await createThumbnail({
+        url: _url,
+        timeStamp: Math.round((i + 0.5) * _step),
+      });
+      _thumbs.push(_thumb);
+    } catch (err) {
+      console.warn(`Thumbnail generation failed for frame ${i}:`, err);
+    }
+  }
+
+  return _thumbs;
+};
+
 export const SpeakUploaderModal = forwardRef(
   ({ setIsUploading, isUploading, onVideoUploaded, isShort = false }: Props, ref) => {
     const intl = useIntl();
@@ -78,23 +114,17 @@ export const SpeakUploaderModal = forwardRef(
           setVisible(true);
           setSelectedVideo(_video);
           setSelectedThumb(null);
+          setAvailableThumbs([]);
 
-          // Generate 5 thumbnails from video
-          const thumbs = [];
-          const _diff = _video.duration / 5;
-          for (let i = 0; i < 5; i++) {
-            // eslint-disable-next-line no-await-in-loop
-            const _thumb = await createThumbnail({
-              url: _video.sourceURL || _video.path,
-              timeStamp: i * _diff,
-            });
-            thumbs.push(_thumb);
-          }
-
-          setAvailableThumbs(thumbs);
+          setAvailableThumbs(await _generateThumbs(_video));
         }
       },
     }));
+
+    // Middle frame is the safest implicit default, opening and closing frames are
+    // commonly black or a fade
+    const _effectiveThumb = () =>
+      selectedThumb || availableThumbs[Math.floor(availableThumbs.length / 2)] || null;
 
     const _startUpload = async () => {
       if (!selectedVido || isUploading) {
@@ -111,7 +141,7 @@ export const SpeakUploaderModal = forwardRef(
         });
 
         // Upload thumbnail to Ecency image server, then set on 3Speak (fire-and-forget)
-        const thumbToUse = selectedThumb || availableThumbs[0];
+        const thumbToUse = _effectiveThumb();
         let uploadedThumbUrl: string | undefined;
 
         if (thumbToUse?.path && result.permlink) {
@@ -202,7 +232,7 @@ export const SpeakUploaderModal = forwardRef(
       const _renderHeader = () => (
         <View style={styles.selectedThumbContainer}>
           <>
-            {_renderThumb(selectedThumb?.path || '', _handleOpenImagePicker)}
+            {_renderThumb(_effectiveThumb()?.path || '', _handleOpenImagePicker)}
             <Icon
               iconType="MaterialCommunityIcons"
               style={{ position: 'absolute', top: 16, left: 8 }}

--- a/src/components/uploadsGalleryModal/children/speakUploaderModal.tsx
+++ b/src/components/uploadsGalleryModal/children/speakUploaderModal.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useImperativeHandle, useState } from 'react';
+import React, { forwardRef, useImperativeHandle, useRef, useState } from 'react';
 import {
   View,
   Text,
@@ -94,6 +94,8 @@ export const SpeakUploaderModal = forwardRef(
     const [availableThumbs, setAvailableThumbs] = useState<Thumbnail[]>([]);
 
     const [selectedVido, setSelectedVideo] = useState<VideoType | null>(null);
+    const [isGeneratingThumbs, setIsGeneratingThumbs] = useState(false);
+    const generationIdRef = useRef(0);
 
     useImperativeHandle(ref, () => ({
       showUploader: async (_video: VideoType) => {
@@ -111,12 +113,26 @@ export const SpeakUploaderModal = forwardRef(
             return;
           }
 
+          // Invalidate any generation still running for a previously selected video, so a
+          // slow batch cannot land on top of the frames for this one
+          const _generationId = ++generationIdRef.current;
+
           setVisible(true);
           setSelectedVideo(_video);
           setSelectedThumb(null);
           setAvailableThumbs([]);
+          setIsGeneratingThumbs(true);
 
-          setAvailableThumbs(await _generateThumbs(_video));
+          try {
+            const _thumbs = await _generateThumbs(_video);
+            if (_generationId === generationIdRef.current) {
+              setAvailableThumbs(_thumbs);
+            }
+          } finally {
+            if (_generationId === generationIdRef.current) {
+              setIsGeneratingThumbs(false);
+            }
+          }
         }
       },
     }));
@@ -290,7 +306,7 @@ export const SpeakUploaderModal = forwardRef(
             text={intl.formatMessage({
               id: `uploads_modal.${isUploading ? 'uploading' : 'start_upload'}`,
             })}
-            isDisable={isUploading}
+            isDisable={isUploading || isGeneratingThumbs}
           />
         </View>
       );

--- a/src/components/uploadsGalleryModal/container/uploadsGalleryModal.tsx
+++ b/src/components/uploadsGalleryModal/container/uploadsGalleryModal.tsx
@@ -58,8 +58,11 @@ interface UploadsGalleryModalProps {
   hideToolbarExtension: () => void;
   handleMediaInsert: (data: Array<MediaInsertData>) => void;
   setIsUploading: (status: boolean) => void;
-  /** Receives the uploaded thumbnail url of a 3Speak video, for post thumbnail selection. */
-  onVideoThumbUrl?: (url: string) => void;
+  /**
+   * Receives the uploaded thumbnail of a 3Speak video along with the embed it belongs to,
+   * so the thumbnail can be dropped again if the embed is removed from the body.
+   */
+  onVideoThumb?: (embedUrl: string, thumbUrl: string) => void;
 }
 
 export const UploadsGalleryModal = forwardRef(
@@ -74,7 +77,7 @@ export const UploadsGalleryModal = forwardRef(
       hideToolbarExtension,
       handleMediaInsert,
       setIsUploading,
-      onVideoThumbUrl,
+      onVideoThumb,
     }: UploadsGalleryModalProps,
     ref,
   ) => {
@@ -627,7 +630,7 @@ export const UploadsGalleryModal = forwardRef(
               },
             ]);
             if (thumbnailUrl) {
-              onVideoThumbUrl?.(thumbnailUrl);
+              onVideoThumb?.(embedUrl, thumbnailUrl);
             }
           }}
         />

--- a/src/components/uploadsGalleryModal/container/uploadsGalleryModal.tsx
+++ b/src/components/uploadsGalleryModal/container/uploadsGalleryModal.tsx
@@ -58,6 +58,8 @@ interface UploadsGalleryModalProps {
   hideToolbarExtension: () => void;
   handleMediaInsert: (data: Array<MediaInsertData>) => void;
   setIsUploading: (status: boolean) => void;
+  /** Receives the uploaded thumbnail url of a 3Speak video, for post thumbnail selection. */
+  onVideoThumbUrl?: (url: string) => void;
 }
 
 export const UploadsGalleryModal = forwardRef(
@@ -72,6 +74,7 @@ export const UploadsGalleryModal = forwardRef(
       hideToolbarExtension,
       handleMediaInsert,
       setIsUploading,
+      onVideoThumbUrl,
     }: UploadsGalleryModalProps,
     ref,
   ) => {
@@ -614,7 +617,7 @@ export const UploadsGalleryModal = forwardRef(
           ref={speakUploaderRef}
           isUploading={isAddingToUploads}
           setIsUploading={_setIsSpeakUploading}
-          onVideoUploaded={(embedUrl) => {
+          onVideoUploaded={(embedUrl, thumbnailUrl) => {
             handleMediaInsert([
               {
                 url: embedUrl,
@@ -623,6 +626,9 @@ export const UploadsGalleryModal = forwardRef(
                 mode: Modes.MODE_VIDEO,
               },
             ]);
+            if (thumbnailUrl) {
+              onVideoThumbUrl?.(thumbnailUrl);
+            }
           }}
         />
       </>

--- a/src/config/locales/en-US.json
+++ b/src/config/locales/en-US.json
@@ -1730,6 +1730,7 @@
     "error-auth": "Authentication failed. Please log in again.",
     "error-generic": "Video upload failed. Please try again.",
     "error-too-long-short": "Short videos must be 60 seconds or less.",
+    "error-one-per-post": "A post can contain only one video. Remove the current video before adding another.",
     "select_source": "Add Video",
     "record": "Record Video",
     "choose_library": "Choose from Library"

--- a/src/screens/editor/children/postOptionsModal.tsx
+++ b/src/screens/editor/children/postOptionsModal.tsx
@@ -47,6 +47,7 @@ interface PostOptionsModalProps {
   body: string;
   draftId: string;
   thumbUrl: string;
+  videoThumbUrls?: string[];
   isEdit: boolean;
   isCommunityPost: boolean;
   rewardType: string;
@@ -68,6 +69,7 @@ const PostOptionsModal = forwardRef(
       body,
       draftId,
       thumbUrl,
+      videoThumbUrls,
       isEdit,
       isCommunityPost,
       rewardType,
@@ -275,7 +277,7 @@ const PostOptionsModal = forwardRef(
             <ThumbSelectionContent
               body={body}
               thumbUrl={thumbUrl}
-              videoThumbUrls={[]}
+              videoThumbUrls={videoThumbUrls || []}
               isUploading={isUploading}
               onThumbSelection={_handleThumbIndexSelection}
             />

--- a/src/screens/editor/children/thumbSelectionContent.tsx
+++ b/src/screens/editor/children/thumbSelectionContent.tsx
@@ -32,7 +32,7 @@ const ThumbSelectionContent = ({
   const [thumbIndex, setThumbIndex] = useState(0);
 
   useEffect(() => {
-    const urls = [...extractImageUrls({ body }), ...videoThumbUrls];
+    const urls = [...new Set([...extractImageUrls({ body }), ...videoThumbUrls])];
 
     if (urls.length < 2) {
       setNeedMore(true);
@@ -51,7 +51,8 @@ const ThumbSelectionContent = ({
     } else {
       setThumbIndex(_urlIndex);
     }
-  }, [body]);
+    // join() keeps the dependency stable by value, the parent rebuilds the array each render
+  }, [body, videoThumbUrls.join(',')]);
 
   // VIEW_RENDERERS
   const _renderImageItem = ({ item, index }: { item: string; index: number }) => {

--- a/src/screens/editor/children/thumbSelectionContent.tsx
+++ b/src/screens/editor/children/thumbSelectionContent.tsx
@@ -52,7 +52,7 @@ const ThumbSelectionContent = ({
       setThumbIndex(_urlIndex);
     }
     // join() keeps the dependency stable by value, the parent rebuilds the array each render
-  }, [body, videoThumbUrls.join(',')]);
+  }, [body, videoThumbUrls.join(','), thumbUrl]);
 
   // VIEW_RENDERERS
   const _renderImageItem = ({ item, index }: { item: string; index: number }) => {

--- a/src/screens/editor/container/editorContainer.tsx
+++ b/src/screens/editor/container/editorContainer.tsx
@@ -36,6 +36,8 @@ import {
   makeJsonMetadata,
   makeOptions,
   extractMetadata,
+  filterActiveVideoThumbs,
+  VideoThumb,
   makeJsonMetadataForUpdate,
   cleanAiTools,
   createPatch,
@@ -138,7 +140,7 @@ class EditorContainer extends Component<EditorContainerProps, any> {
       sharedSnippetText: null,
       onLoadDraftPress: false,
       thumbUrl: '',
-      videoThumbUrls: [],
+      videoThumbs: [],
       shouldReblog: false,
       postDescription: '',
     };
@@ -641,7 +643,8 @@ class EditorContainer extends Component<EditorContainerProps, any> {
       return;
     }
 
-    const { isDraftSaved, draftId, thumbUrl, isReply, rewardType, postDescription } = this.state;
+    const { isDraftSaved, draftId, thumbUrl, videoThumbs, isReply, rewardType, postDescription } =
+      this.state;
     const { currentAccount, dispatch, intl, queryClient, pinCode } = this.props;
 
     try {
@@ -687,6 +690,7 @@ class EditorContainer extends Component<EditorContainerProps, any> {
         const _extractedMeta = await extractMetadata({
           body: draftField.body,
           thumbUrl,
+          videoThumbUrls: filterActiveVideoThumbs(videoThumbs, draftField.body),
           fetchRatios: false,
         });
 
@@ -839,7 +843,7 @@ class EditorContainer extends Component<EditorContainerProps, any> {
   // isDraftSaving and never clears local draft caches, so the normal draft
   // autosave flow keeps working on whatever the user is writing.
   _saveAsTemplate = async (fields, templateName: string) => {
-    const { isReply, isEdit, thumbUrl, rewardType, postDescription } = this.state;
+    const { isReply, isEdit, thumbUrl, videoThumbs, rewardType, postDescription } = this.state;
     const { currentAccount, dispatch, intl, queryClient, pinCode } = this.props;
 
     if (isReply || isEdit || !fields) {
@@ -860,6 +864,7 @@ class EditorContainer extends Component<EditorContainerProps, any> {
       const _extractedMeta = await extractMetadata({
         body: draftField.body,
         thumbUrl,
+        videoThumbUrls: filterActiveVideoThumbs(videoThumbs, draftField.body),
         fetchRatios: false,
       });
 
@@ -993,7 +998,7 @@ class EditorContainer extends Component<EditorContainerProps, any> {
     scheduleDate?: string;
   }) => {
     const { currentAccount, dispatch, intl, navigation, queryClient, pinCode } = this.props;
-    const { rewardType, isPostSending, thumbUrl, draftId, shouldReblog } = this.state;
+    const { rewardType, isPostSending, thumbUrl, videoThumbs, draftId, shouldReblog } = this.state;
 
     const fields = Object.assign({}, _fieldsBase);
     let beneficiaries = this._extractBeneficiaries();
@@ -1129,6 +1134,7 @@ class EditorContainer extends Component<EditorContainerProps, any> {
       const meta = await extractMetadata({
         body: fields.body,
         thumbUrl,
+        videoThumbUrls: filterActiveVideoThumbs(videoThumbs, fields.body),
         fetchRatios: true,
         pollDraft,
       });
@@ -1447,7 +1453,7 @@ class EditorContainer extends Component<EditorContainerProps, any> {
 
   _submitEdit = async (fields) => {
     const { currentAccount, postCachePrimer, updateReplyMutation } = this.props;
-    const { post, isPostSending, thumbUrl, isReply } = this.state;
+    const { post, isPostSending, thumbUrl, videoThumbs, isReply } = this.state;
 
     if (isPostSending) {
       // `_handleSubmit` set `_isSubmitting=true` to gate the confirm Alert;
@@ -1547,6 +1553,7 @@ class EditorContainer extends Component<EditorContainerProps, any> {
       const meta = await extractMetadata({
         body: fields.body,
         thumbUrl,
+        videoThumbUrls: filterActiveVideoThumbs(videoThumbs, fields.body),
         fetchRatios: true,
         postType: jsonMetadata.type,
         contentType: jsonMetadata.content_type,
@@ -1903,13 +1910,14 @@ class EditorContainer extends Component<EditorContainerProps, any> {
     });
   };
 
-  // Thumbnails extracted from uploaded 3Speak videos are not present in the post body,
-  // keep them here so they can be offered as post thumbnail candidates
-  _handleVideoThumbUrl = (url: string) => {
-    this.setState((prevState) =>
-      prevState.videoThumbUrls.includes(url)
+  // Thumbnails extracted from uploaded 3Speak videos are not present in the post body, keep
+  // them here so they can be offered as post thumbnail candidates. Keyed by embed url so a
+  // video removed from the body takes its thumbnail with it, see filterActiveVideoThumbs.
+  _handleVideoThumb = (embedUrl: string, thumbUrl: string) => {
+    this.setState((prevState: any) =>
+      prevState.videoThumbs.some((v: VideoThumb) => v.embedUrl === embedUrl)
         ? null
-        : { videoThumbUrls: [...prevState.videoThumbUrls, url] },
+        : { videoThumbs: [...prevState.videoThumbs, { embedUrl, thumbUrl }] },
     );
   };
 
@@ -1939,7 +1947,7 @@ class EditorContainer extends Component<EditorContainerProps, any> {
       sharedSnippetText,
       onLoadDraftPress,
       thumbUrl,
-      videoThumbUrls,
+      videoThumbs,
       uploadProgress,
       rewardType,
       postDescription,
@@ -1986,8 +1994,8 @@ class EditorContainer extends Component<EditorContainerProps, any> {
         onLoadDraftPress={onLoadDraftPress}
         thumbUrl={thumbUrl}
         setThumbUrl={this._handleSetThumbUrl}
-        videoThumbUrls={videoThumbUrls}
-        handleVideoThumbUrl={this._handleVideoThumbUrl}
+        videoThumbs={videoThumbs}
+        handleVideoThumb={this._handleVideoThumb}
         uploadProgress={uploadProgress}
         rewardType={rewardType}
         postDescription={postDescription}

--- a/src/screens/editor/container/editorContainer.tsx
+++ b/src/screens/editor/container/editorContainer.tsx
@@ -138,6 +138,7 @@ class EditorContainer extends Component<EditorContainerProps, any> {
       sharedSnippetText: null,
       onLoadDraftPress: false,
       thumbUrl: '',
+      videoThumbUrls: [],
       shouldReblog: false,
       postDescription: '',
     };
@@ -1902,6 +1903,16 @@ class EditorContainer extends Component<EditorContainerProps, any> {
     });
   };
 
+  // Thumbnails extracted from uploaded 3Speak videos are not present in the post body,
+  // keep them here so they can be offered as post thumbnail candidates
+  _handleVideoThumbUrl = (url: string) => {
+    this.setState((prevState) =>
+      prevState.videoThumbUrls.includes(url)
+        ? null
+        : { videoThumbUrls: [...prevState.videoThumbUrls, url] },
+    );
+  };
+
   _setIsUploading = (status: boolean) => {
     this.setState({
       isUploading: status,
@@ -1928,6 +1939,7 @@ class EditorContainer extends Component<EditorContainerProps, any> {
       sharedSnippetText,
       onLoadDraftPress,
       thumbUrl,
+      videoThumbUrls,
       uploadProgress,
       rewardType,
       postDescription,
@@ -1974,6 +1986,8 @@ class EditorContainer extends Component<EditorContainerProps, any> {
         onLoadDraftPress={onLoadDraftPress}
         thumbUrl={thumbUrl}
         setThumbUrl={this._handleSetThumbUrl}
+        videoThumbUrls={videoThumbUrls}
+        handleVideoThumbUrl={this._handleVideoThumbUrl}
         uploadProgress={uploadProgress}
         rewardType={rewardType}
         postDescription={postDescription}

--- a/src/screens/editor/container/editorContainer.tsx
+++ b/src/screens/editor/container/editorContainer.tsx
@@ -37,6 +37,7 @@ import {
   makeOptions,
   extractMetadata,
   collectVideoThumbUrls,
+  restoreVideoThumbs,
   VideoThumb,
   makeJsonMetadataForUpdate,
   cleanAiTools,
@@ -141,8 +142,6 @@ class EditorContainer extends Component<EditorContainerProps, any> {
       onLoadDraftPress: false,
       thumbUrl: '',
       videoThumbs: [],
-      // Cover of a reopened draft, whose embed associations are gone
-      restoredThumbUrls: [],
       shouldReblog: false,
       postDescription: '',
     };
@@ -474,9 +473,9 @@ class EditorContainer extends Component<EditorContainerProps, any> {
       // const urls = extractImageUrls({ body });
       this.setState({
         thumbUrl: draft.meta.image[0],
-        // A video thumbnail is not in the body, so it cannot be recovered by parsing the
-        // draft. Keep the saved images as candidates so reopening does not drop the cover.
-        restoredThumbUrls: draft.meta.image,
+        // A video thumbnail is not in the body, so rebuild the association the draft could
+        // not carry, otherwise reopening silently drops the cover.
+        videoThumbs: restoreVideoThumbs(draft.body, draft.meta.image),
       });
     }
 
@@ -648,16 +647,8 @@ class EditorContainer extends Component<EditorContainerProps, any> {
       return;
     }
 
-    const {
-      isDraftSaved,
-      draftId,
-      thumbUrl,
-      videoThumbs,
-      restoredThumbUrls,
-      isReply,
-      rewardType,
-      postDescription,
-    } = this.state;
+    const { isDraftSaved, draftId, thumbUrl, videoThumbs, isReply, rewardType, postDescription } =
+      this.state;
     const { currentAccount, dispatch, intl, queryClient, pinCode } = this.props;
 
     try {
@@ -703,11 +694,7 @@ class EditorContainer extends Component<EditorContainerProps, any> {
         const _extractedMeta = await extractMetadata({
           body: draftField.body,
           thumbUrl,
-          videoThumbUrls: collectVideoThumbUrls({
-            videoThumbs,
-            restoredThumbUrls,
-            body: draftField.body,
-          }),
+          videoThumbUrls: collectVideoThumbUrls({ videoThumbs, body: draftField.body }),
           fetchRatios: false,
         });
 
@@ -860,15 +847,7 @@ class EditorContainer extends Component<EditorContainerProps, any> {
   // isDraftSaving and never clears local draft caches, so the normal draft
   // autosave flow keeps working on whatever the user is writing.
   _saveAsTemplate = async (fields, templateName: string) => {
-    const {
-      isReply,
-      isEdit,
-      thumbUrl,
-      videoThumbs,
-      restoredThumbUrls,
-      rewardType,
-      postDescription,
-    } = this.state;
+    const { isReply, isEdit, thumbUrl, videoThumbs, rewardType, postDescription } = this.state;
     const { currentAccount, dispatch, intl, queryClient, pinCode } = this.props;
 
     if (isReply || isEdit || !fields) {
@@ -889,11 +868,7 @@ class EditorContainer extends Component<EditorContainerProps, any> {
       const _extractedMeta = await extractMetadata({
         body: draftField.body,
         thumbUrl,
-        videoThumbUrls: collectVideoThumbUrls({
-          videoThumbs,
-          restoredThumbUrls,
-          body: draftField.body,
-        }),
+        videoThumbUrls: collectVideoThumbUrls({ videoThumbs, body: draftField.body }),
         fetchRatios: false,
       });
 
@@ -1027,15 +1002,7 @@ class EditorContainer extends Component<EditorContainerProps, any> {
     scheduleDate?: string;
   }) => {
     const { currentAccount, dispatch, intl, navigation, queryClient, pinCode } = this.props;
-    const {
-      rewardType,
-      isPostSending,
-      thumbUrl,
-      videoThumbs,
-      restoredThumbUrls,
-      draftId,
-      shouldReblog,
-    } = this.state;
+    const { rewardType, isPostSending, thumbUrl, videoThumbs, draftId, shouldReblog } = this.state;
 
     const fields = Object.assign({}, _fieldsBase);
     let beneficiaries = this._extractBeneficiaries();
@@ -1171,11 +1138,7 @@ class EditorContainer extends Component<EditorContainerProps, any> {
       const meta = await extractMetadata({
         body: fields.body,
         thumbUrl,
-        videoThumbUrls: collectVideoThumbUrls({
-          videoThumbs,
-          restoredThumbUrls,
-          body: fields.body,
-        }),
+        videoThumbUrls: collectVideoThumbUrls({ videoThumbs, body: fields.body }),
         fetchRatios: true,
         pollDraft,
       });
@@ -1494,7 +1457,7 @@ class EditorContainer extends Component<EditorContainerProps, any> {
 
   _submitEdit = async (fields) => {
     const { currentAccount, postCachePrimer, updateReplyMutation } = this.props;
-    const { post, isPostSending, thumbUrl, videoThumbs, restoredThumbUrls, isReply } = this.state;
+    const { post, isPostSending, thumbUrl, videoThumbs, isReply } = this.state;
 
     if (isPostSending) {
       // `_handleSubmit` set `_isSubmitting=true` to gate the confirm Alert;
@@ -1594,11 +1557,7 @@ class EditorContainer extends Component<EditorContainerProps, any> {
       const meta = await extractMetadata({
         body: fields.body,
         thumbUrl,
-        videoThumbUrls: collectVideoThumbUrls({
-          videoThumbs,
-          restoredThumbUrls,
-          body: fields.body,
-        }),
+        videoThumbUrls: collectVideoThumbUrls({ videoThumbs, body: fields.body }),
         fetchRatios: true,
         postType: jsonMetadata.type,
         contentType: jsonMetadata.content_type,
@@ -1993,7 +1952,6 @@ class EditorContainer extends Component<EditorContainerProps, any> {
       onLoadDraftPress,
       thumbUrl,
       videoThumbs,
-      restoredThumbUrls,
       uploadProgress,
       rewardType,
       postDescription,
@@ -2041,7 +1999,6 @@ class EditorContainer extends Component<EditorContainerProps, any> {
         thumbUrl={thumbUrl}
         setThumbUrl={this._handleSetThumbUrl}
         videoThumbs={videoThumbs}
-        restoredThumbUrls={restoredThumbUrls}
         handleVideoThumb={this._handleVideoThumb}
         uploadProgress={uploadProgress}
         rewardType={rewardType}

--- a/src/screens/editor/container/editorContainer.tsx
+++ b/src/screens/editor/container/editorContainer.tsx
@@ -36,7 +36,7 @@ import {
   makeJsonMetadata,
   makeOptions,
   extractMetadata,
-  filterActiveVideoThumbs,
+  collectVideoThumbUrls,
   VideoThumb,
   makeJsonMetadataForUpdate,
   cleanAiTools,
@@ -141,6 +141,8 @@ class EditorContainer extends Component<EditorContainerProps, any> {
       onLoadDraftPress: false,
       thumbUrl: '',
       videoThumbs: [],
+      // Cover of a reopened draft, whose embed associations are gone
+      restoredThumbUrls: [],
       shouldReblog: false,
       postDescription: '',
     };
@@ -472,6 +474,9 @@ class EditorContainer extends Component<EditorContainerProps, any> {
       // const urls = extractImageUrls({ body });
       this.setState({
         thumbUrl: draft.meta.image[0],
+        // A video thumbnail is not in the body, so it cannot be recovered by parsing the
+        // draft. Keep the saved images as candidates so reopening does not drop the cover.
+        restoredThumbUrls: draft.meta.image,
       });
     }
 
@@ -643,8 +648,16 @@ class EditorContainer extends Component<EditorContainerProps, any> {
       return;
     }
 
-    const { isDraftSaved, draftId, thumbUrl, videoThumbs, isReply, rewardType, postDescription } =
-      this.state;
+    const {
+      isDraftSaved,
+      draftId,
+      thumbUrl,
+      videoThumbs,
+      restoredThumbUrls,
+      isReply,
+      rewardType,
+      postDescription,
+    } = this.state;
     const { currentAccount, dispatch, intl, queryClient, pinCode } = this.props;
 
     try {
@@ -690,7 +703,11 @@ class EditorContainer extends Component<EditorContainerProps, any> {
         const _extractedMeta = await extractMetadata({
           body: draftField.body,
           thumbUrl,
-          videoThumbUrls: filterActiveVideoThumbs(videoThumbs, draftField.body),
+          videoThumbUrls: collectVideoThumbUrls({
+            videoThumbs,
+            restoredThumbUrls,
+            body: draftField.body,
+          }),
           fetchRatios: false,
         });
 
@@ -843,7 +860,15 @@ class EditorContainer extends Component<EditorContainerProps, any> {
   // isDraftSaving and never clears local draft caches, so the normal draft
   // autosave flow keeps working on whatever the user is writing.
   _saveAsTemplate = async (fields, templateName: string) => {
-    const { isReply, isEdit, thumbUrl, videoThumbs, rewardType, postDescription } = this.state;
+    const {
+      isReply,
+      isEdit,
+      thumbUrl,
+      videoThumbs,
+      restoredThumbUrls,
+      rewardType,
+      postDescription,
+    } = this.state;
     const { currentAccount, dispatch, intl, queryClient, pinCode } = this.props;
 
     if (isReply || isEdit || !fields) {
@@ -864,7 +889,11 @@ class EditorContainer extends Component<EditorContainerProps, any> {
       const _extractedMeta = await extractMetadata({
         body: draftField.body,
         thumbUrl,
-        videoThumbUrls: filterActiveVideoThumbs(videoThumbs, draftField.body),
+        videoThumbUrls: collectVideoThumbUrls({
+          videoThumbs,
+          restoredThumbUrls,
+          body: draftField.body,
+        }),
         fetchRatios: false,
       });
 
@@ -998,7 +1027,15 @@ class EditorContainer extends Component<EditorContainerProps, any> {
     scheduleDate?: string;
   }) => {
     const { currentAccount, dispatch, intl, navigation, queryClient, pinCode } = this.props;
-    const { rewardType, isPostSending, thumbUrl, videoThumbs, draftId, shouldReblog } = this.state;
+    const {
+      rewardType,
+      isPostSending,
+      thumbUrl,
+      videoThumbs,
+      restoredThumbUrls,
+      draftId,
+      shouldReblog,
+    } = this.state;
 
     const fields = Object.assign({}, _fieldsBase);
     let beneficiaries = this._extractBeneficiaries();
@@ -1134,7 +1171,11 @@ class EditorContainer extends Component<EditorContainerProps, any> {
       const meta = await extractMetadata({
         body: fields.body,
         thumbUrl,
-        videoThumbUrls: filterActiveVideoThumbs(videoThumbs, fields.body),
+        videoThumbUrls: collectVideoThumbUrls({
+          videoThumbs,
+          restoredThumbUrls,
+          body: fields.body,
+        }),
         fetchRatios: true,
         pollDraft,
       });
@@ -1453,7 +1494,7 @@ class EditorContainer extends Component<EditorContainerProps, any> {
 
   _submitEdit = async (fields) => {
     const { currentAccount, postCachePrimer, updateReplyMutation } = this.props;
-    const { post, isPostSending, thumbUrl, videoThumbs, isReply } = this.state;
+    const { post, isPostSending, thumbUrl, videoThumbs, restoredThumbUrls, isReply } = this.state;
 
     if (isPostSending) {
       // `_handleSubmit` set `_isSubmitting=true` to gate the confirm Alert;
@@ -1553,7 +1594,11 @@ class EditorContainer extends Component<EditorContainerProps, any> {
       const meta = await extractMetadata({
         body: fields.body,
         thumbUrl,
-        videoThumbUrls: filterActiveVideoThumbs(videoThumbs, fields.body),
+        videoThumbUrls: collectVideoThumbUrls({
+          videoThumbs,
+          restoredThumbUrls,
+          body: fields.body,
+        }),
         fetchRatios: true,
         postType: jsonMetadata.type,
         contentType: jsonMetadata.content_type,
@@ -1948,6 +1993,7 @@ class EditorContainer extends Component<EditorContainerProps, any> {
       onLoadDraftPress,
       thumbUrl,
       videoThumbs,
+      restoredThumbUrls,
       uploadProgress,
       rewardType,
       postDescription,
@@ -1995,6 +2041,7 @@ class EditorContainer extends Component<EditorContainerProps, any> {
         thumbUrl={thumbUrl}
         setThumbUrl={this._handleSetThumbUrl}
         videoThumbs={videoThumbs}
+        restoredThumbUrls={restoredThumbUrls}
         handleVideoThumb={this._handleVideoThumb}
         uploadProgress={uploadProgress}
         rewardType={rewardType}

--- a/src/screens/editor/screen/editorScreen.tsx
+++ b/src/screens/editor/screen/editorScreen.tsx
@@ -9,6 +9,7 @@ import { getCommunityQueryOptions } from '@ecency/sdk';
 import {
   cleanAiTools,
   extractMetadata,
+  filterActiveVideoThumbs,
   getWordsCount,
   makeJsonMetadata,
 } from '../../../utils/editor';
@@ -499,8 +500,8 @@ class EditorScreen extends Component {
       sharedSnippetText,
       onLoadDraftPress,
       thumbUrl,
-      videoThumbUrls,
-      handleVideoThumbUrl,
+      videoThumbs,
+      handleVideoThumb,
       uploadProgress,
       rewardType,
       postDescription,
@@ -605,7 +606,7 @@ class EditorScreen extends Component {
             onLoadDraftPress={onLoadDraftPress}
             uploadProgress={uploadProgress}
             setIsUploading={setIsUploading}
-            handleVideoThumbUrl={handleVideoThumbUrl}
+            handleVideoThumb={handleVideoThumb}
             isPreviewActive={isPreviewActive}
           />
         </Fragment>
@@ -617,7 +618,7 @@ class EditorScreen extends Component {
           body={fields.body}
           draftId={draftId}
           thumbUrl={thumbUrl}
-          videoThumbUrls={videoThumbUrls}
+          videoThumbUrls={filterActiveVideoThumbs(videoThumbs, fields.body)}
           isEdit={isEdit}
           isCommunityPost={selectedCommunity !== null}
           rewardType={rewardType}

--- a/src/screens/editor/screen/editorScreen.tsx
+++ b/src/screens/editor/screen/editorScreen.tsx
@@ -501,7 +501,6 @@ class EditorScreen extends Component {
       onLoadDraftPress,
       thumbUrl,
       videoThumbs,
-      restoredThumbUrls,
       handleVideoThumb,
       uploadProgress,
       rewardType,
@@ -619,11 +618,7 @@ class EditorScreen extends Component {
           body={fields.body}
           draftId={draftId}
           thumbUrl={thumbUrl}
-          videoThumbUrls={collectVideoThumbUrls({
-            videoThumbs,
-            restoredThumbUrls,
-            body: fields.body,
-          })}
+          videoThumbUrls={collectVideoThumbUrls({ videoThumbs, body: fields.body })}
           isEdit={isEdit}
           isCommunityPost={selectedCommunity !== null}
           rewardType={rewardType}

--- a/src/screens/editor/screen/editorScreen.tsx
+++ b/src/screens/editor/screen/editorScreen.tsx
@@ -499,6 +499,8 @@ class EditorScreen extends Component {
       sharedSnippetText,
       onLoadDraftPress,
       thumbUrl,
+      videoThumbUrls,
+      handleVideoThumbUrl,
       uploadProgress,
       rewardType,
       postDescription,
@@ -603,6 +605,7 @@ class EditorScreen extends Component {
             onLoadDraftPress={onLoadDraftPress}
             uploadProgress={uploadProgress}
             setIsUploading={setIsUploading}
+            handleVideoThumbUrl={handleVideoThumbUrl}
             isPreviewActive={isPreviewActive}
           />
         </Fragment>
@@ -614,6 +617,7 @@ class EditorScreen extends Component {
           body={fields.body}
           draftId={draftId}
           thumbUrl={thumbUrl}
+          videoThumbUrls={videoThumbUrls}
           isEdit={isEdit}
           isCommunityPost={selectedCommunity !== null}
           rewardType={rewardType}

--- a/src/screens/editor/screen/editorScreen.tsx
+++ b/src/screens/editor/screen/editorScreen.tsx
@@ -8,8 +8,8 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { getCommunityQueryOptions } from '@ecency/sdk';
 import {
   cleanAiTools,
+  collectVideoThumbUrls,
   extractMetadata,
-  filterActiveVideoThumbs,
   getWordsCount,
   makeJsonMetadata,
 } from '../../../utils/editor';
@@ -501,6 +501,7 @@ class EditorScreen extends Component {
       onLoadDraftPress,
       thumbUrl,
       videoThumbs,
+      restoredThumbUrls,
       handleVideoThumb,
       uploadProgress,
       rewardType,
@@ -618,7 +619,11 @@ class EditorScreen extends Component {
           body={fields.body}
           draftId={draftId}
           thumbUrl={thumbUrl}
-          videoThumbUrls={filterActiveVideoThumbs(videoThumbs, fields.body)}
+          videoThumbUrls={collectVideoThumbUrls({
+            videoThumbs,
+            restoredThumbUrls,
+            body: fields.body,
+          })}
           isEdit={isEdit}
           isCommunityPost={selectedCommunity !== null}
           rewardType={rewardType}

--- a/src/utils/editor.test.ts
+++ b/src/utils/editor.test.ts
@@ -1,36 +1,76 @@
-import { cleanAiTools, filterActiveVideoThumbs, makeJsonMetadata } from './editor';
+import { cleanAiTools, collectVideoThumbUrls, makeJsonMetadata } from './editor';
 
 // Video thumbnails are not present in the body, so they are carried in state keyed by the
 // embed they belong to. Only thumbnails whose embed is still in the body stay eligible.
-describe('filterActiveVideoThumbs', () => {
+describe('collectVideoThumbUrls', () => {
   const thumbA = { embedUrl: 'https://3speak.tv/embed?v=alice/aaa', thumbUrl: 'https://img/a.jpg' };
   const thumbB = { embedUrl: 'https://3speak.tv/embed?v=bob/bbb', thumbUrl: 'https://img/b.jpg' };
 
   it('returns an empty list for missing input', () => {
-    expect(filterActiveVideoThumbs(undefined, 'body')).toEqual([]);
-    expect(filterActiveVideoThumbs([], 'body')).toEqual([]);
-    expect(filterActiveVideoThumbs([thumbA], undefined)).toEqual([]);
-    expect(filterActiveVideoThumbs([thumbA], '')).toEqual([]);
+    expect(collectVideoThumbUrls({ body: 'body' })).toEqual([]);
+    expect(collectVideoThumbUrls({ videoThumbs: [], body: 'body' })).toEqual([]);
+    expect(collectVideoThumbUrls({ videoThumbs: [thumbA] })).toEqual([]);
+    expect(collectVideoThumbUrls({ videoThumbs: [thumbA], body: '' })).toEqual([]);
   });
 
   it('keeps a thumbnail while its embed is in the body', () => {
-    expect(filterActiveVideoThumbs([thumbA], `text\n${thumbA.embedUrl}\nmore`)).toEqual([
-      thumbA.thumbUrl,
-    ]);
+    expect(
+      collectVideoThumbUrls({ videoThumbs: [thumbA], body: `text\n${thumbA.embedUrl}\nmore` }),
+    ).toEqual([thumbA.thumbUrl]);
   });
 
   it('drops a thumbnail once its embed is removed from the body', () => {
-    expect(filterActiveVideoThumbs([thumbA], 'the video was deleted')).toEqual([]);
+    expect(collectVideoThumbUrls({ videoThumbs: [thumbA], body: 'the video was deleted' })).toEqual(
+      [],
+    );
   });
 
   it('keeps only the embeds still present when several were uploaded', () => {
-    expect(filterActiveVideoThumbs([thumbA, thumbB], `only ${thumbB.embedUrl} left`)).toEqual([
-      thumbB.thumbUrl,
-    ]);
+    expect(
+      collectVideoThumbUrls({
+        videoThumbs: [thumbA, thumbB],
+        body: `only ${thumbB.embedUrl} left`,
+      }),
+    ).toEqual([thumbB.thumbUrl]);
+  });
+
+  it('does not keep a removed video whose embed url is a prefix of the one replacing it', () => {
+    const replacement = { embedUrl: `${thumbA.embedUrl}2`, thumbUrl: 'https://img/a2.jpg' };
+    expect(
+      collectVideoThumbUrls({
+        videoThumbs: [thumbA, replacement],
+        body: `\n${replacement.embedUrl}\n`,
+      }),
+    ).toEqual([replacement.thumbUrl]);
   });
 
   it('drops everything when the editor is cleared', () => {
-    expect(filterActiveVideoThumbs([thumbA, thumbB], '')).toEqual([]);
+    expect(collectVideoThumbUrls({ videoThumbs: [thumbA, thumbB], body: '' })).toEqual([]);
+  });
+
+  it('restores a reopened draft cover while a video embed is still in the body', () => {
+    expect(
+      collectVideoThumbUrls({
+        restoredThumbUrls: [thumbA.thumbUrl],
+        body: `\n${thumbA.embedUrl}\n`,
+      }),
+    ).toEqual([thumbA.thumbUrl]);
+  });
+
+  it('ignores a restored cover when the body holds no video embed', () => {
+    expect(
+      collectVideoThumbUrls({ restoredThumbUrls: [thumbA.thumbUrl], body: 'just text' }),
+    ).toEqual([]);
+  });
+
+  it('omits thumbnails that are already images in the body, to avoid duplicates', () => {
+    const inBody = 'https://img/a.jpg';
+    expect(
+      collectVideoThumbUrls({
+        videoThumbs: [thumbA],
+        body: `![x](${inBody})\n${thumbA.embedUrl}\n`,
+      }),
+    ).toEqual([]);
   });
 });
 

--- a/src/utils/editor.test.ts
+++ b/src/utils/editor.test.ts
@@ -1,4 +1,38 @@
-import { cleanAiTools, makeJsonMetadata } from './editor';
+import { cleanAiTools, filterActiveVideoThumbs, makeJsonMetadata } from './editor';
+
+// Video thumbnails are not present in the body, so they are carried in state keyed by the
+// embed they belong to. Only thumbnails whose embed is still in the body stay eligible.
+describe('filterActiveVideoThumbs', () => {
+  const thumbA = { embedUrl: 'https://3speak.tv/embed?v=alice/aaa', thumbUrl: 'https://img/a.jpg' };
+  const thumbB = { embedUrl: 'https://3speak.tv/embed?v=bob/bbb', thumbUrl: 'https://img/b.jpg' };
+
+  it('returns an empty list for missing input', () => {
+    expect(filterActiveVideoThumbs(undefined, 'body')).toEqual([]);
+    expect(filterActiveVideoThumbs([], 'body')).toEqual([]);
+    expect(filterActiveVideoThumbs([thumbA], undefined)).toEqual([]);
+    expect(filterActiveVideoThumbs([thumbA], '')).toEqual([]);
+  });
+
+  it('keeps a thumbnail while its embed is in the body', () => {
+    expect(filterActiveVideoThumbs([thumbA], `text\n${thumbA.embedUrl}\nmore`)).toEqual([
+      thumbA.thumbUrl,
+    ]);
+  });
+
+  it('drops a thumbnail once its embed is removed from the body', () => {
+    expect(filterActiveVideoThumbs([thumbA], 'the video was deleted')).toEqual([]);
+  });
+
+  it('keeps only the embeds still present when several were uploaded', () => {
+    expect(filterActiveVideoThumbs([thumbA, thumbB], `only ${thumbB.embedUrl} left`)).toEqual([
+      thumbB.thumbUrl,
+    ]);
+  });
+
+  it('drops everything when the editor is cleared', () => {
+    expect(filterActiveVideoThumbs([thumbA, thumbB], '')).toEqual([]);
+  });
+});
 
 // The AI-usage disclosure is optional and interoperable with other Hive frontends: only
 // the truthy flags are kept,

--- a/src/utils/editor.test.ts
+++ b/src/utils/editor.test.ts
@@ -1,4 +1,9 @@
-import { cleanAiTools, collectVideoThumbUrls, makeJsonMetadata } from './editor';
+import {
+  cleanAiTools,
+  collectVideoThumbUrls,
+  makeJsonMetadata,
+  restoreVideoThumbs,
+} from './editor';
 
 // Video thumbnails are not present in the body, so they are carried in state keyed by the
 // embed they belong to. Only thumbnails whose embed is still in the body stay eligible.
@@ -48,21 +53,6 @@ describe('collectVideoThumbUrls', () => {
     expect(collectVideoThumbUrls({ videoThumbs: [thumbA, thumbB], body: '' })).toEqual([]);
   });
 
-  it('restores a reopened draft cover while a video embed is still in the body', () => {
-    expect(
-      collectVideoThumbUrls({
-        restoredThumbUrls: [thumbA.thumbUrl],
-        body: `\n${thumbA.embedUrl}\n`,
-      }),
-    ).toEqual([thumbA.thumbUrl]);
-  });
-
-  it('ignores a restored cover when the body holds no video embed', () => {
-    expect(
-      collectVideoThumbUrls({ restoredThumbUrls: [thumbA.thumbUrl], body: 'just text' }),
-    ).toEqual([]);
-  });
-
   it('omits thumbnails that are already images in the body, to avoid duplicates', () => {
     const inBody = 'https://img/a.jpg';
     expect(
@@ -71,6 +61,47 @@ describe('collectVideoThumbUrls', () => {
         body: `![x](${inBody})\n${thumbA.embedUrl}\n`,
       }),
     ).toEqual([]);
+  });
+});
+
+// A saved draft stores its cover as a flat meta.image[0] with no link to the video it came
+// from, so the association has to be inferred, and only when it is unambiguous.
+describe('restoreVideoThumbs', () => {
+  const embedA = 'https://3speak.tv/embed?v=alice/aaa';
+  const embedB = 'https://3speak.tv/embed?v=bob/bbb';
+  const cover = 'https://img/a.jpg';
+
+  it('rebuilds the association for a single video draft', () => {
+    expect(restoreVideoThumbs(`text\n${embedA}\n`, [cover])).toEqual([
+      { embedUrl: embedA, thumbUrl: cover },
+    ]);
+  });
+
+  it('returns nothing when the draft has no cover or no embed', () => {
+    expect(restoreVideoThumbs(`\n${embedA}\n`, [])).toEqual([]);
+    expect(restoreVideoThumbs(`\n${embedA}\n`, undefined)).toEqual([]);
+    expect(restoreVideoThumbs('just text', [cover])).toEqual([]);
+    expect(restoreVideoThumbs(undefined, [cover])).toEqual([]);
+  });
+
+  // With several embeds the cover cannot be attributed to one of them. Guessing would let a
+  // removed video's cover survive into a post that no longer contains it.
+  it('refuses to guess in a multi video draft', () => {
+    expect(restoreVideoThumbs(`\n${embedA}\n${embedB}\n`, [cover])).toEqual([]);
+  });
+
+  it('drops the restored cover once its video is removed from the body', () => {
+    // Reopen a single video draft, then delete the video
+    const restored = restoreVideoThumbs(`\n${embedA}\n`, [cover]);
+    expect(collectVideoThumbUrls({ videoThumbs: restored, body: `\n${embedA}\n` })).toEqual([
+      cover,
+    ]);
+    expect(collectVideoThumbUrls({ videoThumbs: restored, body: 'video deleted' })).toEqual([]);
+  });
+
+  it('does not carry the cover over to a replacement video', () => {
+    const restored = restoreVideoThumbs(`\n${embedA}\n`, [cover]);
+    expect(collectVideoThumbUrls({ videoThumbs: restored, body: `\n${embedB}\n` })).toEqual([]);
   });
 });
 

--- a/src/utils/editor.ts
+++ b/src/utils/editor.ts
@@ -265,6 +265,25 @@ export const extractFilenameFromPath = ({
   }
 };
 
+/** A thumbnail generated for an uploaded video, paired with the embed it belongs to. */
+export interface VideoThumb {
+  embedUrl: string;
+  thumbUrl: string;
+}
+
+/**
+ * Video thumbnails live outside the body, so they cannot be rediscovered by parsing it and
+ * have to be carried in state. Keeping them keyed by embed url lets a removed video drop its
+ * thumbnail instead of leaving it selectable, or published, after the video is gone.
+ */
+export const filterActiveVideoThumbs = (
+  videoThumbs: VideoThumb[] | undefined,
+  body: string | undefined,
+): string[] =>
+  (videoThumbs || [])
+    .filter(({ embedUrl }) => !!body && !!embedUrl && body.includes(embedUrl))
+    .map(({ thumbUrl }) => thumbUrl);
+
 export const extractMetadata = async ({
   body,
   thumbUrl,

--- a/src/utils/editor.ts
+++ b/src/utils/editor.ts
@@ -10,6 +10,7 @@ import { PostTypes } from '../constants/postTypes';
 import { PollDraft } from '../providers/ecency/ecency.types';
 import { ContentType, PollMetadata, PostMetadata } from '../providers/hive/hive.types';
 import postUrlParser from './postUrlParser';
+import { hasThreeSpeakEmbed } from '../providers/speak/beneficiary';
 
 export const getWordsCount = (text) =>
   text && typeof text === 'string' ? text.replace(/^\s+|\s+$/g, '').split(/\s+/).length : 0;
@@ -271,9 +272,15 @@ export interface VideoThumb {
   thumbUrl: string;
 }
 
-/** 3Speak embeds in the body. Videos are inserted as a raw url on their own line. */
+/**
+ * 3Speak embeds in the body. Videos are inserted as a raw url on their own line.
+ *
+ * Deliberately reuses the same predicate as the threespeakfund beneficiary enforcement, so
+ * what counts as a video here cannot drift from what counts as one when the payout route is
+ * attached.
+ */
 export const extractVideoEmbedUrls = (body?: string): string[] =>
-  (body ? extractUrls(body) : []).filter((url) => /3speak\.tv/i.test(url));
+  (body ? extractUrls(body) : []).filter((url) => hasThreeSpeakEmbed(url));
 
 /**
  * Rebuilds the embed to thumbnail association that a saved draft could not carry.

--- a/src/utils/editor.ts
+++ b/src/utils/editor.ts
@@ -273,16 +273,46 @@ export interface VideoThumb {
 
 /**
  * Video thumbnails live outside the body, so they cannot be rediscovered by parsing it and
- * have to be carried in state. Keeping them keyed by embed url lets a removed video drop its
- * thumbnail instead of leaving it selectable, or published, after the video is gone.
+ * have to be carried in state.
+ *
+ * `videoThumbs` are the associations built during this editing session, keyed by embed url so
+ * that a removed video drops its thumbnail instead of leaving it selectable, or published,
+ * after the video is gone. `restoredThumbUrls` come from a reopened draft, which no longer
+ * carries those associations, and are honoured only while the body still holds a 3Speak
+ * embed to attribute them to.
+ *
+ * Thumbnails already present as images in the body are left out, the caller merges this list
+ * with the body images and duplicates would otherwise reach `meta.image`.
  */
-export const filterActiveVideoThumbs = (
-  videoThumbs: VideoThumb[] | undefined,
-  body: string | undefined,
-): string[] =>
-  (videoThumbs || [])
-    .filter(({ embedUrl }) => !!body && !!embedUrl && body.includes(embedUrl))
+export const collectVideoThumbUrls = ({
+  videoThumbs,
+  restoredThumbUrls,
+  body,
+}: {
+  videoThumbs?: VideoThumb[];
+  restoredThumbUrls?: string[];
+  body?: string;
+}): string[] => {
+  if (!body) {
+    return [];
+  }
+
+  const bodyUrls = extractUrls(body);
+  // Exact match, not a substring test: one embed url can be a prefix of another, so
+  // `includes` would keep a removed video alive on the strength of the one replacing it
+  const bodyUrlSet = new Set(bodyUrls);
+  const active = (videoThumbs || [])
+    .filter(({ embedUrl }) => !!embedUrl && bodyUrlSet.has(embedUrl))
     .map(({ thumbUrl }) => thumbUrl);
+
+  const hasVideoEmbed = bodyUrls.some((url) => /3speak\.tv/i.test(url));
+  const restored = hasVideoEmbed ? restoredThumbUrls || [] : [];
+
+  const bodyImages = new Set(extractImageUrls({ body, urls: bodyUrls }));
+  return Array.from(new Set([...active, ...restored])).filter(
+    (url) => !!url && !bodyImages.has(url),
+  );
+};
 
 export const extractMetadata = async ({
   body,

--- a/src/utils/editor.ts
+++ b/src/utils/editor.ts
@@ -271,26 +271,39 @@ export interface VideoThumb {
   thumbUrl: string;
 }
 
+/** 3Speak embeds in the body. Videos are inserted as a raw url on their own line. */
+export const extractVideoEmbedUrls = (body?: string): string[] =>
+  (body ? extractUrls(body) : []).filter((url) => /3speak\.tv/i.test(url));
+
+/**
+ * Rebuilds the embed to thumbnail association that a saved draft could not carry.
+ *
+ * A draft stores its cover as a flat `meta.image[0]` with no link to the video it came from.
+ * That link can only be inferred when the draft holds exactly one embed. With several, the
+ * cover cannot be attributed to any one of them, and guessing would let a removed video's
+ * cover stay selectable and publishable for a post that no longer contains it. Those drafts
+ * restore no cover, which is what happened before any of this was carried at all.
+ */
+export const restoreVideoThumbs = (body?: string, metaImages?: string[]): VideoThumb[] => {
+  const thumbUrl = metaImages?.[0];
+  const embedUrls = extractVideoEmbedUrls(body);
+  return thumbUrl && embedUrls.length === 1 ? [{ embedUrl: embedUrls[0], thumbUrl }] : [];
+};
+
 /**
  * Video thumbnails live outside the body, so they cannot be rediscovered by parsing it and
- * have to be carried in state.
- *
- * `videoThumbs` are the associations built during this editing session, keyed by embed url so
- * that a removed video drops its thumbnail instead of leaving it selectable, or published,
- * after the video is gone. `restoredThumbUrls` come from a reopened draft, which no longer
- * carries those associations, and are honoured only while the body still holds a 3Speak
- * embed to attribute them to.
+ * have to be carried in state, keyed by the embed they belong to so that a removed video
+ * drops its thumbnail instead of leaving it selectable, or published, after the video is
+ * gone. This holds for a reopened draft too, see `restoreVideoThumbs`.
  *
  * Thumbnails already present as images in the body are left out, the caller merges this list
  * with the body images and duplicates would otherwise reach `meta.image`.
  */
 export const collectVideoThumbUrls = ({
   videoThumbs,
-  restoredThumbUrls,
   body,
 }: {
   videoThumbs?: VideoThumb[];
-  restoredThumbUrls?: string[];
   body?: string;
 }): string[] => {
   if (!body) {
@@ -301,17 +314,15 @@ export const collectVideoThumbUrls = ({
   // Exact match, not a substring test: one embed url can be a prefix of another, so
   // `includes` would keep a removed video alive on the strength of the one replacing it
   const bodyUrlSet = new Set(bodyUrls);
-  const active = (videoThumbs || [])
-    .filter(({ embedUrl }) => !!embedUrl && bodyUrlSet.has(embedUrl))
-    .map(({ thumbUrl }) => thumbUrl);
-
-  const hasVideoEmbed = bodyUrls.some((url) => /3speak\.tv/i.test(url));
-  const restored = hasVideoEmbed ? restoredThumbUrls || [] : [];
-
   const bodyImages = new Set(extractImageUrls({ body, urls: bodyUrls }));
-  return Array.from(new Set([...active, ...restored])).filter(
-    (url) => !!url && !bodyImages.has(url),
-  );
+
+  return Array.from(
+    new Set(
+      (videoThumbs || [])
+        .filter(({ embedUrl }) => !!embedUrl && bodyUrlSet.has(embedUrl))
+        .map(({ thumbUrl }) => thumbUrl),
+    ),
+  ).filter((url) => !!url && !bodyImages.has(url));
 };
 
 export const extractMetadata = async ({


### PR DESCRIPTION
Video thumbnails are auto-generated from frames on mobile already, but three issues made it look like they were not.

### Frame generation (`speakUploaderModal`)

- A single `createThumbnail` rejection (unsupported codec, iOS `ph://` url) rejected the whole `showUploader` promise. The modal stayed open with an empty strip and the video uploaded with no thumbnail. Failures are now tolerated per frame.
- `react-native-image-crop-picker` omits `duration` on some Android paths, which made every `timeStamp` `NaN`. Falls back to a fixed duration.
- `availableThumbs` was not reset on open, so a previous video's frames could persist.

Frames are now sampled at the middle of each slice rather than at its start, so the first frame, commonly black, is no longer the implicit default. The default is the middle frame, and the header tile previews it so the user can see which thumbnail will be used.

### Post editor passthrough

`UploadsGalleryModal` ignored the `thumbnailUrl` argument from `onVideoUploaded`, and `postOptionsModal` hardcoded `videoThumbUrls={[]}`. A video only post therefore had no thumbnail candidate: the selection strip showed "add more images" and the post published with no `meta.image`.

The uploaded thumbnail url is now threaded up to `editorContainer` the same way `setIsUploading` is threaded down, and fed into the thumbnail selection list. The candidate list is deduped, and `videoThumbUrls` is included in the effect dependencies since the url arrives after the body update.

Waves already handled this correctly and is unchanged.

### Verification

- `npx tsc --noEmit` clean on changed files
- `npx eslint` 0 errors, no new warnings
- `npx prettier --check` clean
- Jest: 663 passed, 1 skipped

Not exercised on a device yet, the upload path needs a real 3Speak account.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added video thumbnail generation that samples multiple frames and selects a sensible default.
  * Added support for carrying multiple pre-supplied video thumbnail URLs through the post thumbnail selection dialog.
  * Video thumbs captured from uploads can now be passed into the editor when saving or editing posts.
* **Bug Fixes**
  * Avoided invalid timestamp calculations during thumbnail generation.
  * Prevented stale thumbnail results from overwriting newer uploads.
  * Upload button is disabled while thumbnails are generating, and partial thumbnail failures are tolerated.
  * Thumbnail options are deduplicated and only retained while their embed URLs remain in the post body.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->