### PR TITLE
fix(chat): treat last_viewed_at 0 as never viewed, exempt DMs

### DIFF
--- a/src/providers/chat/mattermost.test.ts
+++ b/src/providers/chat/mattermost.test.ts
@@ -1,0 +1,80 @@
+import { getChannelUnreadTotal } from './mattermost';
+
+// The module pulls in the API client, realm and crypto at import time; none of
+// them are involved in the pure badge math under test.
+jest.mock('../../config/chatApi', () => ({
+  __esModule: true,
+  default: { get: jest.fn(), post: jest.fn() },
+  setChatApiToken: jest.fn(),
+}));
+jest.mock('../hive/hive', () => ({ getDigitPinCode: jest.fn() }));
+jest.mock('../../utils/crypto', () => ({ decryptKey: jest.fn() }));
+jest.mock('../../realm/realm', () => ({ getSCAccount: jest.fn() }));
+
+describe('getChannelUnreadTotal', () => {
+  it('counts unread messages of a viewed channel', () => {
+    expect(getChannelUnreadTotal({ type: 'O', last_viewed_at: 1000, message_count: 4 })).toBe(4);
+  });
+
+  it('ignores a muted channel', () => {
+    expect(
+      getChannelUnreadTotal({ type: 'O', last_viewed_at: 1000, message_count: 4, is_muted: true }),
+    ).toBe(0);
+  });
+
+  it('ignores a channel that was never viewed', () => {
+    expect(getChannelUnreadTotal({ type: 'O', last_viewed_at: null, message_count: 9 })).toBe(0);
+  });
+
+  // The regression: Mattermost reports "never viewed" as 0, not as null, so
+  // every auto-joined community channel used to dump its whole history into
+  // the badge.
+  it('treats last_viewed_at of 0 as never viewed', () => {
+    expect(getChannelUnreadTotal({ type: 'O', last_viewed_at: 0, message_count: 900 })).toBe(0);
+  });
+
+  // The mirror image: a first DM from someone new is ALWAYS last_viewed_at 0,
+  // so the never-viewed rule must not reach DMs.
+  it('counts a never-viewed DM', () => {
+    expect(getChannelUnreadTotal({ type: 'D', last_viewed_at: 0, message_count: 2 })).toBe(2);
+  });
+
+  it('counts a DM that has no last_viewed_at at all', () => {
+    expect(getChannelUnreadTotal({ type: 'D', message_count: 1 })).toBe(1);
+  });
+
+  it('still ignores a muted DM', () => {
+    expect(
+      getChannelUnreadTotal({ type: 'D', last_viewed_at: 0, message_count: 2, is_muted: true }),
+    ).toBe(0);
+  });
+
+  // The server knows about DMs whose posts were all deleted; the channel
+  // payload alone cannot express that, so its verdict wins.
+  it('honours unread_eligible=false from the server', () => {
+    expect(
+      getChannelUnreadTotal({
+        type: 'D',
+        last_viewed_at: 1000,
+        message_count: 2,
+        mention_count: 2,
+        unread_eligible: false,
+      }),
+    ).toBe(0);
+  });
+
+  it('does not require unread_eligible to be present', () => {
+    expect(getChannelUnreadTotal({ type: 'D', last_viewed_at: 1000, message_count: 3 })).toBe(3);
+  });
+
+  it('uses mentions when they exceed the message count', () => {
+    expect(
+      getChannelUnreadTotal({
+        type: 'O',
+        last_viewed_at: 1000,
+        message_count: 1,
+        mention_count: 5,
+      }),
+    ).toBe(5);
+  });
+});

--- a/src/providers/chat/mattermost.test.ts
+++ b/src/providers/chat/mattermost.test.ts
@@ -1,4 +1,4 @@
-import { getChannelUnreadTotal } from './mattermost';
+import { getChannelUnreadMeta, getChannelUnreadTotal } from './mattermost';
 
 // The module pulls in the API client, realm and crypto at import time; none of
 // them are involved in the pure badge math under test.
@@ -76,5 +76,64 @@ describe('getChannelUnreadTotal', () => {
         mention_count: 5,
       }),
     ).toBe(5);
