### PR TITLE
fix(chat): community moderator check reads team tuples as objects

### DIFF
--- a/src/screens/chats/container/chatThreadContainer.tsx
+++ b/src/screens/chats/container/chatThreadContainer.tsx
@@ -57,6 +57,7 @@ import { extractImageUrls, extractUrls } from '../../../utils/editor';
 import postUrlParser from '../../../utils/postUrlParser';
 import { fetchLinkMetadata } from '../../../utils/linkMetadata';
 import { isMediaPickerCancellation, reportMediaPickerError } from '../../../utils/mediaPickerError';
+import { isCommunityModerator } from '../../../utils/communityModeration';
 import { LinkPreview, HiveLinkPreview } from '../../../components';
 import { SheetNames } from '../../../navigation/sheets';
 
@@ -673,13 +674,7 @@ export const ChatThreadContainer: React.FC<ChatThreadContainerProps> = ({
         const community = await queryClient.fetchQuery(
           getCommunityQueryOptions(derivedCommunityIdentifier, currentAccount.name),
         );
-        const team = community?.team || [];
-        const isModerator = team.some(
-          (member: any) =>
-            member?.account === currentAccount.name &&
-            ['mod', 'admin', 'owner'].includes(member?.role as string),
-        );
-        setCanModerate(isModerator);
+        setCanModerate(isCommunityModerator(community?.team, currentAccount.name));
       } catch (err) {
         setCanModerate(false);
       }

--- a/src/screens/chats/container/chatThreadContainer.tsx
+++ b/src/screens/chats/container/chatThreadContainer.tsx
@@ -664,6 +664,13 @@ export const ChatThreadContainer: React.FC<ChatThreadContainerProps> = ({
 
   // Resolve moderation status effect
   useEffect(() => {
+    // The lookup is async, so a pending request from a previous account or
+    // community can resolve after the deps change and grant moderation in a
+    // context it was never resolved for (logging out clears the flag, then a
+    // stale resolve sets it back to true). Ignore any result whose effect run
+    // has already been cleaned up.
+    let cancelled = false;
+
     const resolveModeration = async () => {
       if (!derivedCommunityIdentifier || !currentAccount?.name) {
         setCanModerate(false);
@@ -674,13 +681,22 @@ export const ChatThreadContainer: React.FC<ChatThreadContainerProps> = ({
         const community = await queryClient.fetchQuery(
           getCommunityQueryOptions(derivedCommunityIdentifier, currentAccount.name),
         );
+        if (cancelled) {
+          return;
+        }
         setCanModerate(isCommunityModerator(community?.team, currentAccount.name));
       } catch (err) {
-        setCanModerate(false);
+        if (!cancelled) {
+          setCanModerate(false);
+        }
       }
     };
 
     resolveModeration();
+
+    return () => {
+      cancelled = true;
+    };
   }, [currentAccount?.name, derivedCommunityIdentifier, queryClient]);
 
   // Detect and fetch link metadata when message changes

--- a/src/utils/communityModeration.test.ts
+++ b/src/utils/communityModeration.test.ts
@@ -1,0 +1,63 @@
+import { getCommunityRole, isCommunityModerator, MODERATOR_ROLES } from './communityModeration';
+
+// Shape mirrors what hivemind returns for `community.team`: [account, role, title].
+const TEAM = [
+  ['hive-125125', 'owner', ''],
+  ['alice', 'admin', 'Head mod'],
+  ['bob', 'mod', ''],
+  ['carol', 'member', ''],
+  ['dave', 'guest', ''],
+  ['erin', 'muted', ''],
+];
+
+describe('getCommunityRole', () => {
+  it('reads the role out of a positional tuple', () => {
+    expect(getCommunityRole(TEAM, 'alice')).toBe('admin');
+    expect(getCommunityRole(TEAM, 'bob')).toBe('mod');
+    expect(getCommunityRole(TEAM, 'erin')).toBe('muted');
+  });
+
+  it('returns undefined for an account that is not on the team', () => {
+    expect(getCommunityRole(TEAM, 'frank')).toBeUndefined();
+  });
+
+  it('returns undefined when team or username is missing', () => {
+    expect(getCommunityRole(undefined, 'alice')).toBeUndefined();
+    expect(getCommunityRole(TEAM, undefined)).toBeUndefined();
+    expect(getCommunityRole([], 'alice')).toBeUndefined();
+  });
+
+  it('does not match an account name against the role column', () => {
+    expect(getCommunityRole(TEAM, 'mod')).toBeUndefined();
+  });
+});
+
+describe('isCommunityModerator', () => {
+  it.each(MODERATOR_ROLES)('is true for %s', (role) => {
+    expect(isCommunityModerator([['alice', role, '']], 'alice')).toBe(true);
+  });
+
+  it.each(['member', 'guest', 'muted'])('is false for %s', (role) => {
+    expect(isCommunityModerator([['alice', role, '']], 'alice')).toBe(false);
+  });
+
+  it('is false for an account that is not on the team', () => {
+    expect(isCommunityModerator(TEAM, 'frank')).toBe(false);
+  });
+
+  it('is false when team or username is missing', () => {
+    expect(isCommunityModerator(undefined, 'alice')).toBe(false);
+    expect(isCommunityModerator(TEAM, undefined)).toBe(false);
+  });
+
+  it('is false for a malformed tuple rather than throwing', () => {
+    expect(isCommunityModerator([[], ['alice']] as string[][], 'alice')).toBe(false);
+  });
+
+  it('regression: object-shaped members are not treated as moderators', () => {
+    // The previous implementation read `member.account` / `member.role`, which
+    // are always undefined on a tuple. Guard against a revert to that shape.
+    const objectTeam = [{ account: 'alice', role: 'mod' }] as unknown as string[][];
+    expect(isCommunityModerator(objectTeam, 'alice')).toBe(false);
+  });
+});

--- a/src/utils/communityModeration.ts
+++ b/src/utils/communityModeration.ts
@@ -1,0 +1,36 @@
+import { ROLES } from '@ecency/sdk';
+import type { CommunityTeam } from '@ecency/sdk';
+
+// `CommunityTeam` is `Array<Array<string>>` - hivemind returns each team member
+// as a positional tuple, not an object. Reading `member.account` / `member.role`
+// yields `undefined` and silently disables every moderator gate, so all access
+// to the team goes through these helpers.
+const ACCOUNT_INDEX = 0;
+const ROLE_INDEX = 1;
+
+// Roles that carry moderation authority on chain. `member`, `guest` and `muted`
+// do not.
+export const MODERATOR_ROLES: string[] = [ROLES.OWNER, ROLES.ADMIN, ROLES.MOD];
+
+/**
+ * Returns the community role of `username`, or undefined when the account is
+ * not on the team.
+ */
+export const getCommunityRole = (team?: CommunityTeam, username?: string): string | undefined => {
+  if (!team || !username) {
+    return undefined;
+  }
+
+  return team.find((member) => member?.[ACCOUNT_INDEX] === username)?.[ROLE_INDEX];
+};
+
+/**
+ * True when `username` is an owner, admin or mod of the community.
+ *
+ * This gates UI affordances only. Hivemind replays the operation and is the
+ * only authority on whether the action is accepted, so a stale or missing team
+ * never grants more than it should - but it can wrongly withhold an action, and
+ * moderator authority does not depend on being subscribed.
+ */
+export const isCommunityModerator = (team?: CommunityTeam, username?: string): boolean =>
+  MODERATOR_ROLES.includes(getCommunityRole(team, username) ?? '');


### PR DESCRIPTION
Closes #3380

`community.team` is `CommunityTeam = Array<Array<string>>` (tuples of `[account, role, title]`), but `chatThreadContainer` read it as an array of objects:

```ts
const isModerator = team.some(
  (member: any) =>
    member?.account === currentAccount.name &&
    ['mod', 'admin', 'owner'].includes(member?.role as string),
);
```

`member?.account` and `member?.role` are always `undefined`, so `canModerate` was always `false`. Channel moderation (delete any message, pin/unpin) is shipped and gated behind that flag, so no community moderator could use it. The `as any` is what let it past type checking.

### Changes

- `src/utils/communityModeration.ts`: `getCommunityRole` and `isCommunityModerator`, indexing the tuple positionally and taking roles from the SDK `ROLES` constant instead of string literals.
- `src/utils/communityModeration.test.ts`: 14 tests, including a regression test asserting object-shaped members are not treated as moderators.
- `src/screens/chats/container/chatThreadContainer.tsx`: use the helper.

The helper is the shared moderator gate for the rest of the community moderation work (#3381, #3383), so it lands here rather than inline.

Behaviour is unchanged for non-moderators. Gating stays advisory either way, since hivemind and the chat server are the actual authorities.

### Testing

- `yarn test:ci`: 721 passed, 1 skipped, 48 suites.
- `yarn lint`: 0 errors.
