### PR TITLE
fix(community): gate community pin on authoritative team roles

### DIFF
--- a/src/components/postOptionsModal/container/postOptionsModal.tsx
+++ b/src/components/postOptionsModal/container/postOptionsModal.tsx
@@ -141,8 +141,28 @@ const PostOptionsModal = ({ pageType, isWave, isVisibleTranslateModal, onDelete 
     if (content && !reblogsQuery.isLoading) {
       _initOptions();
     }
+    // `currentAccount?.profile?.pinned` is included so the blog pin/unpin
+    // option recomputes after pinning from the detail modal (where the stored
+    // `content` and its stats don't change).
+    //
+    // `communityQuery.data` is included because `_initOptions` computes the
+    // menu imperatively when the sheet opens. On a cold cache the community
+    // resolves after that first pass, and without this the moderator would see
+    // a menu with no pin action until the sheet was reopened.
+  }, [
+    content,
+    reblogsQuery.data,
+    reblogsQuery.isLoading,
+    currentAccount?.profile?.pinned,
+    communityQuery.data,
+  ]);
 
-    return () => {
+  // Timers are cleared on unmount only. These fire after the sheet has already
+  // hidden (copy/share/report defer 300-700ms before their toast or sheet), so
+  // tearing them down whenever an option input changes would cancel an action
+  // the user had already selected. A late-resolving query was enough to do it.
+  useEffect(
+    () => () => {
       if (alertTimer.current) {
         clearTimeout(alertTimer.current);
         alertTimer.current = null;
@@ -161,22 +181,9 @@ const PostOptionsModal = ({ pageType, isWave, isVisibleTranslateModal, onDelete 
         clearTimeout(reportTimer.current);
         reportTimer.current = null;
       }
-    };
-    // `currentAccount?.profile?.pinned` is included so the blog pin/unpin
-    // option recomputes after pinning from the detail modal (where the stored
-    // `content` and its stats don't change).
-    //
-    // `communityQuery.data` is included because `_initOptions` computes the
-    // menu imperatively when the sheet opens. On a cold cache the community
-    // resolves after that first pass, and without this the moderator would see
-    // a menu with no pin action until the sheet was reopened.
-  }, [
-    content,
-    reblogsQuery.data,
-    reblogsQuery.isLoading,
-    currentAccount?.profile?.pinned,
-    communityQuery.data,
-  ]);
+    },
+    [],
+  );
 
   const _initOptions = () => {
     // check if post is owned by current user or not, if so pinned or not

--- a/src/components/postOptionsModal/container/postOptionsModal.tsx
+++ b/src/components/postOptionsModal/container/postOptionsModal.tsx
@@ -8,10 +8,11 @@ import EStyleSheet from 'react-native-extended-stylesheet';
 import { useNavigation } from '@react-navigation/native';
 import { FlatList } from 'react-native-gesture-handler';
 import ActionSheet, { SheetManager } from 'react-native-actions-sheet';
-import { useQueryClient } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import {
   getPostQueryOptions,
   getAccountFullQueryOptions,
+  getCommunityQueryOptions,
   parseProfileMetadata,
   useDeleteComment,
 } from '@ecency/sdk';
@@ -34,6 +35,7 @@ import ROUTES from '../../../constants/routeNames';
 import { writeToClipboard } from '../../../utils/clipboard';
 import { resolveProfileMergeBase } from '../../../utils/profileMergeBase';
 import { getPostUrl, stripCategoryFromPostPath } from '../../../utils/post';
+import { isCommunityModerator } from '../../../utils/communityModeration';
 
 // Component
 
@@ -96,7 +98,6 @@ const PostOptionsModal = ({ pageType, isWave, isVisibleTranslateModal, onDelete 
   const ignoreUserMutation = useIgnoreUserMutation();
   const updateReplyMutation = useUpdateReplyMutation();
   const isPinCodeOpen = useAppSelector(selectIsPinCodeOpen);
-  const subscribedCommunities = useAppSelector((state) => state.communities.subscribedCommunities);
 
   const [content, setContent] = useState<any>(null);
   const [options, setOptions] = useState(OPTIONS);
@@ -109,6 +110,14 @@ const PostOptionsModal = ({ pageType, isWave, isVisibleTranslateModal, onDelete 
     content?.author || '',
     content?.permlink || '',
     shouldFetchReblogs, // Only fetch when needed
+  );
+
+  // Authoritative source for the moderator gate on community pin/unpin. The
+  // Redux `subscribedCommunities` tuple this replaced only covered communities
+  // the moderator had subscribed to, and its role slot can be blanked by the
+  // Discover-tab subscribe path, which silently removed the action.
+  const communityQuery = useQuery(
+    getCommunityQueryOptions(content?.community, currentAccount?.name, !!content?.community),
   );
 
   useImperativeHandle(ref, () => ({
@@ -156,7 +165,18 @@ const PostOptionsModal = ({ pageType, isWave, isVisibleTranslateModal, onDelete 
     // `currentAccount?.profile?.pinned` is included so the blog pin/unpin
     // option recomputes after pinning from the detail modal (where the stored
     // `content` and its stats don't change).
-  }, [content, reblogsQuery.data, reblogsQuery.isLoading, currentAccount?.profile?.pinned]);
+    //
+    // `communityQuery.data` is included because `_initOptions` computes the
+    // menu imperatively when the sheet opens. On a cold cache the community
+    // resolves after that first pass, and without this the moderator would see
+    // a menu with no pin action until the sheet was reopened.
+  }, [
+    content,
+    reblogsQuery.data,
+    reblogsQuery.isLoading,
+    currentAccount?.profile?.pinned,
+    communityQuery.data,
+  ]);
 
   const _initOptions = () => {
     // check if post is owned by current user or not, if so pinned or not
@@ -183,14 +203,7 @@ const PostOptionsModal = ({ pageType, isWave, isVisibleTranslateModal, onDelete 
     const _isCommunityPost = !!content && !!content.community;
 
     const _canUpdateCommunityPin =
-      subscribedCommunities.data && !!content && content.community
-        ? subscribedCommunities.data.reduce((role, subscription) => {
-            if (content.community === subscription[0]) {
-              return ['owner', 'admin', 'mod'].includes(subscription[2]);
-            }
-            return role;
-          }, false)
-        : false;
+      _isCommunityPost && isCommunityModerator(communityQuery.data?.team, currentAccount?.name);
     const _isPinnedInCommunity = !!content && content.stats?.is_pinned;
 
     // check if post can be deleted


### PR DESCRIPTION
Closes #3381

Builds on the helper added in #3384.

"Pin to community" / "Unpin from community" was gated on the Redux `subscribedCommunities` tuple:

```ts
subscribedCommunities.data.reduce((role, subscription) => {
  if (content.community === subscription[0]) {
    return ['owner', 'admin', 'mod'].includes(subscription[2]);
  }
  return role;
}, false)
```

Two problems with that source:

1. It only covers communities the moderator is **subscribed** to. Moderator authority on chain is independent of subscription, so an unsubscribed mod lost the action entirely.
2. `subscription[2]` is overwritable. `mergeSubCommunitiesCacheInSubList` mutates its first argument in place (`src/utils/communitiesUtils.ts:20,25`) and `cacheActions.ts:68` defaults `userRole` to `''`, so subscribing from the Discover tab could blank the role and silently remove the pin action until relaunch.

### Changes

- Resolve the role from `getCommunityQueryOptions(content?.community, currentAccount?.name, !!content?.community)` and the shared `isCommunityModerator` helper. The query is disabled for non-community posts.
- Add `communityQuery.data` to the `_initOptions` effect deps. That effect computes the menu imperatively when the sheet opens, so on a cold cache the community resolves after the first pass and the moderator would otherwise see a menu with no pin action until reopening the sheet.
- Drop the now-unused `subscribedCommunities` selector from this component. Other consumers of that Redux slice are untouched.

Behaviour for non-moderators is unchanged. The gate stays advisory either way, since hivemind is the authority on whether the pin is accepted.

### Testing

- `yarn test:ci`: 721 passed, 1 skipped, 48 suites.
- `yarn lint`: 0 errors.

Manual check worth doing on device: as a moderator who is **not** subscribed to the community, open the sheet on a post in it and confirm the pin action now appears.
