### PR TITLE
feat(editor): dictate posts from the mobile editor toolbar

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.CAMERA"/>
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="com.android.vending.BILLING" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.DOWNLOAD_WITHOUT_NOTIFICATION" />

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -49,6 +49,28 @@ jest.mock('@react-native-async-storage/async-storage', () =>
 );
 
 // Mock Expo crypto
+// expo-audio is a native module: importing it unmocked fails any test that reaches
+// the dictation sheet. Mirrors the shape useDictationRecorder actually consumes.
+jest.mock('expo-audio', () => ({
+  RecordingPresets: { HIGH_QUALITY: {} },
+  requestRecordingPermissionsAsync: jest.fn(async () => ({ granted: true })),
+  setAudioModeAsync: jest.fn(async () => undefined),
+  useAudioRecorder: jest.fn(() => ({
+    isRecording: false,
+    uri: null,
+    record: jest.fn(),
+    stop: jest.fn(async () => undefined),
+    prepareToRecordAsync: jest.fn(async () => undefined),
+  })),
+  useAudioRecorderState: jest.fn(() => ({
+    canRecord: true,
+    isRecording: false,
+    durationMillis: 0,
+    mediaServicesDidReset: false,
+    url: null,
+  })),
+}));
+
 jest.mock('expo-crypto', () => ({
   digestStringAsync: jest.fn(),
 }));

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "domain-browser": "^5.7.0",
     "events": "^1.0.0",
     "expo": "^53.0.20",
+    "expo-audio": "~0.4.9",
     "expo-crypto": "~14.1.5",
     "expo-iap": "^4.6.0",
     "expo-image": "~2.4.0",

--- a/src/components/dictationModal/dictationModal.styles.ts
+++ b/src/components/dictationModal/dictationModal.styles.ts
@@ -1,0 +1,91 @@
+import { ViewStyle, TextStyle } from 'react-native';
+import EStyleSheet from 'react-native-extended-stylesheet';
+
+export default EStyleSheet.create({
+  sheetContent: {
+    backgroundColor: '$primaryBackgroundColor',
+    borderTopLeftRadius: 16,
+    borderTopRightRadius: 16,
+  } as ViewStyle,
+
+  container: {
+    paddingHorizontal: 16,
+    paddingBottom: 24,
+    paddingTop: 16,
+    alignItems: 'center',
+  } as ViewStyle,
+
+  title: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: '$primaryBlack',
+    marginBottom: 8,
+  } as TextStyle,
+
+  clock: {
+    fontSize: 40,
+    fontWeight: '300',
+    color: '$primaryBlack',
+    // Tabular figures so the timer does not jitter as digits change width.
+    fontVariant: ['tabular-nums'],
+    marginVertical: 8,
+  } as TextStyle,
+
+  recordingRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 8,
+  } as ViewStyle,
+
+  recordingDot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+    backgroundColor: '$primaryRed',
+    marginRight: 6,
+  } as ViewStyle,
+
+  recordingLabel: {
+    fontSize: 14,
+    color: '$primaryRed',
+  } as TextStyle,
+
+  cost: {
+    fontSize: 14,
+    color: '$primaryDarkGray',
+    marginBottom: 4,
+  } as TextStyle,
+
+  hint: {
+    fontSize: 12,
+    color: '$primaryDarkGray',
+  } as TextStyle,
+
+  error: {
+    fontSize: 14,
+    color: '$primaryRed',
+    textAlign: 'center',
+    marginBottom: 8,
+  } as TextStyle,
+
+  retryButton: {
+    alignSelf: 'center',
+    marginBottom: 8,
+  } as ViewStyle,
+
+  actions: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    marginTop: 16,
+  } as ViewStyle,
+
+  button: {
+    marginHorizontal: 6,
+  } as ViewStyle,
+
+  transcribingRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginTop: 12,
+  } as ViewStyle,
+});

--- a/src/components/dictationModal/dictationModal.tsx
+++ b/src/components/dictationModal/dictationModal.tsx
@@ -149,6 +149,13 @@ export const DictationModal = ({ payload }: SheetProps<SheetNames.DICTATION>) =>
           <Text style={styles.error}>{intl.formatMessage({ id: 'dictation.denied' })}</Text>
         )}
 
