### PR TITLE
feat(ui): reusable moderation notes bottom sheet

### DIFF
--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -124,6 +124,7 @@ import { PostingAuthoritySheet } from './postingAuthoritySheet';
 import { HiveAuthBroadcastSheet } from './hiveAuthBroadcastSheet';
 import EmojiPickerSheet from './emojiPickerSheet';
 import { AuthUpgradeSheet } from './authUpgradeSheet';
+import { ModNotesSheet } from './modNotesSheet';
 import TransferFavoritesSheet from './transferFavoritesSheet/transferFavoritesSheet';
 
 // Basic UI Elements
@@ -304,5 +305,6 @@ export {
   HiveAuthBroadcastSheet,
   EmojiPickerSheet,
   AuthUpgradeSheet,
+  ModNotesSheet,
   TransferFavoritesSheet,
 };

--- a/src/components/modNotesSheet/index.ts
+++ b/src/components/modNotesSheet/index.ts
@@ -1,1 +1,2 @@
 export { default as ModNotesSheet } from './modNotesSheet';
+export type { ModNotesResult } from './modNotesSheet';

--- a/src/components/modNotesSheet/index.ts
+++ b/src/components/modNotesSheet/index.ts
@@ -1,0 +1,1 @@
+export { default as ModNotesSheet } from './modNotesSheet';

--- a/src/components/modNotesSheet/modNotesSheet.tsx
+++ b/src/components/modNotesSheet/modNotesSheet.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Text, TextInput, View } from 'react-native';
 import { useIntl } from 'react-intl';
 import ActionSheet, { SheetManager, SheetProps } from 'react-native-actions-sheet';
@@ -26,12 +26,24 @@ const ModNotesSheet: React.FC<SheetProps<'mod_notes'>> = ({ sheetId, payload }) 
 
   const maxLength = payload?.maxLength ?? DEFAULT_MAX_LENGTH;
 