+  });
+
+  // Group messages cannot be auto-joined either, so the never-viewed guard has
+  // nothing to protect against there.
+  it('counts a never-viewed group message', () => {
+    expect(getChannelUnreadTotal({ type: 'G', last_viewed_at: 0, message_count: 3 })).toBe(3);
+  });
+});
+
+// The channel list used to carry its own copy of this rule, so a row could show
+// a badge the global count did not include. Both now read the same helper.
+describe('getChannelUnreadMeta', () => {
+  it('returns the full breakdown for an eligible channel', () => {
+    expect(
+      getChannelUnreadMeta({
+        type: 'O',
+        last_viewed_at: 1000,
+        message_count: 4,
+        mention_count: 2,
+      }),
+    ).toEqual({
+      unreadMentions: 2,
+      unreadMessages: 4,
+      unreadCount: 2,
+      totalUnread: 4,
+    });
+  });
+
+  it('zeroes every field of an ineligible channel', () => {
+    expect(
+      getChannelUnreadMeta({
+        type: 'O',
+        last_viewed_at: 0,
+        message_count: 900,
+        mention_count: 7,
+      }),
+    ).toEqual({
+      unreadMentions: 0,
+      unreadMessages: 0,
+      unreadCount: 0,
+      totalUnread: 0,
+    });
+  });
+
+  it('agrees with getChannelUnreadTotal across every branch', () => {
+    const channels = [
+      { type: 'O', last_viewed_at: 1000, message_count: 4 },
+      { type: 'O', last_viewed_at: 0, message_count: 900 },
+      { type: 'O', last_viewed_at: null, message_count: 9 },
+      { type: 'D', last_viewed_at: 0, message_count: 2 },
+      { type: 'G', last_viewed_at: 0, message_count: 3 },
+      { type: 'D', last_viewed_at: 0, message_count: 2, is_muted: true },
+      { type: 'D', last_viewed_at: 1000, message_count: 2, unread_eligible: false },
+      { type: 'O', last_viewed_at: 1000, message_count: 1, mention_count: 5 },
+    ];
+
+    channels.forEach((channel) => {
+      expect(getChannelUnreadMeta(channel).totalUnread).toBe(getChannelUnreadTotal(channel));
+    });
   });
 });

--- a/src/providers/chat/mattermost.ts
+++ b/src/providers/chat/mattermost.ts
@@ -168,16 +168,34 @@ export const normalizeMattermostChannels = (rawChannels: any): any[] => {
   return [];
 };
 