+        {state === 'failed' && (
+          // Distinct from 'denied': nothing was refused, the audio session or recorder
+          // itself failed, so retrying is worth offering rather than sending the user
+          // to Settings.
+          <Text style={styles.error}>{intl.formatMessage({ id: 'dictation.error_recorder' })}</Text>
+        )}
+
         {isPriceError && (
           <View>
             <Text style={styles.error}>{intl.formatMessage({ id: 'dictation.price_error' })}</Text>

--- a/src/components/dictationModal/dictationModal.tsx
+++ b/src/components/dictationModal/dictationModal.tsx
@@ -1,0 +1,228 @@
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
+import { ActivityIndicator, Alert, Text, View } from 'react-native';
+import { useIntl } from 'react-intl';
+import ActionSheet, { SheetManager, SheetProps } from 'react-native-actions-sheet';
+import { useQuery } from '@tanstack/react-query';
+import { getAiTranscribePriceQueryOptions, useAiTranscribe } from '@ecency/sdk';
+import { useAuth } from '../../hooks';
+import { useDictationRecorder } from '../../hooks/useDictationRecorder';
+import { SheetNames } from '../../navigation/sheets';
+import { MainButton } from '..';
+import styles from './dictationModal.styles';
+
+const DEFAULT_MAX_SECONDS = 300;
+
+function formatClock(totalSeconds: number) {
+  const m = Math.floor(totalSeconds / 60);
+  const s = totalSeconds % 60;
+  return `${m}:${s.toString().padStart(2, '0')}`;
+}
+
+/**
+ * Dictation: record, see the cost while recording, insert the transcript.
+ *
+ * Billing is metered per 30s block, so the cost shown has to match the server's
+ * arithmetic exactly -- rounding up to whole units, minimum one unit, and a free
+ * allowance that discounts units rather than whole clips. All of those numbers come
+ * from the price endpoint so a pricing change does not need an app release.
+ */
+export const DictationModal = ({ payload }: SheetProps<SheetNames.DICTATION>) => {
+  const intl = useIntl();
+  const { username, code } = useAuth();
+
+  const {
+    data: price,
+    isLoading: isPriceLoading,
+    isError: isPriceError,
+    refetch: refetchPrice,
+  } = useQuery(getAiTranscribePriceQueryOptions(username, code ?? ''));
+
+  const { mutateAsync: transcribe, isPending: isTranscribing } = useAiTranscribe(username, code);
+
+  const maxSeconds = price?.max_seconds ?? DEFAULT_MAX_SECONDS;
+  const { state, seconds, result, start, stop, reset } = useDictationRecorder({ maxSeconds });
+
+  // One key per recording, reused across retries. A retry after a lost response must
+  // replay the finished transcription rather than pay for a second one.
+  const idempotencyKeyRef = useRef<string | null>(null);
+  const closedRef = useRef(false);
+
+  const isPriceReady = !!price && !isPriceLoading && !isPriceError;
+
+  const estimatedCost = useMemo(() => {
+    if (!isPriceReady) {
+      return 0;
+    }
+    const units = Math.max(1, Math.ceil(seconds / price!.unit_seconds));
+    const billable = Math.max(0, units - (price!.free_remaining ?? 0));
+    return billable * price!.unit_cost;
+  }, [isPriceReady, seconds, price]);
+
+  const close = useCallback(() => {
+    closedRef.current = true;
+    reset();
+    idempotencyKeyRef.current = null;
+    SheetManager.hide(SheetNames.DICTATION);
+  }, [reset]);
+
+  // A new recording is a different operation and gets a fresh key.
+  useEffect(() => {
+    if (state === 'recording') {
+      idempotencyKeyRef.current = null;
+    }
+  }, [state]);
+
+  useEffect(
+    () => () => {
+      closedRef.current = true;
+    },
+    [],
+  );
+
+  const submit = useCallback(async () => {
+    if (!result || isTranscribing) {
+      return;
+    }
+
+    if (!idempotencyKeyRef.current) {
+      // Matches the backend validator [A-Za-z0-9_-]{8,64}.
+      idempotencyKeyRef.current = `m${Date.now()}${Math.random().toString(36).slice(2, 10)}`;
+    }
+
+    try {
+      const response = await transcribe({
+        audio: { uri: result.uri, name: 'dictation.m4a', type: 'audio/m4a' } as any,
+        durationMs: result.durationMs,
+        fileName: 'dictation.m4a',
+        idempotency_key: idempotencyKeyRef.current,
+      });
+
+      if (closedRef.current) {
+        return;
+      }
+
+      if (!response.text.trim()) {
+        // A silent clip still costs Points, so say so rather than closing as if it worked.
+        Alert.alert(
+          intl.formatMessage({ id: 'alert.fail' }),
+          intl.formatMessage({ id: 'dictation.error_empty' }),
+        );
+        return;
+      }
+
+      payload?.onInsert?.(response.text);
+      close();
+    } catch (err: any) {
+      if (closedRef.current) {
+        return;
+      }
+      const status = err?.status;
+      const id =
+        status === 402
+          ? 'dictation.error_insufficient_points'
+          : status === 429
+          ? 'dictation.error_rate_limited'
+          : status === 400
+          ? 'dictation.error_too_long'
+          : 'dictation.error_failed';
+      Alert.alert(intl.formatMessage({ id: 'alert.fail' }), intl.formatMessage({ id }));
+      // The key is kept deliberately so a retry replays instead of re-charging.
+    }
+  }, [result, isTranscribing, transcribe, payload, close, intl]);
+
+  return (
+    <ActionSheet
+      id={SheetNames.DICTATION}
+      gestureEnabled={!isTranscribing}
+      closeOnPressBack={!isTranscribing}
+      closeOnTouchBackdrop={!isTranscribing}
+      onClose={() => {
+        closedRef.current = true;
+        reset();
+      }}
+      containerStyle={styles.sheetContent}
+    >
+      <View style={styles.container}>
+        <Text style={styles.title}>{intl.formatMessage({ id: 'dictation.title' })}</Text>
+
+        {state === 'denied' && (
+          <Text style={styles.error}>{intl.formatMessage({ id: 'dictation.denied' })}</Text>
+        )}
+
+        {isPriceError && (
+          <View>
+            <Text style={styles.error}>{intl.formatMessage({ id: 'dictation.price_error' })}</Text>
+            <MainButton
+              style={styles.retryButton}
+              onPress={() => refetchPrice()}
+              text={intl.formatMessage({ id: 'alert.try_again' })}
+            />
+          </View>
+        )}
+
+        <Text style={styles.clock}>{formatClock(seconds)}</Text>
+
+        {state === 'recording' && (
+          <View style={styles.recordingRow}>
+            <View style={styles.recordingDot} />
+            <Text style={styles.recordingLabel}>
+              {intl.formatMessage({ id: 'dictation.recording' })}
+            </Text>
+          </View>
+        )}
+
+        <Text style={styles.cost}>
+          {!isPriceReady
+            ? intl.formatMessage({ id: 'dictation.price_loading' })
+            : estimatedCost > 0
+            ? intl.formatMessage({ id: 'dictation.cost' }, { n: estimatedCost })
+            : intl.formatMessage({ id: 'dictation.free' })}
+        </Text>
+
+        {isPriceReady && (
+          <Text style={styles.hint}>
+            {intl.formatMessage({ id: 'dictation.max' }, { n: Math.floor(maxSeconds / 60) })}
+          </Text>
+        )}
+
+        <View style={styles.actions}>
+          {state === 'recording' ? (
+            <MainButton
+              style={styles.button}
+              onPress={stop}
+              iconName="stop"
+              iconType="MaterialIcons"
+              text={intl.formatMessage({ id: 'dictation.stop' })}
+            />
+          ) : (
+            <MainButton
+              style={styles.button}
+              isDisabled={state === 'requesting' || isTranscribing || !isPriceReady}
+              onPress={start}
+              iconName="mic"
+              iconType="MaterialIcons"
+              text={intl.formatMessage({
+                id: result ? 'dictation.rerecord' : 'dictation.start',
+              })}
+            />
+          )}
+
+          <MainButton
+            style={styles.button}
+            isDisabled={!result || isTranscribing || !isPriceReady}
+            isLoading={isTranscribing}
+            onPress={submit}
+            text={intl.formatMessage({ id: 'dictation.insert' })}
+          />
+        </View>
+
+        {isTranscribing && (
+          <View style={styles.transcribingRow}>
+            <ActivityIndicator />
+            <Text style={styles.hint}>{intl.formatMessage({ id: 'dictation.transcribing' })}</Text>
+          </View>
+        )}
+      </View>
+    </ActionSheet>
+  );
+};

--- a/src/components/dictationModal/index.ts
+++ b/src/components/dictationModal/index.ts
@@ -1,0 +1,1 @@
+export { DictationModal } from './dictationModal';

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -116,6 +116,7 @@ import { WalkthroughMarker } from './walkthroughMarker';
 import { LinkPreview, HiveLinkPreview } from './linkPreview';
 import { CrossPostModal } from './crossPostModal';
 import { AiAssistModal } from './aiAssistModal';
+import { DictationModal } from './dictationModal';
 import { ComposeTranslateModal } from './composeTranslateModal';
 import { ChatOptionsSheet } from './chatOptionsSheet';
 import { ChatChannelOptionsSheet } from './chatChannelOptionsSheet';
@@ -295,6 +296,7 @@ export {
   HiveLinkPreview,
   CrossPostModal,
   AiAssistModal,
+  DictationModal,
   ComposeTranslateModal,
   CopyModal,
   ChatOptionsSheet,

--- a/src/components/markdownEditor/children/editorToolbar.tsx
+++ b/src/components/markdownEditor/children/editorToolbar.tsx
@@ -71,6 +71,7 @@ type Props = {
   handleAiAssistResult?: (output: string, action: string) => void;
   handleAiToolUsed?: (key: string) => void;
   handleShowTranslate?: () => void;
+  handleOnDictationResult?: (text: string) => void;
 };
 
 export const EditorToolbar = ({
@@ -93,6 +94,7 @@ export const EditorToolbar = ({
   handleShowSnippets,
   handleAiAssistResult,
   handleShowTranslate,
+  handleOnDictationResult,
 }: Props) => {
   const navigation = useNavigation();
   const insets = useSafeAreaInsets();
@@ -219,6 +221,14 @@ export const EditorToolbar = ({
 
   const _openPerks = () => {
     navigation.navigate(ROUTES.SCREENS.PERKS);
+  };
+
+  const _showDictation = () => {
+    SheetManager.show(SheetNames.DICTATION, {
+      payload: {
+        onInsert: (text: string) => handleOnDictationResult?.(text),
+      },
+    });
   };
 
   const _showAiAssist = () => {
@@ -581,6 +591,17 @@ export const EditorToolbar = ({
               iconStyle={styles.icon}
               iconType="MaterialCommunityIcons"
               name="video-outline"
+            />
+            <IconButton
+              onPress={_showDictation}
+              style={styles.rightIcons}
+              size={22}
+              iconStyle={styles.icon}
+              iconType="MaterialCommunityIcons"
+              name="microphone-outline"
+              badgeCount="AI"
+              badgeStyle={styles.aiBadge}
+              badgeTextStyle={styles.aiBadgeText}
             />
           </ScrollView>
 

--- a/src/components/markdownEditor/view/markdownEditorView.tsx
+++ b/src/components/markdownEditor/view/markdownEditorView.tsx
@@ -394,6 +394,20 @@ const MarkdownEditorView = ({
     insertLinkModalRef.current?.hideModal();
   };
 
+  // Dictated text goes in at the caret, like a snippet -- not replacing the body the
+  // way the AI assist edit actions do. Someone dictating mid-draft is adding to it.
+  const _handleDictationResult = useCallback(
+    (text: string) => {
+      applySnippet({
+        text: bodyTextRef.current,
+        selection: bodySelectionRef.current,
+        setTextAndSelection: _setTextAndSelection,
+        snippetText: text,
+      });
+    },
+    [_setTextAndSelection],
+  );
+
   const _handleAiAssistResult = useCallback(
     (output: string, action: string) => {
       if (action === 'improve' || action === 'check_grammar' || action === 'summarize') {
@@ -581,6 +595,7 @@ const MarkdownEditorView = ({
           handleShowSnippets={() => setIsSnippetsOpen(true)}
           handleOnClearPress={() => clearRef.current.show()}
           handleAiAssistResult={_handleAiAssistResult}
+          handleOnDictationResult={_handleDictationResult}
           handleShowTranslate={_showTranslateModal}
           handleOnMarkupButtonPress={(item) => {
             item.onPress({

--- a/src/config/locales/en-US.json
+++ b/src/config/locales/en-US.json
@@ -1159,7 +1159,8 @@
     "error_insufficient_points": "Not enough Points to transcribe that recording.",
     "error_rate_limited": "Too many recordings for now. Please try again shortly.",
     "error_too_long": "That recording is too long to transcribe.",
-    "error_failed": "Could not transcribe that recording. Please try again."
+    "error_failed": "Could not transcribe that recording. Please try again.",
+    "error_recorder": "Could not start recording. Please try again."
   },
   "wallet": {
     "delegations_out": "Delegations Out",

--- a/src/config/locales/en-US.json
+++ b/src/config/locales/en-US.json
@@ -1141,6 +1141,26 @@
     "btn_register": "Register Free",
     "title": "Free Account"
   },
+  "dictation": {
+    "title": "Dictate",
+    "start": "Record",
+    "stop": "Stop",
+    "rerecord": "Record again",
+    "insert": "Insert",
+    "recording": "Recording",
+    "transcribing": "Transcribing",
+    "cost": "{n} Points",
+    "free": "Free",
+    "max": "Up to {n} minutes",
+    "price_loading": "Checking price",
+    "price_error": "Could not load transcription pricing.",
+    "denied": "Ecency needs microphone access to dictate. Allow it in Settings and try again.",
+    "error_empty": "No speech was detected in that recording.",
+    "error_insufficient_points": "Not enough Points to transcribe that recording.",
+    "error_rate_limited": "Too many recordings for now. Please try again shortly.",
+    "error_too_long": "That recording is too long to transcribe.",
+    "error_failed": "Could not transcribe that recording. Please try again."
+  },
   "wallet": {
     "delegations_out": "Delegations Out",
     "estimated_value_desc": "According to purchase value",

--- a/src/hooks/useDictationRecorder.ts
+++ b/src/hooks/useDictationRecorder.ts
@@ -1,0 +1,117 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  RecordingPresets,
+  requestRecordingPermissionsAsync,
+  setAudioModeAsync,
+  useAudioRecorder,
+  useAudioRecorderState,
+} from 'expo-audio';
+
+export type DictationRecorderState = 'idle' | 'requesting' | 'recording' | 'stopped' | 'denied';
+
+interface Options {
+  /** Server cap. Recording stops itself before this rather than being rejected after upload. */
+  maxSeconds: number;
+}
+
+/**
+ * Microphone recording for dictation, on top of expo-audio.
+ *
+ * HIGH_QUALITY records AAC in an .m4a container on both platforms, which the
+ * transcription backend accepts directly -- no transcode, and no dependence on
+ * whatever container a given OS version happens to prefer.
+ */
+export function useDictationRecorder({ maxSeconds }: Options) {
+  const recorder = useAudioRecorder(RecordingPresets.HIGH_QUALITY);
+  // 250ms so the timer and the running cost read as live without spinning.
+  const recorderState = useAudioRecorderState(recorder, 250);
+
+  const [state, setState] = useState<DictationRecorderState>('idle');
+  const [result, setResult] = useState<{ uri: string; durationMs: number } | null>(null);
+
+  // Bumped by every reset/unmount. start() captures the value it began with, so a
+  // permission prompt answered after the sheet closed can tell it is stale instead
+  // of opening a microphone with no UI left to stop it.
+  const generationRef = useRef(0);
+
+  const durationMs = recorderState.durationMillis ?? 0;
+  // Round UP: the server bills whole units off the real duration, so flooring would
+  // quote one unit for a clip that crosses into two.
+  const seconds = Math.ceil(durationMs / 1000);
+
+  const stop = useCallback(async () => {
+    if (!recorder.isRecording) {
+      return;
+    }
+    const elapsed = recorderState.durationMillis ?? 0;
+    await recorder.stop();
+    setResult(recorder.uri ? { uri: recorder.uri, durationMs: elapsed } : null);
+    setState('stopped');
+  }, [recorder, recorderState.durationMillis]);
+
+  const start = useCallback(async () => {
+    setResult(null);
+    setState('requesting');
+
+    const generation = generationRef.current;
+
+    const permission = await requestRecordingPermissionsAsync();
+    if (generation !== generationRef.current) {
+      // Superseded while the OS prompt was open.
+      return;
+    }
+    if (!permission.granted) {
+      setState('denied');
+      return;
+    }
+
+    // iOS records nothing unless the session allows it, and stays muted by the
+    // hardware silent switch without playsInSilentMode.
+    await setAudioModeAsync({ allowsRecording: true, playsInSilentMode: true });
+    if (generation !== generationRef.current) {
+      return;
+    }
+
+    await recorder.prepareToRecordAsync();
+    if (generation !== generationRef.current) {
+      return;
+    }
+
+    recorder.record();
+    setState('recording');
+  }, [recorder]);
+
+  const reset = useCallback(() => {
+    generationRef.current += 1;
+    if (recorder.isRecording) {
+      recorder.stop();
+    }
+    setResult(null);
+    setState('idle');
+  }, [recorder]);
+
+  // Stop itself at the cap. Without this a forgotten recording is only rejected
+  // once the user has already waited through the upload.
+  useEffect(() => {
+    if (state === 'recording' && durationMs >= (maxSeconds - 1) * 1000) {
+      stop();
+    }
+  }, [state, durationMs, maxSeconds, stop]);
+
+  // Leaving the screen mid-recording would otherwise keep the microphone open with
+  // no UI left able to close it.
+  useEffect(
+    () => () => {
+      generationRef.current += 1;
+      if (recorder.isRecording) {
+        recorder.stop();
+      }
+      setAudioModeAsync({ allowsRecording: false }).catch(() => {
+        // Restoring the audio mode is best-effort; failing it must not crash unmount.
+      });
+    },
+    [recorder],
+  );
+
+  return { state, seconds, durationMs, result, start, stop, reset };
+}

--- a/src/hooks/useDictationRecorder.ts
+++ b/src/hooks/useDictationRecorder.ts
@@ -7,7 +7,17 @@ import {
   useAudioRecorderState,
 } from 'expo-audio';
 
-export type DictationRecorderState = 'idle' | 'requesting' | 'recording' | 'stopped' | 'denied';
+export type DictationRecorderState =
+  | 'idle'
+  | 'requesting'
+  | 'recording'
+  | 'stopped'
+  | 'denied'
+  // A native call rejected. Distinct from 'denied' because the user did not refuse
+  // anything -- the audio session or the recorder itself failed, and retrying is
+  // reasonable. Without it a rejection stranded the hook in 'requesting' or
+  // 'recording' with its button disabled and no way out but closing the sheet.
+  | 'failed';
 
 interface Options {
   /** Server cap. Recording stops itself before this rather than being rejected after upload. */
@@ -43,8 +53,18 @@ export function useDictationRecorder({ maxSeconds }: Options) {
     if (!recorder.isRecording) {
       return;
     }
+    // Read the duration BEFORE stopping: the recorder resets it, and this is what
+    // the charge is quoted from.
     const elapsed = recorderState.durationMillis ?? 0;
-    await recorder.stop();
+    try {
+      await recorder.stop();
+    } catch {
+      // Leaving state as 'recording' would strand the sheet: the stop button stays
+      // up but no longer works, and there is no recording to submit either.
+      setResult(null);
+      setState('failed');
+      return;
+    }
     setResult(recorder.uri ? { uri: recorder.uri, durationMs: elapsed } : null);
     setState('stopped');
   }, [recorder, recorderState.durationMillis]);
@@ -55,36 +75,52 @@ export function useDictationRecorder({ maxSeconds }: Options) {
 
     const generation = generationRef.current;
 
-    const permission = await requestRecordingPermissionsAsync();
-    if (generation !== generationRef.current) {
-      // Superseded while the OS prompt was open.
-      return;
-    }
-    if (!permission.granted) {
-      setState('denied');
-      return;
-    }
+    // Every step here is a native call that can reject -- a denied prompt is only
+    // the expected failure. An audio-service interruption rejects setAudioModeAsync
+    // or prepareToRecordAsync, and without this the hook sat in 'requesting'
+    // forever: Record disabled, an unhandled rejection logged, and no way out
+    // except closing and reopening the sheet.
+    try {
+      const permission = await requestRecordingPermissionsAsync();
+      if (generation !== generationRef.current) {
+        // Superseded while the OS prompt was open.
+        return;
+      }
+      if (!permission.granted) {
+        setState('denied');
+        return;
+      }
 
-    // iOS records nothing unless the session allows it, and stays muted by the
-    // hardware silent switch without playsInSilentMode.
-    await setAudioModeAsync({ allowsRecording: true, playsInSilentMode: true });
-    if (generation !== generationRef.current) {
-      return;
-    }
+      // iOS records nothing unless the session allows it, and stays muted by the
+      // hardware silent switch without playsInSilentMode.
+      await setAudioModeAsync({ allowsRecording: true, playsInSilentMode: true });
+      if (generation !== generationRef.current) {
+        return;
+      }
 
-    await recorder.prepareToRecordAsync();
-    if (generation !== generationRef.current) {
-      return;
-    }
+      await recorder.prepareToRecordAsync();
+      if (generation !== generationRef.current) {
+        return;
+      }
 
-    recorder.record();
-    setState('recording');
+      recorder.record();
+      setState('recording');
+    } catch {
+      if (generation !== generationRef.current) {
+        // A rejection from a superseded attempt must not clobber the recording that
+        // replaced it, same as the denial path above.
+        return;
+      }
+      setState('failed');
+    }
   }, [recorder]);
 
   const reset = useCallback(() => {
     generationRef.current += 1;
     if (recorder.isRecording) {
-      recorder.stop();
+      // Fire-and-forget, but caught: an unhandled rejection here would surface as a
+      // redbox in dev over a teardown the user cannot act on anyway.
+      recorder.stop().catch(() => undefined);
     }
     setResult(null);
     setState('idle');
@@ -94,7 +130,9 @@ export function useDictationRecorder({ maxSeconds }: Options) {
   // once the user has already waited through the upload.
   useEffect(() => {
     if (state === 'recording' && durationMs >= (maxSeconds - 1) * 1000) {
-      stop();
+      // stop() handles its own failures; this catch only stops the floated promise
+      // from becoming an unhandled rejection.
+      stop().catch(() => undefined);
     }
   }, [state, durationMs, maxSeconds, stop]);
 
@@ -104,7 +142,7 @@ export function useDictationRecorder({ maxSeconds }: Options) {
     () => () => {
       generationRef.current += 1;
       if (recorder.isRecording) {
-        recorder.stop();
+        recorder.stop().catch(() => undefined);
       }
       setAudioModeAsync({ allowsRecording: false }).catch(() => {
         // Restoring the audio mode is best-effort; failing it must not crash unmount.

--- a/src/navigation/sheets.tsx
+++ b/src/navigation/sheets.tsx
@@ -15,6 +15,7 @@ import {
   EmojiPickerSheet,
   AuthUpgradeSheet,
   AiAssistModal,
+  DictationModal,
   ComposeTranslateModal,
   TransferFavoritesSheet,
 } from '../components';
@@ -43,6 +44,7 @@ export enum SheetNames {
   EMOJI_PICKER = 'emoji_picker',
   AUTH_UPGRADE = 'auth_upgrade',
   AI_ASSIST = 'ai_assist',
+  DICTATION = 'dictation',
   COMPOSE_TRANSLATE = 'compose_translate',
   SHARE_INTENT = 'share_intent',
   SIGN_CONFIRM = 'sign_confirm',
@@ -67,6 +69,7 @@ registerSheet(SheetNames.HIVE_AUTH_BROADCAST, HiveAuthBroadcastSheet);
 registerSheet(SheetNames.EMOJI_PICKER, EmojiPickerSheet);
 registerSheet(SheetNames.AUTH_UPGRADE, AuthUpgradeSheet);
 registerSheet(SheetNames.AI_ASSIST, AiAssistModal);
+registerSheet(SheetNames.DICTATION, DictationModal);
 registerSheet(SheetNames.COMPOSE_TRANSLATE, ComposeTranslateModal);
 registerSheet(SheetNames.SHARE_INTENT, ShareIntentSheet);
 registerSheet(SheetNames.SIGN_CONFIRM, SignConfirmSheet);
@@ -191,6 +194,11 @@ declare module 'react-native-actions-sheet' {
         text: string;
         onApply?: (output: string, action: string) => void;
         supportedActions?: string[];
+      };
+    }>;
+    [SheetNames.DICTATION]: SheetDefinition<{
+      payload: {
+        onInsert: (text: string) => void;
       };
     }>;
     [SheetNames.COMPOSE_TRANSLATE]: SheetDefinition<{

--- a/yarn.lock
+++ b/yarn.lock
@@ -6596,6 +6596,11 @@ expo-asset@~11.1.7:
     "@expo/image-utils" "^0.7.6"
     expo-constants "~17.1.7"
 
+expo-audio@~0.4.9:
+  version "0.4.9"
+  resolved "https://registry.yarnpkg.com/expo-audio/-/expo-audio-0.4.9.tgz#f15f64652785ecd416ad351bf42666315e1e0b69"
+  integrity sha512-J4mMYEt2mqRqqwmSsXFylMGlrNWa+MbCzGl1IZBs+smvPAMJ3Ni8fNplzCQ0I9RnRzygKhRwJNpnAVL+n4MuyA==
+
 expo-constants@~17.1.7:
   version "17.1.7"
   resolved "https://registry.npmjs.org/expo-constants/-/expo-constants-17.1.7.tgz"


### PR DESCRIPTION
> **Draft: this has never been compiled or run.** I cannot build this app in my environment (no Java, and iOS builds are not possible on Linux), so everything below is verified at the JS layer only. Expect the first real build to need fixes.

Adds a microphone button beside the video upload, opening a sheet that records, shows the running cost, and inserts the transcript at the caret.

Final piece of the dictation series. ePoints (#45/#46/#47), vision-api (#62) and vision-next (#1285/#1286) are merged and live.

## Written against the real API, not a guessed one

I unpacked the published `expo-audio@0.4.9` tarball and read its types rather than writing from memory: `useAudioRecorder`, `useAudioRecorderState` (which is where `durationMillis` comes from), `requestRecordingPermissionsAsync`, `setAudioModeAsync`, `RecordingPresets`.

The version is what Expo SDK 53 pins in `bundledNativeModules.json` (`~0.4.9`), not something I picked.

`HIGH_QUALITY` records AAC in `.m4a` on both platforms, which the backend accepts directly — no transcode, and no dependence on whichever container a given OS version prefers.

## Carries over what web review found

The web implementation took several review rounds. Rather than repeat those mistakes here, this starts from their conclusions:

- **Duration rounds UP.** The server bills whole 30s units off the real duration, so flooring quotes one unit for a clip that costs two.
- **Recording stops a second before the cap.** Stopping exactly at it lets the real duration drift past by the time the recorder flushes, and the server then rejects an upload the user already waited through.
- **A permission prompt answered after the sheet closed cannot start a recording.** A generation counter is checked after every `await` in `start()` — otherwise a late grant opens a microphone with no UI able to close it.
- **The sheet cannot be dismissed while transcribing.** Points are charged the moment the request lands, so closing mid-flight would pay for a transcript and throw it away.
- **Unmount marks it closed**, so a late response cannot edit the draft of a screen the user has left.
- **The idempotency key is held across retries**, so a retry after a lost response replays rather than paying twice.
- **Pricing is never guessed.** Recording is blocked until the price endpoint answers, because the user pays the server's number, not ours.

## Placement

The mic sits next to the video upload rather than among the AI text actions. Dictation is media capture, so it belongs with the other capture controls.

## Insertion

Dictated text goes in at the caret via `applySnippet`, not replacing the body the way the AI assist edit actions do. Someone dictating mid-draft is adding to it.

## What is verified

- `tsc` clean on all new code (the one `tsconfig.json customConditions` error is pre-existing on `development`)
- eslint 0 errors on every touched file
- 708 tests passing
- `expo-audio` mocked in `jest.setup.ts` alongside the other native modules, so a future test reaching this sheet does not fail on the import
- Lockfile change is 5 lines, only `expo-audio`

## What is NOT verified

Everything native. Specifically worth attention on first build:

1. **`pod install`** for the new native module, and the iOS build generally.
2. **Android runtime permission.** `RECORD_AUDIO` is declared in the manifest, but Android 6+ also needs a runtime grant — `requestRecordingPermissionsAsync` should handle it, though that path is untested.
3. **The upload shape.** `useAiTranscribe` builds a `FormData` and appends `params.audio`. On web that is a `Blob`; here it is React Native's `{ uri, name, type }` file object, which RN's `FormData` understands but TypeScript does not, so it is cast. **This is the single most likely thing to be wrong on first run.**
4. **iOS audio session.** `setAudioModeAsync({ allowsRecording: true, playsInSilentMode: true })` is set before recording and reset on unmount; whether that interacts well with other audio in the app is untested.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added voice dictation to the editor through a microphone action.
  * Record audio, view duration and pricing, and submit recordings for transcription.
  * Insert transcribed text at the current cursor position.
  * Added handling for permissions, recording limits, retries, and transcription errors.
  * Added localized messaging for dictation controls and status updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->