-  // react-native-actions-sheet keeps registered sheets mounted, so without this
-  // the previous moderator's note would be prefilled on the next open.
-  useEffect(() => {
+  const _reset = useCallback(() => {
     closedRef.current = false;
     setValue('');
-  }, [payload]);
+  }, []);
+
+  // react-native-actions-sheet keeps registered sheets mounted, so without a
+  // reset the previous moderator's note would be prefilled on the next open and
+  // closedRef would still be true, leaving confirm and cancel unable to close
+  // the sheet at all.
+  //
+  // Resetting on `payload` identity alone is not enough: payload is optional
+  // and a caller may reopen with no payload or the same object, in which case
+  // the effect never re-runs. onBeforeShow fires on every presentation, so it
+  // is the authoritative reset; the effect covers a payload swap while the
+  // sheet is already open.
+  useEffect(() => {
+    _reset();
+  }, [payload, _reset]);
 
   const _close = (result: string | false) => {
     if (closedRef.current) {
@@ -54,6 +66,7 @@ const ModNotesSheet: React.FC<SheetProps<'mod_notes'>> = ({ sheetId, payload }) 
       id={sheetId || FALLBACK_SHEET_ID}
       gestureEnabled
       closeOnTouchBackdrop
+      onBeforeShow={_reset}
       containerStyle={styles.sheetContainer}
     >
       <View style={styles.container}>

--- a/src/components/modNotesSheet/modNotesSheet.tsx
+++ b/src/components/modNotesSheet/modNotesSheet.tsx
@@ -1,0 +1,153 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { Text, TextInput, View } from 'react-native';
+import { useIntl } from 'react-intl';
+import ActionSheet, { SheetManager, SheetProps } from 'react-native-actions-sheet';
+import EStyleSheet from 'react-native-extended-stylesheet';
+import { MainButton } from '../mainButton';
+
+const FALLBACK_SHEET_ID = 'mod_notes';
+
+// Hivemind stores the note on the moderation action itself. Web caps the same
+// field at 120 characters, so keep the two clients consistent.
+const DEFAULT_MAX_LENGTH = 120;
+
+/**
+ * Prompts a moderator for the free-text reason that community moderation
+ * operations carry (mutePost/unmutePost take a required `notes` field).
+ *
+ * Resolves the `SheetManager.show` promise with the trimmed note, or `false`
+ * when the moderator backs out. Backdrop dismissal resolves `undefined`, so
+ * callers should treat any falsy result as a cancellation.
+ */
+const ModNotesSheet: React.FC<SheetProps<'mod_notes'>> = ({ sheetId, payload }) => {
+  const intl = useIntl();
+  const [value, setValue] = useState('');
+  const closedRef = useRef(false);
+
+  const maxLength = payload?.maxLength ?? DEFAULT_MAX_LENGTH;
+
+  // react-native-actions-sheet keeps registered sheets mounted, so without this
+  // the previous moderator's note would be prefilled on the next open.
+  useEffect(() => {
+    closedRef.current = false;
+    setValue('');
+  }, [payload]);
+
+  const _close = (result: string | false) => {
+    if (closedRef.current) {
+      return;
+    }
+    closedRef.current = true;
+    SheetManager.hide(sheetId || FALLBACK_SHEET_ID, { payload: result });
+  };
+
+  const _handleConfirm = () => {
+    const notes = value.trim();
+    if (!notes) {
+      return;
+    }
+    _close(notes);
+  };
+
+  return (
+    <ActionSheet
+      id={sheetId || FALLBACK_SHEET_ID}
+      gestureEnabled
+      closeOnTouchBackdrop
+      containerStyle={styles.sheetContainer}
+    >
+      <View style={styles.container}>
+        <Text style={styles.title}>
+          {payload?.title || intl.formatMessage({ id: 'mod_notes.title' })}
+        </Text>
+
+        {!!payload?.description && <Text style={styles.description}>{payload.description}</Text>}
+
+        <TextInput
+          style={styles.input}
+          placeholder={payload?.placeholder || intl.formatMessage({ id: 'mod_notes.placeholder' })}
+          placeholderTextColor={EStyleSheet.value('$primaryDarkGray')}
+          autoCapitalize="sentences"
+          autoCorrect
+          autoFocus
+          value={value}
+          onChangeText={setValue}
+          maxLength={maxLength}
+          returnKeyType="done"
+          onSubmitEditing={_handleConfirm}
+        />
+
+        <Text style={styles.counter}>{`${value.length} / ${maxLength}`}</Text>
+
+        <MainButton
+          onPress={_handleConfirm}
+          isDisable={!value.trim()}
+          text={payload?.confirmLabel || intl.formatMessage({ id: 'mod_notes.confirm' })}
+          style={styles.confirmButton}
+        />
+
+        <MainButton
+          onPress={() => _close(false)}
+          text={intl.formatMessage({ id: 'mod_notes.cancel' })}
+          style={styles.cancelButton}
+          textStyle={styles.cancelButtonText}
+        />
+      </View>
+    </ActionSheet>
+  );
+};
+
+const styles = EStyleSheet.create({
+  sheetContainer: {
+    paddingHorizontal: 0,
+    backgroundColor: '$primaryBackgroundColor',
+  },
+  container: {
+    paddingHorizontal: 20,
+    paddingVertical: 24,
+    paddingBottom: 40,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    color: '$primaryBlack',
+    textAlign: 'center',
+    marginBottom: 8,
+  },
+  description: {
+    fontSize: 15,
+    color: '$primaryDarkGray',
+    textAlign: 'center',
+    marginBottom: 16,
+    lineHeight: 22,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '$primaryLightGray',
+    borderRadius: 8,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    fontSize: 15,
+    color: '$primaryBlack',
+    backgroundColor: '$primaryLightBackground',
+  },
+  counter: {
+    fontSize: 12,
+    color: '$primaryDarkGray',
+    textAlign: 'right',
+    marginTop: 6,
+    marginBottom: 12,
+  },
+  confirmButton: {
+    marginBottom: 0,
+  },
+  cancelButton: {
+    backgroundColor: 'transparent',
+    marginTop: 8,
+  },
+  cancelButtonText: {
+    color: '$primaryDarkGray',
+  },
+});
+
+export default ModNotesSheet;

--- a/src/components/modNotesSheet/modNotesSheet.tsx
+++ b/src/components/modNotesSheet/modNotesSheet.tsx
@@ -7,6 +7,18 @@ import { MainButton } from '../mainButton';
 
 const FALLBACK_SHEET_ID = 'mod_notes';
 
+/**
+ * Result of the sheet. Both variants are objects because
+ * react-native-actions-sheet 0.9.7 publishes `data || payloadRef.current` on
+ * close (dist/src/index.js:403), so a falsy return value is silently replaced
+ * by the original payload object. Any `false`/`undefined`/`''` contract would
+ * therefore reach the caller as a truthy object and read as a confirmation.
+ */
+export interface ModNotesResult {
+  notes?: string;
+  cancelled?: boolean;
+}
+
 // Hivemind stores the note on the moderation action itself. Web caps the same
 // field at 120 characters, so keep the two clients consistent.
 const DEFAULT_MAX_LENGTH = 120;
@@ -15,9 +27,10 @@ const DEFAULT_MAX_LENGTH = 120;
  * Prompts a moderator for the free-text reason that community moderation
  * operations carry (mutePost/unmutePost take a required `notes` field).
  *
- * Resolves the `SheetManager.show` promise with the trimmed note, or `false`
- * when the moderator backs out. Backdrop dismissal resolves `undefined`, so
- * callers should treat any falsy result as a cancellation.
+ * Resolves the `SheetManager.show` promise with `{ notes }` on confirm and
+ * `{ cancelled: true }` on an explicit cancel. Dismissing by backdrop, swipe or
+ * back button resolves the original payload object instead (see ModNotesResult),
+ * so callers must gate on a string `notes` rather than on truthiness.
  */
 const ModNotesSheet: React.FC<SheetProps<'mod_notes'>> = ({ sheetId, payload }) => {
   const intl = useIntl();
@@ -45,7 +58,7 @@ const ModNotesSheet: React.FC<SheetProps<'mod_notes'>> = ({ sheetId, payload }) 
     _reset();
   }, [payload, _reset]);
 
-  const _close = (result: string | false) => {
+  const _close = (result: ModNotesResult) => {
     if (closedRef.current) {
       return;
     }
@@ -58,7 +71,7 @@ const ModNotesSheet: React.FC<SheetProps<'mod_notes'>> = ({ sheetId, payload }) 
     if (!notes) {
       return;
     }
-    _close(notes);
+    _close({ notes });
   };
 
   return (
@@ -100,7 +113,7 @@ const ModNotesSheet: React.FC<SheetProps<'mod_notes'>> = ({ sheetId, payload }) 
         />
 
         <MainButton
-          onPress={() => _close(false)}
+          onPress={() => _close({ cancelled: true })}
           text={intl.formatMessage({ id: 'mod_notes.cancel' })}
           style={styles.cancelButton}
           textStyle={styles.cancelButtonText}

--- a/src/config/locales/en-US.json
+++ b/src/config/locales/en-US.json
@@ -1747,5 +1747,11 @@
     "blog_post_desc": "Create a full blog post in the editor",
     "wave": "Wave",
     "wave_desc": "Share a quick update"
+  },
+  "mod_notes": {
+    "title": "Add a reason",
+    "placeholder": "Reason (visible to other moderators)",
+    "confirm": "Confirm",
+    "cancel": "Cancel"
   }
 }

--- a/src/navigation/sheets.tsx
+++ b/src/navigation/sheets.tsx
@@ -17,6 +17,7 @@ import {
   AiAssistModal,
   ComposeTranslateModal,
   TransferFavoritesSheet,
+  ModNotesSheet,
 } from '../components';
 import { ShareIntentSheet } from '../components/shareIntentSheet';
 import SignConfirmSheet from '../screens/dappBrowser/components/signConfirmSheet';
@@ -49,6 +50,7 @@ export enum SheetNames {
   RECEIVE_QR = 'receive_qr',
   BALANCE_ANALYTICS = 'balance_analytics',
   TRANSFER_FAVORITES = 'transfer_favorites',
+  MOD_NOTES = 'mod_notes',
 }
 
 registerSheet(SheetNames.POST_TRANSLATION, PostTranslationModal);
@@ -73,6 +75,7 @@ registerSheet(SheetNames.SIGN_CONFIRM, SignConfirmSheet);
 registerSheet(SheetNames.RECEIVE_QR, ReceiveQrSheet);
 registerSheet(SheetNames.BALANCE_ANALYTICS, BalanceAnalyticsSheet);
 registerSheet(SheetNames.TRANSFER_FAVORITES, TransferFavoritesSheet);
+registerSheet(SheetNames.MOD_NOTES, ModNotesSheet);
 
 // We extend some of the types here to give us great intellisense
 // across the app for all registered sheets.
@@ -226,6 +229,19 @@ declare module 'react-native-actions-sheet' {
         limit?: number;
       };
       returnValue: string | undefined;
+    }>;
+    [SheetNames.MOD_NOTES]: SheetDefinition<{
+      payload?: {
+        title?: string;
+        description?: string;
+        placeholder?: string;
+        maxLength?: number;
+        confirmLabel?: string;
+      };
+      // Trimmed note on confirm, false on explicit cancel. Backdrop dismissal
+      // resolves undefined, so callers should treat any falsy value as a
+      // cancellation.
+      returnValue: string | false | undefined;
     }>;
   }
 }

