### PR TITLE
chore: bump @ecency/sdk to 2.3.68

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@babel/preset-typescript": "^7.26.0",
     "@babel/runtime": "^7.26.7",
     "@ecency/render-helper": "^2.5.23",
-    "@ecency/sdk": "^2.3.67",
+    "@ecency/sdk": "^2.3.68",
     "@esteemapp/react-native-autocomplete-input": "^4.2.1",
     "@esteemapp/react-native-multi-slider": "^1.1.0",
     "@native-html/iframe-plugin": "^2.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1210,10 +1210,10 @@
     url "^0.11.0"
     xss "^1.0.9"
 
-"@ecency/sdk@^2.3.67":
-  version "2.3.67"
-  resolved "https://registry.yarnpkg.com/@ecency/sdk/-/sdk-2.3.67.tgz#e871b53ab676247f16e84918c369815b64d1abdf"
-  integrity sha512-G14vGFC+ccxyA6ENelQY+E4049zngNNq9gNdSLYS2bfsvtLzbXkj/WgAnIrbyDaM0c4qBdY37O1hVSDAH9Kv4g==
+"@ecency/sdk@^2.3.68":
+  version "2.3.68"
+  resolved "https://registry.yarnpkg.com/@ecency/sdk/-/sdk-2.3.68.tgz#4008a0b494c142036f7a539ed1382d3fd0ae3b80"
+  integrity sha512-dpG7a/8ZbWpmi8nlM1qsg7xmInKiVID3MaecdHezsDO7NOZowMlbpf9LUA66/zvoWnbqloLj2cMsyVmZwF6Rxw==
   dependencies:
     "@noble/ciphers" "^2.1.1"
     "@noble/curves" "^2.0.1"


### PR DESCRIPTION
Bumps `@ecency/sdk` 2.3.67 to 2.3.68.

That release contains exactly two changes, both to queries this app already uses:

- **`post-tips` is now read with a `GET`** on `/private-api/post-tips/{author}/{permlink}` instead of a `POST` with a JSON body. A POST response is uncacheable by definition, so the same tip totals were re-requested on every mount; the query also had no `staleTime`, meaning it was stale on every mount and window refocus. Both are fixed upstream.
- **`pro-members` freshness** documented and left at 5 minutes, deliberately below the endpoint's own cache window (react-query cannot see how old a cached response already was, so matching the two would add the windows together rather than align them).

No app-side change is needed: `tipsQueries.ts` and `proQueries.ts` consume `getPostTipsQueryOptions` and `getProMembersQueryOptions` straight from the SDK.

The server side is already deployed and the previous `POST` route is still served, so an older build keeps working and this can ship on the normal release cadence.

Verified the installed build resolves to 2.3.68 and calls the GET path with both segments encoded.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Ecency SDK dependency to the latest compatible version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->