+// Mattermost writes "never viewed" as the int64 zero, not as a missing value,
+// so both have to count. Checking only for null let every never-opened channel
+// through, and an unopened channel reports its ENTIRE history as unread.
+const isChannelNeverViewed = (channel: any): boolean => {
+  const lastViewed = channel?.last_viewed_at ?? channel?.last_view_at;
+  return lastViewed == null || lastViewed === 0;
+};
+
 export const getChannelUnreadTotal = (channel: any): number => {
+  // The server decides eligibility when it can, and it knows things the channel
+  // payload cannot express — a DM whose posts were all deleted still reports
+  // unread, because Mattermost never decrements total_msg_count on delete.
+  // Trust that verdict; the local rules below are the fallback for servers that
+  // do not send the flag yet.
+  if (channel?.unread_eligible === false) {
+    return 0;
+  }
+
   if (channel?.is_muted) {
     return 0;
   }
 
-  // Channels that have never been viewed (null/undefined last_viewed_at)
-  // should not count unreads — prevents auto-joined channels from
-  // inflating the badge with all historical messages.
-  const lastViewed = channel?.last_viewed_at ?? channel?.last_view_at;
-  if (lastViewed == null) {
+  // Never-viewed channels should not count unreads — prevents auto-joined
+  // channels from inflating the badge with all historical messages.
+  //
+  // DMs are exempt: last_viewed_at is 0 for a first message from someone new,
+  // so applying this to them would hide every first-contact DM instead.
+  if (channel?.type !== 'D' && isChannelNeverViewed(channel)) {
     return 0;
   }
 

--- a/src/providers/chat/mattermost.ts
+++ b/src/providers/chat/mattermost.ts
@@ -176,27 +176,55 @@ const isChannelNeverViewed = (channel: any): boolean => {
   return lastViewed == null || lastViewed === 0;
 };
 
-export const getChannelUnreadTotal = (channel: any): number => {
+// Direct and group messages. Neither can be auto-joined — someone has to be put
+// in one deliberately — which is what exempts them from the never-viewed rule.
+const isDirectLikeChannel = (channel: any): boolean =>
+  channel?.type === 'D' || channel?.type === 'G';
+
+/**
+ * Whether a channel may contribute to the unread badge at all.
+ *
+ * Shared by the global badge and the channel list. They used to carry separate
+ * copies of this rule, which is how a channel could show a row badge that the
+ * global count did not include.
+ */
+export const isChannelUnreadEligible = (channel: any): boolean => {
   // The server decides eligibility when it can, and it knows things the channel
   // payload cannot express — a DM whose posts were all deleted still reports
   // unread, because Mattermost never decrements total_msg_count on delete.
   // Trust that verdict; the local rules below are the fallback for servers that
   // do not send the flag yet.
   if (channel?.unread_eligible === false) {
-    return 0;
+    return false;
   }
 
   if (channel?.is_muted) {
-    return 0;
+    return false;
   }
 
   // Never-viewed channels should not count unreads — prevents auto-joined
   // channels from inflating the badge with all historical messages.
   //
-  // DMs are exempt: last_viewed_at is 0 for a first message from someone new,
-  // so applying this to them would hide every first-contact DM instead.
-  if (channel?.type !== 'D' && isChannelNeverViewed(channel)) {
-    return 0;
+  // DMs and group messages are exempt: last_viewed_at is 0 for a first message
+  // from someone new, so applying this to them would hide every first-contact
+  // conversation instead.
+  if (!isDirectLikeChannel(channel) && isChannelNeverViewed(channel)) {
+    return false;
+  }
+
+  return true;
+};
+
+const ZERO_UNREAD_META = {
+  unreadMentions: 0,
+  unreadMessages: 0,
+  unreadCount: 0,
+  totalUnread: 0,
+};
+
+export const getChannelUnreadMeta = (channel: any) => {
+  if (!isChannelUnreadEligible(channel)) {
+    return ZERO_UNREAD_META;
   }
 
   const unreadMentionValues = [
@@ -220,9 +248,17 @@ export const getChannelUnreadTotal = (channel: any): number => {
     ? channel.unread_count
     : 0;
 
-  // mentions are a subset of unread messages, use max to avoid double-counting
-  return Math.max(unreadMentions, unreadMessages);
+  return {
+    unreadMentions,
+    unreadMessages,
+    unreadCount: unreadMentions || unreadMessages || 0,
+    // mentions are a subset of unread messages, use max to avoid double-counting
+    totalUnread: Math.max(unreadMentions, unreadMessages),
+  };
 };
+
+export const getChannelUnreadTotal = (channel: any): number =>
+  getChannelUnreadMeta(channel).totalUnread;
 
 export const calculateGlobalUnreadTotal = async (): Promise<number> => {
   const channelResponse = await fetchMattermostChannels();

--- a/src/providers/chat/mattermost.ts
+++ b/src/providers/chat/mattermost.ts
@@ -189,11 +189,13 @@ const isDirectLikeChannel = (channel: any): boolean =>
  * global count did not include.
  */
 export const isChannelUnreadEligible = (channel: any): boolean => {
-  // The server decides eligibility when it can, and it knows things the channel
-  // payload cannot express — a DM whose posts were all deleted still reports
-  // unread, because Mattermost never decrements total_msg_count on delete.
-  // Trust that verdict; the local rules below are the fallback for servers that
-  // do not send the flag yet.
+  // Only `false` is authoritative, and deliberately so: it carries information
+  // the channel payload cannot express — a DM whose posts were all deleted
+  // still reports unread, because Mattermost never decrements total_msg_count
+  // on delete, so no client-side rule could infer it. A `true` (or absent)
+  // value is not a licence to skip the checks below; they still run. The server
+  // applies the same rules, so agreeing twice costs nothing, and older servers
+  // that never send the field stay correct.
   if (channel?.unread_eligible === false) {
     return false;
   }

--- a/src/screens/chats/container/chatsContainer.tsx
+++ b/src/screens/chats/container/chatsContainer.tsx
@@ -30,6 +30,7 @@ import {
   markMattermostChannelViewed,
   normalizeMattermostChannels,
   calculateGlobalUnreadTotal,
+  getChannelUnreadMeta,
 } from '../../../providers/chat/mattermost';
 import { Header } from '../../../components';
 import { chatsStyles as styles } from '../styles/chats.styles';
@@ -125,58 +126,11 @@ const ChatsContainer = () => {
   // Unread Meta Calculation
   // ============================================================================
 
-  const _getUnreadMeta = useCallback((channel: any) => {
-    const _zeroUnread = {
-      unreadMentions: 0,
-      unreadMessages: 0,
-      unreadCount: 0,
-      totalUnread: 0,
-    };
-
-    if (channel?.is_muted) {
-      return _zeroUnread;
-    }
-
-    // Channels that have never been viewed (null/undefined) should
-    // not show unreads — prevents auto-joined channels from showing
-    // all historical messages as new
-    const lastViewed = channel?.last_viewed_at ?? channel?.last_view_at;
-    if (lastViewed == null) {
-      return _zeroUnread;
-    }
-
-    const unreadMentionValues = [
-      channel?.unread_mentions,
-      channel?.mention_count,
-      channel?.mentions_count,
-      channel?.mention_count_root,
-      channel?.urgent_mention_count,
-      channel?.channel_wide_mention_count,
-    ].filter((value) => Number.isFinite(value)) as number[];
-
-    const unreadMentions = unreadMentionValues.length ? Math.max(0, ...unreadMentionValues) : 0;
-
-    const unreadMessages = Number.isFinite(channel?.message_count)
-      ? channel.message_count
-      : Number.isFinite(channel?.unread_messages)
-      ? channel.unread_messages
-      : Number.isFinite(channel?.unread_msg_count)
-      ? channel.unread_msg_count
-      : Number.isFinite(channel?.unread_count)
-      ? channel.unread_count
-      : 0;
-
-    const unreadCount = unreadMentions || unreadMessages || 0;
-    // mentions are a subset of unread messages, use max to avoid double-counting
-    const totalUnread = Math.max(unreadMentions, unreadMessages);
-
-    return {
-      unreadMentions,
-      unreadMessages,
-      unreadCount,
-      totalUnread,
-    };
-  }, []);
+  // Row badges, sorting and the channel-options sheet all read this. It has to
+  // be the SAME rule the global badge uses (calculateGlobalUnreadTotal), or a
+  // row shows a count the badge does not include — or worse, the badge counts a
+  // channel whose row shows nothing to clear.
+  const _getUnreadMeta = useCallback((channel: any) => getChannelUnreadMeta(channel), []);
 
   const _refreshGlobalUnreadChatCount = useCallback(async () => {
     try {


### PR DESCRIPTION
Fixes #3376

## The bug

`getChannelUnreadTotal()` guarded against never-viewed channels with `lastViewed == null`. Mattermost writes "never viewed" as the int64 zero, not as a missing value, so the guard never fired: an unopened channel has `msg_count = 0`, which makes its unread count equal to its **entire history**.

Every community channel a user joined but never opened was therefore folded into the badge. Measured against live data that is roughly 4 million phantom unreads; about 2,000 accounts would render a badge over 1,000, worst case over 5,000. This is also why an account can show a large count in the app and nothing on the website — the web app already handles the zero.

## The fix

Treat `0` as never-viewed, **but exempt DMs**. Copying the web rule verbatim would have swapped this bug for the mirror image of it: a first message from someone new is always `last_viewed_at = 0`, so a blanket zero-check hides first-contact DMs. That is a real defect on web today, fixed in ecency/vision-next#1288. Auto-join is the thing the guard is for, and DMs have no auto-join path.

Also honour `unread_eligible` when the server sends it. The server sees things the channel payload cannot express — a DM whose posts were all deleted keeps reporting unread, because Mattermost never decrements `total_msg_count` on delete — and deferring to one verdict is what keeps the two clients from drifting apart again. The local rules remain the fallback for servers that do not send the flag, so this is safe to ship in either order relative to the web PR.

## Tests

New `src/providers/chat/mattermost.test.ts`, 10 cases: `last_viewed_at` of `0` and `null` on a normal channel, both counted for a DM, muted still wins over both, `unread_eligible: false` respected, absent flag ignored, mentions vs messages.

Full suite green (45 suites, 697 tests).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Mattermost unread indicators for channels that have never been viewed.
  * Prevented unread counts from appearing for muted, ineligible, or never-viewed channels where appropriate.
  * Preserved unread notifications for direct messages and group messages, including first-contact messages.
  * Corrected unread totals when mention counts exceed message counts.
  * Aligned channel-level and overall unread indicators for consistent results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->