--- a/src/navigation/sheets.tsx
+++ b/src/navigation/sheets.tsx
@@ -19,6 +19,7 @@ import {
   TransferFavoritesSheet,
   ModNotesSheet,
 } from '../components';
+import type { ModNotesResult } from '../components/modNotesSheet/modNotesSheet';
 import { ShareIntentSheet } from '../components/shareIntentSheet';
 import SignConfirmSheet from '../screens/dappBrowser/components/signConfirmSheet';
 import ReceiveQrSheet from '../components/receiveQrSheet/receiveQrSheet';
@@ -238,10 +239,12 @@ declare module 'react-native-actions-sheet' {
         maxLength?: number;
         confirmLabel?: string;
       };
-      // Trimmed note on confirm, false on explicit cancel. Backdrop dismissal
-      // resolves undefined, so callers should treat any falsy value as a
-      // cancellation.
-      returnValue: string | false | undefined;
+      // `{ notes }` on confirm, `{ cancelled: true }` on explicit cancel.
+      // Dismissing by backdrop, swipe or back button resolves the payload
+      // object instead, because the library publishes
+      // `data || payloadRef.current` on close. Gate on a string `notes`, never
+      // on truthiness.
+      returnValue: ModNotesResult | undefined;
     }>;
   }
 }


### PR DESCRIPTION
Closes #3382

Community moderation operations carry a required free-text note (`mutePost` and `unmutePost` both take one), and nothing in the app prompts for free text today. #3383 needs this first.

Web's equivalent is the modal in `apps/web/src/features/shared/mute-btn/index.tsx`: single-line input, 120 character cap, confirm disabled while empty.

### Changes

- `src/components/modNotesSheet/`: the sheet. Confirm is disabled until the value is non-empty after trimming, and `SheetManager.show` resolves with the trimmed note or `false` on cancel.
- `src/navigation/sheets.tsx`: `SheetNames.MOD_NOTES`, `registerSheet`, and the `Sheets` type declaration.
- `src/components/index.tsx`: barrel import and export.
- `src/config/locales/en-US.json`: `mod_notes` block. Title, placeholder and confirm label are all overridable per call site so callers can phrase mute vs unmute differently without new keys.

State resets in `useEffect(..., [payload])` because registered sheets stay mounted, otherwise the previous moderator's note would be prefilled on the next open. The return type is `string | false | undefined`, since backdrop dismissal resolves `undefined` rather than `false`.

No call sites yet. #3383 is the first consumer.

### Testing

- `yarn test:ci`: 707 passed, 1 skipped, 47 suites.
- `yarn lint`: 0 errors.

Screenshots to follow once #3383 wires it to a real action.
