### PR TITLE
feat(community): mute and unmute posts as a community moderator

### DIFF
--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -124,6 +124,7 @@ import { PostingAuthoritySheet } from './postingAuthoritySheet';
 import { HiveAuthBroadcastSheet } from './hiveAuthBroadcastSheet';
 import EmojiPickerSheet from './emojiPickerSheet';
 import { AuthUpgradeSheet } from './authUpgradeSheet';
+import { ModNotesSheet } from './modNotesSheet';
 import TransferFavoritesSheet from './transferFavoritesSheet/transferFavoritesSheet';
 
 // Basic UI Elements
@@ -304,5 +305,6 @@ export {
   HiveAuthBroadcastSheet,
   EmojiPickerSheet,
   AuthUpgradeSheet,
+  ModNotesSheet,
   TransferFavoritesSheet,
 };

--- a/src/components/modNotesSheet/index.ts
+++ b/src/components/modNotesSheet/index.ts
@@ -1,1 +1,2 @@
 export { default as ModNotesSheet } from './modNotesSheet';
+export type { ModNotesResult } from './modNotesSheet';

--- a/src/components/modNotesSheet/index.ts
+++ b/src/components/modNotesSheet/index.ts
@@ -1,0 +1,1 @@
+export { default as ModNotesSheet } from './modNotesSheet';

--- a/src/components/modNotesSheet/modNotesSheet.tsx
+++ b/src/components/modNotesSheet/modNotesSheet.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Text, TextInput, View } from 'react-native';
 import { useIntl } from 'react-intl';
 import ActionSheet, { SheetManager, SheetProps } from 'react-native-actions-sheet';
@@ -26,12 +26,24 @@ const ModNotesSheet: React.FC<SheetProps<'mod_notes'>> = ({ sheetId, payload }) 
 
   const maxLength = payload?.maxLength ?? DEFAULT_MAX_LENGTH;
 
-  // react-native-actions-sheet keeps registered sheets mounted, so without this
-  // the previous moderator's note would be prefilled on the next open.
-  useEffect(() => {
+  const _reset = useCallback(() => {
     closedRef.current = false;
     setValue('');
-  }, [payload]);
+  }, []);
+
+  // react-native-actions-sheet keeps registered sheets mounted, so without a
+  // reset the previous moderator's note would be prefilled on the next open and
+  // closedRef would still be true, leaving confirm and cancel unable to close
+  // the sheet at all.
+  //
+  // Resetting on `payload` identity alone is not enough: payload is optional
+  // and a caller may reopen with no payload or the same object, in which case
+  // the effect never re-runs. onBeforeShow fires on every presentation, so it
+  // is the authoritative reset; the effect covers a payload swap while the
+  // sheet is already open.
+  useEffect(() => {
+    _reset();
+  }, [payload, _reset]);
 
   const _close = (result: string | false) => {
     if (closedRef.current) {
@@ -54,6 +66,7 @@ const ModNotesSheet: React.FC<SheetProps<'mod_notes'>> = ({ sheetId, payload }) 
       id={sheetId || FALLBACK_SHEET_ID}
       gestureEnabled
       closeOnTouchBackdrop
+      onBeforeShow={_reset}
       containerStyle={styles.sheetContainer}
     >
       <View style={styles.container}>

--- a/src/components/modNotesSheet/modNotesSheet.tsx
+++ b/src/components/modNotesSheet/modNotesSheet.tsx
@@ -1,0 +1,153 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { Text, TextInput, View } from 'react-native';
+import { useIntl } from 'react-intl';
+import ActionSheet, { SheetManager, SheetProps } from 'react-native-actions-sheet';
+import EStyleSheet from 'react-native-extended-stylesheet';
+import { MainButton } from '../mainButton';
+
+const FALLBACK_SHEET_ID = 'mod_notes';
+
+// Hivemind stores the note on the moderation action itself. Web caps the same
+// field at 120 characters, so keep the two clients consistent.
+const DEFAULT_MAX_LENGTH = 120;
+
+/**
+ * Prompts a moderator for the free-text reason that community moderation
+ * operations carry (mutePost/unmutePost take a required `notes` field).
+ *
+ * Resolves the `SheetManager.show` promise with the trimmed note, or `false`
+ * when the moderator backs out. Backdrop dismissal resolves `undefined`, so
+ * callers should treat any falsy result as a cancellation.
+ */
+const ModNotesSheet: React.FC<SheetProps<'mod_notes'>> = ({ sheetId, payload }) => {
+  const intl = useIntl();
+  const [value, setValue] = useState('');
+  const closedRef = useRef(false);
+
+  const maxLength = payload?.maxLength ?? DEFAULT_MAX_LENGTH;
+
+  // react-native-actions-sheet keeps registered sheets mounted, so without this
+  // the previous moderator's note would be prefilled on the next open.
+  useEffect(() => {
+    closedRef.current = false;
+    setValue('');
+  }, [payload]);
+
+  const _close = (result: string | false) => {
+    if (closedRef.current) {
+      return;
+    }
+    closedRef.current = true;
+    SheetManager.hide(sheetId || FALLBACK_SHEET_ID, { payload: result });
+  };
+
+  const _handleConfirm = () => {
+    const notes = value.trim();
+    if (!notes) {
+      return;
+    }
+    _close(notes);
+  };
+
+  return (
+    <ActionSheet
+      id={sheetId || FALLBACK_SHEET_ID}
+      gestureEnabled
+      closeOnTouchBackdrop
+      containerStyle={styles.sheetContainer}
+    >
+      <View style={styles.container}>
+        <Text style={styles.title}>
+          {payload?.title || intl.formatMessage({ id: 'mod_notes.title' })}
+        </Text>
+
+        {!!payload?.description && <Text style={styles.description}>{payload.description}</Text>}
+
+        <TextInput
+          style={styles.input}
+          placeholder={payload?.placeholder || intl.formatMessage({ id: 'mod_notes.placeholder' })}
+          placeholderTextColor={EStyleSheet.value('$primaryDarkGray')}
+          autoCapitalize="sentences"
+          autoCorrect
+          autoFocus
+          value={value}
+          onChangeText={setValue}
+          maxLength={maxLength}
+          returnKeyType="done"
+          onSubmitEditing={_handleConfirm}
+        />
+
+        <Text style={styles.counter}>{`${value.length} / ${maxLength}`}</Text>
+
+        <MainButton
+          onPress={_handleConfirm}
+          isDisable={!value.trim()}
+          text={payload?.confirmLabel || intl.formatMessage({ id: 'mod_notes.confirm' })}
+          style={styles.confirmButton}
+        />
+
+        <MainButton
+          onPress={() => _close(false)}
+          text={intl.formatMessage({ id: 'mod_notes.cancel' })}
+          style={styles.cancelButton}
+          textStyle={styles.cancelButtonText}
+        />
+      </View>
+    </ActionSheet>
+  );
+};
+
+const styles = EStyleSheet.create({
+  sheetContainer: {
+    paddingHorizontal: 0,
+    backgroundColor: '$primaryBackgroundColor',
+  },
+  container: {
+    paddingHorizontal: 20,
+    paddingVertical: 24,
+    paddingBottom: 40,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    color: '$primaryBlack',
+    textAlign: 'center',
+    marginBottom: 8,
+  },
+  description: {
+    fontSize: 15,
+    color: '$primaryDarkGray',
+    textAlign: 'center',
+    marginBottom: 16,
+    lineHeight: 22,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '$primaryLightGray',
+    borderRadius: 8,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    fontSize: 15,
+    color: '$primaryBlack',
+    backgroundColor: '$primaryLightBackground',
+  },
+  counter: {
+    fontSize: 12,
+    color: '$primaryDarkGray',
+    textAlign: 'right',
+    marginTop: 6,
+    marginBottom: 12,
+  },
+  confirmButton: {
+    marginBottom: 0,
+  },
+  cancelButton: {
+    backgroundColor: 'transparent',
+    marginTop: 8,
+  },
+  cancelButtonText: {
+    color: '$primaryDarkGray',
+  },
+});
+
+export default ModNotesSheet;

--- a/src/components/modNotesSheet/modNotesSheet.tsx
+++ b/src/components/modNotesSheet/modNotesSheet.tsx
@@ -7,6 +7,18 @@ import { MainButton } from '../mainButton';
 
 const FALLBACK_SHEET_ID = 'mod_notes';
 
+/**
+ * Result of the sheet. Both variants are objects because
+ * react-native-actions-sheet 0.9.7 publishes `data || payloadRef.current` on
+ * close (dist/src/index.js:403), so a falsy return value is silently replaced
+ * by the original payload object. Any `false`/`undefined`/`''` contract would
+ * therefore reach the caller as a truthy object and read as a confirmation.
+ */
+export interface ModNotesResult {
+  notes?: string;
+  cancelled?: boolean;
+}
+
 // Hivemind stores the note on the moderation action itself. Web caps the same
 // field at 120 characters, so keep the two clients consistent.
 const DEFAULT_MAX_LENGTH = 120;
@@ -15,9 +27,10 @@ const DEFAULT_MAX_LENGTH = 120;
  * Prompts a moderator for the free-text reason that community moderation
  * operations carry (mutePost/unmutePost take a required `notes` field).
  *
- * Resolves the `SheetManager.show` promise with the trimmed note, or `false`
- * when the moderator backs out. Backdrop dismissal resolves `undefined`, so
- * callers should treat any falsy result as a cancellation.
+ * Resolves the `SheetManager.show` promise with `{ notes }` on confirm and
+ * `{ cancelled: true }` on an explicit cancel. Dismissing by backdrop, swipe or
+ * back button resolves the original payload object instead (see ModNotesResult),
+ * so callers must gate on a string `notes` rather than on truthiness.
  */
 const ModNotesSheet: React.FC<SheetProps<'mod_notes'>> = ({ sheetId, payload }) => {
   const intl = useIntl();
@@ -45,7 +58,7 @@ const ModNotesSheet: React.FC<SheetProps<'mod_notes'>> = ({ sheetId, payload }) 
     _reset();
   }, [payload, _reset]);
 
-  const _close = (result: string | false) => {
+  const _close = (result: ModNotesResult) => {
     if (closedRef.current) {
       return;
     }
@@ -58,7 +71,7 @@ const ModNotesSheet: React.FC<SheetProps<'mod_notes'>> = ({ sheetId, payload }) 
     if (!notes) {
       return;
     }
-    _close(notes);
+    _close({ notes });
   };
 
   return (
@@ -100,7 +113,7 @@ const ModNotesSheet: React.FC<SheetProps<'mod_notes'>> = ({ sheetId, payload }) 
         />
 
         <MainButton
-          onPress={() => _close(false)}
+          onPress={() => _close({ cancelled: true })}
           text={intl.formatMessage({ id: 'mod_notes.cancel' })}
           style={styles.cancelButton}
           textStyle={styles.cancelButtonText}

--- a/src/components/postOptionsModal/container/postOptionsModal.tsx
+++ b/src/components/postOptionsModal/container/postOptionsModal.tsx
@@ -141,8 +141,28 @@ const PostOptionsModal = ({ pageType, isWave, isVisibleTranslateModal, onDelete 
     if (content && !reblogsQuery.isLoading) {
       _initOptions();
     }
+    // `currentAccount?.profile?.pinned` is included so the blog pin/unpin
+    // option recomputes after pinning from the detail modal (where the stored
+    // `content` and its stats don't change).
+    //
+    // `communityQuery.data` is included because `_initOptions` computes the
+    // menu imperatively when the sheet opens. On a cold cache the community
+    // resolves after that first pass, and without this the moderator would see
+    // a menu with no pin action until the sheet was reopened.
+  }, [
+    content,
+    reblogsQuery.data,
+    reblogsQuery.isLoading,
+    currentAccount?.profile?.pinned,
+    communityQuery.data,
+  ]);
 
-    return () => {
+  // Timers are cleared on unmount only. These fire after the sheet has already
+  // hidden (copy/share/report defer 300-700ms before their toast or sheet), so
+  // tearing them down whenever an option input changes would cancel an action
+  // the user had already selected. A late-resolving query was enough to do it.
+  useEffect(
+    () => () => {
       if (alertTimer.current) {
         clearTimeout(alertTimer.current);
         alertTimer.current = null;
@@ -161,22 +181,9 @@ const PostOptionsModal = ({ pageType, isWave, isVisibleTranslateModal, onDelete 
         clearTimeout(reportTimer.current);
         reportTimer.current = null;
       }
-    };
-    // `currentAccount?.profile?.pinned` is included so the blog pin/unpin
-    // option recomputes after pinning from the detail modal (where the stored
-    // `content` and its stats don't change).
-    //
-    // `communityQuery.data` is included because `_initOptions` computes the
-    // menu imperatively when the sheet opens. On a cold cache the community
-    // resolves after that first pass, and without this the moderator would see
-    // a menu with no pin action until the sheet was reopened.
-  }, [
-    content,
-    reblogsQuery.data,
-    reblogsQuery.isLoading,
-    currentAccount?.profile?.pinned,
-    communityQuery.data,
-  ]);
+    },
+    [],
+  );
 
   const _initOptions = () => {
     // check if post is owned by current user or not, if so pinned or not

--- a/src/components/postOptionsModal/container/postOptionsModal.tsx
+++ b/src/components/postOptionsModal/container/postOptionsModal.tsx
@@ -666,7 +666,7 @@ const PostOptionsModal = ({ pageType, isWave, isVisibleTranslateModal, onDelete 
 
   const _muteCommunityPost = async ({ unmute }: { unmute: boolean } = { unmute: false }) => {
     // hivemind requires a note on both mute and unmute.
-    const notes = await SheetManager.show(SheetNames.MOD_NOTES, {
+    const result = await SheetManager.show(SheetNames.MOD_NOTES, {
       payload: {
         title: intl.formatMessage({
           id: unmute ? 'community.unmute_post_title' : 'community.mute_post_title',
@@ -681,7 +681,11 @@ const PostOptionsModal = ({ pageType, isWave, isVisibleTranslateModal, onDelete 
       },
     });
 
-    // Explicit cancel resolves false, backdrop dismissal resolves undefined.
+    // Only a confirmation carries a string `notes`. Cancelling yields
+    // { cancelled: true }, and a backdrop, swipe or back dismissal yields the
+    // payload object, because the library publishes `data || payloadRef.current`
+    // on close. Testing truthiness here would broadcast on every dismissal.
+    const notes = typeof result?.notes === 'string' ? result.notes.trim() : '';
     if (!notes) {
       return;
     }

--- a/src/components/postOptionsModal/container/postOptionsModal.tsx
+++ b/src/components/postOptionsModal/container/postOptionsModal.tsx
@@ -216,15 +216,19 @@ const PostOptionsModal = ({ pageType, isWave, isVisibleTranslateModal, onDelete 
       currentAccount?.name,
     );
 
-    const _canUpdateCommunityPin = _isCommunityPost && _isCommunityModerator;
-    const _isPinnedInCommunity = !!content && content.stats?.is_pinned;
-
     // Moderating a cross-post is not expressible: `parsePost` swaps author and
     // permlink to the original entry but leaves `community` as the wrapper's,
     // so the {community, author, permlink} tuple would not match anything
     // hivemind knows about. Moderate the original post instead.
-    const _canMuteCommunityPost =
+    //
+    // Both pin and mute build that same tuple, so both are withheld.
+    const _canModerateCommunityPost =
       _isCommunityPost && _isCommunityModerator && !content.crosspostMeta;
+
+    const _canUpdateCommunityPin = _canModerateCommunityPost;
+    const _isPinnedInCommunity = !!content && content.stats?.is_pinned;
+
+    const _canMuteCommunityPost = _canModerateCommunityPost;
 
     // Read `stats.gray` directly rather than the parsed `isMuted`. getMutedReason
     // also reports MODERATED for low-reputation and downvoted posts, which would

--- a/src/components/postOptionsModal/container/postOptionsModal.tsx
+++ b/src/components/postOptionsModal/container/postOptionsModal.tsx
@@ -20,6 +20,7 @@ import { useAuthContext } from '../../../providers/sdk';
 import {
   useReblogMutation,
   usePinPostMutation,
+  useMutePostMutation,
   useAccountUpdateMutation,
   useIgnoreUserMutation,
   useUpdateReplyMutation,
@@ -94,6 +95,7 @@ const PostOptionsModal = ({ pageType, isWave, isVisibleTranslateModal, onDelete 
   const deleteCommentMutation = useDeleteComment(currentAccount?.name, authContext, 'async');
   const reblogMutation = useReblogMutation();
   const pinPostMutation = usePinPostMutation();
+  const mutePostMutation = useMutePostMutation();
   const accountUpdateMutation = useAccountUpdateMutation();
   const ignoreUserMutation = useIgnoreUserMutation();
   const updateReplyMutation = useUpdateReplyMutation();
@@ -202,9 +204,25 @@ const PostOptionsModal = ({ pageType, isWave, isVisibleTranslateModal, onDelete 
     // check community pin update eligibility
     const _isCommunityPost = !!content && !!content.community;
 
-    const _canUpdateCommunityPin =
-      _isCommunityPost && isCommunityModerator(communityQuery.data?.team, currentAccount?.name);
+    const _isCommunityModerator = isCommunityModerator(
+      communityQuery.data?.team,
+      currentAccount?.name,
+    );
+
+    const _canUpdateCommunityPin = _isCommunityPost && _isCommunityModerator;
     const _isPinnedInCommunity = !!content && content.stats?.is_pinned;
+
+    // Moderating a cross-post is not expressible: `parsePost` swaps author and
+    // permlink to the original entry but leaves `community` as the wrapper's,
+    // so the {community, author, permlink} tuple would not match anything
+    // hivemind knows about. Moderate the original post instead.
+    const _canMuteCommunityPost =
+      _isCommunityPost && _isCommunityModerator && !content.crosspostMeta;
+
+    // Read `stats.gray` directly rather than the parsed `isMuted`. getMutedReason
+    // also reports MODERATED for low-reputation and downvoted posts, which would
+    // offer "unmute" on posts no moderator ever muted.
+    const _isMutedInCommunity = !!content && !!content.stats?.gray;
 
     // check if post can be deleted
     // Hive's on-chain rule is: no children AND no net positive rshares. Using
@@ -268,6 +286,10 @@ const PostOptionsModal = ({ pageType, isWave, isVisibleTranslateModal, onDelete 
           return _canPinReply && !_isPinnedReply;
         case 'unpin-reply':
           return _canPinReply && _isPinnedReply;
+        case 'mute-post':
+          return _canMuteCommunityPost && !_isMutedInCommunity;
+        case 'unmute-post':
+          return _canMuteCommunityPost && _isMutedInCommunity;
         case 'translate':
           return isVisibleTranslateModal;
         case 'delete-post':
@@ -635,6 +657,63 @@ const PostOptionsModal = ({ pageType, isWave, isVisibleTranslateModal, onDelete 
     }
   };
 
+  const _muteCommunityPost = async ({ unmute }: { unmute: boolean } = { unmute: false }) => {
+    // hivemind requires a note on both mute and unmute.
+    const notes = await SheetManager.show(SheetNames.MOD_NOTES, {
+      payload: {
+        title: intl.formatMessage({
+          id: unmute ? 'community.unmute_post_title' : 'community.mute_post_title',
+        }),
+        description: `@${content.author}/${content.permlink}`,
+        placeholder: intl.formatMessage({
+          id: unmute ? 'community.unmute_post_reason' : 'community.mute_post_reason',
+        }),
+        confirmLabel: intl.formatMessage({
+          id: unmute ? 'post_dropdown.unmute-post' : 'post_dropdown.mute-post',
+        }),
+      },
+    });
+
+    // Explicit cancel resolves false, backdrop dismissal resolves undefined.
+    if (!notes) {
+      return;
+    }
+
+    try {
+      await mutePostMutation.mutateAsync({
+        community: content.community,
+        author: content.author,
+        permlink: content.permlink,
+        notes,
+        mute: !unmute,
+      });
+      dispatch(toastNotification(intl.formatMessage({ id: 'alert.successful' })));
+
+      const { queryKey: entryQueryKey } = getPostQueryOptions(
+        content.author,
+        content.permlink,
+        currentAccount?.name || '',
+      );
+      queryClient.invalidateQueries({ queryKey: entryQueryKey });
+
+      // Refresh the community feeds so the post is hidden or restored.
+      queryClient.invalidateQueries({
+        predicate: (query) =>
+          query.queryKey[0] === 'posts' &&
+          query.queryKey[1] === 'posts-ranked' &&
+          query.queryKey[3] === content.community,
+      });
+    } catch (err) {
+      console.warn('Failed to update mute status of community post', err);
+      Alert.alert(
+        intl.formatMessage({
+          id: 'alert.fail',
+        }),
+        get(err, 'message') || String(err) || 'Unknown error',
+      );
+    }
+  };
+
   const _updatePinnedReply = async ({ unpin }: { unpin: boolean } = { unpin: false }) => {
     const observer = currentAccount?.name || currentAccount?.username;
     const parentPost = queryClient.getQueryData(
@@ -787,6 +866,16 @@ const PostOptionsModal = ({ pageType, isWave, isVisibleTranslateModal, onDelete 
         break;
       case 'unpin-reply':
         _updatePinnedReply({ unpin: true });
+        break;
+      // Delayed like the other cases that open a sheet, so this one is not
+      // swallowed by the options sheet's own hide animation.
+      case 'mute-post':
+        await delay(700);
+        _muteCommunityPost();
+        break;
+      case 'unmute-post':
+        await delay(700);
+        _muteCommunityPost({ unmute: true });
         break;
       case 'edit-history':
         navigation.navigate({

--- a/src/components/postOptionsModal/container/postOptionsModal.tsx
+++ b/src/components/postOptionsModal/container/postOptionsModal.tsx
@@ -8,10 +8,11 @@ import EStyleSheet from 'react-native-extended-stylesheet';
 import { useNavigation } from '@react-navigation/native';
 import { FlatList } from 'react-native-gesture-handler';
 import ActionSheet, { SheetManager } from 'react-native-actions-sheet';
-import { useQueryClient } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import {
   getPostQueryOptions,
   getAccountFullQueryOptions,
+  getCommunityQueryOptions,
   parseProfileMetadata,
   useDeleteComment,
 } from '@ecency/sdk';
@@ -34,6 +35,7 @@ import ROUTES from '../../../constants/routeNames';
 import { writeToClipboard } from '../../../utils/clipboard';
 import { resolveProfileMergeBase } from '../../../utils/profileMergeBase';
 import { getPostUrl, stripCategoryFromPostPath } from '../../../utils/post';
+import { isCommunityModerator } from '../../../utils/communityModeration';
 
 // Component
 
@@ -96,7 +98,6 @@ const PostOptionsModal = ({ pageType, isWave, isVisibleTranslateModal, onDelete 
   const ignoreUserMutation = useIgnoreUserMutation();
   const updateReplyMutation = useUpdateReplyMutation();
   const isPinCodeOpen = useAppSelector(selectIsPinCodeOpen);
-  const subscribedCommunities = useAppSelector((state) => state.communities.subscribedCommunities);
 
   const [content, setContent] = useState<any>(null);
   const [options, setOptions] = useState(OPTIONS);
@@ -109,6 +110,14 @@ const PostOptionsModal = ({ pageType, isWave, isVisibleTranslateModal, onDelete 
     content?.author || '',
     content?.permlink || '',
     shouldFetchReblogs, // Only fetch when needed
+  );
+
+  // Authoritative source for the moderator gate on community pin/unpin. The
+  // Redux `subscribedCommunities` tuple this replaced only covered communities
+  // the moderator had subscribed to, and its role slot can be blanked by the
+  // Discover-tab subscribe path, which silently removed the action.
+  const communityQuery = useQuery(
+    getCommunityQueryOptions(content?.community, currentAccount?.name, !!content?.community),
   );
 
   useImperativeHandle(ref, () => ({
@@ -156,7 +165,18 @@ const PostOptionsModal = ({ pageType, isWave, isVisibleTranslateModal, onDelete 
     // `currentAccount?.profile?.pinned` is included so the blog pin/unpin
     // option recomputes after pinning from the detail modal (where the stored
     // `content` and its stats don't change).
-  }, [content, reblogsQuery.data, reblogsQuery.isLoading, currentAccount?.profile?.pinned]);
+    //
+    // `communityQuery.data` is included because `_initOptions` computes the
+    // menu imperatively when the sheet opens. On a cold cache the community
+    // resolves after that first pass, and without this the moderator would see
+    // a menu with no pin action until the sheet was reopened.
+  }, [
+    content,
+    reblogsQuery.data,
+    reblogsQuery.isLoading,
+    currentAccount?.profile?.pinned,
+    communityQuery.data,
+  ]);
 
   const _initOptions = () => {
     // check if post is owned by current user or not, if so pinned or not
@@ -183,14 +203,7 @@ const PostOptionsModal = ({ pageType, isWave, isVisibleTranslateModal, onDelete 
     const _isCommunityPost = !!content && !!content.community;
 
     const _canUpdateCommunityPin =
-      subscribedCommunities.data && !!content && content.community
-        ? subscribedCommunities.data.reduce((role, subscription) => {
-            if (content.community === subscription[0]) {
-              return ['owner', 'admin', 'mod'].includes(subscription[2]);
-            }
-            return role;
-          }, false)
-        : false;
+      _isCommunityPost && isCommunityModerator(communityQuery.data?.team, currentAccount?.name);
     const _isPinnedInCommunity = !!content && content.stats?.is_pinned;
 
     // check if post can be deleted

--- a/src/config/locales/en-US.json
+++ b/src/config/locales/en-US.json
@@ -181,7 +181,11 @@
     "payout": "Payout",
     "details": "Details",
     "community": "community",
-    "new_post": "New Post"
+    "new_post": "New Post",
+    "mute_post_title": "Mute this post",
+    "unmute_post_title": "Unmute this post",
+    "mute_post_reason": "Why is this being muted?",
+    "unmute_post_reason": "Why is this being restored?"
   },
   "trade": {
     "swap_for": "Swapping {fromAmount} for {toAmount}",
@@ -213,6 +217,8 @@
     "pin-blog": "Pin to blog",
     "copy": "copy link",
     "unpin-community": "Unpin from community",
+    "mute-post": "Mute post",
+    "unmute-post": "Unmute post",
     "mute": "Mute / Block",
     "reblog": "reblog",
     "undo-reblog": "undo reblog",

--- a/src/config/locales/en-US.json
+++ b/src/config/locales/en-US.json
@@ -1747,5 +1747,11 @@
     "blog_post_desc": "Create a full blog post in the editor",
     "wave": "Wave",
     "wave_desc": "Share a quick update"
+  },
+  "mod_notes": {
+    "title": "Add a reason",
+    "placeholder": "Reason (visible to other moderators)",
+    "confirm": "Confirm",
+    "cancel": "Cancel"
   }
 }

--- a/src/constants/options/post.ts
+++ b/src/constants/options/post.ts
@@ -12,6 +12,10 @@ export default [
   'unpin-community',
   'pin-reply',
   'unpin-reply',
+  // Community moderation. Distinct from 'mute' below, which is the personal
+  // author ignore rather than a moderator action.
+  'mute-post',
+  'unmute-post',
   'edit-history',
   'share',
   'bookmarks',

--- a/src/navigation/sheets.tsx
+++ b/src/navigation/sheets.tsx
@@ -17,6 +17,7 @@ import {
   AiAssistModal,
   ComposeTranslateModal,
   TransferFavoritesSheet,
+  ModNotesSheet,
 } from '../components';
 import { ShareIntentSheet } from '../components/shareIntentSheet';
 import SignConfirmSheet from '../screens/dappBrowser/components/signConfirmSheet';
@@ -49,6 +50,7 @@ export enum SheetNames {
   RECEIVE_QR = 'receive_qr',
   BALANCE_ANALYTICS = 'balance_analytics',
   TRANSFER_FAVORITES = 'transfer_favorites',
+  MOD_NOTES = 'mod_notes',
 }
 
 registerSheet(SheetNames.POST_TRANSLATION, PostTranslationModal);
@@ -73,6 +75,7 @@ registerSheet(SheetNames.SIGN_CONFIRM, SignConfirmSheet);
 registerSheet(SheetNames.RECEIVE_QR, ReceiveQrSheet);
 registerSheet(SheetNames.BALANCE_ANALYTICS, BalanceAnalyticsSheet);
 registerSheet(SheetNames.TRANSFER_FAVORITES, TransferFavoritesSheet);
+registerSheet(SheetNames.MOD_NOTES, ModNotesSheet);
 
 // We extend some of the types here to give us great intellisense
 // across the app for all registered sheets.
@@ -226,6 +229,19 @@ declare module 'react-native-actions-sheet' {
         limit?: number;
       };
       returnValue: string | undefined;
+    }>;
+    [SheetNames.MOD_NOTES]: SheetDefinition<{
+      payload?: {
+        title?: string;
+        description?: string;
+        placeholder?: string;
+        maxLength?: number;
+        confirmLabel?: string;
+      };
+      // Trimmed note on confirm, false on explicit cancel. Backdrop dismissal
+      // resolves undefined, so callers should treat any falsy value as a
+      // cancellation.
+      returnValue: string | false | undefined;
     }>;
   }
 }

--- a/src/navigation/sheets.tsx
+++ b/src/navigation/sheets.tsx
@@ -19,6 +19,7 @@ import {
   TransferFavoritesSheet,
   ModNotesSheet,
 } from '../components';
+import type { ModNotesResult } from '../components/modNotesSheet/modNotesSheet';
 import { ShareIntentSheet } from '../components/shareIntentSheet';
 import SignConfirmSheet from '../screens/dappBrowser/components/signConfirmSheet';
 import ReceiveQrSheet from '../components/receiveQrSheet/receiveQrSheet';
@@ -238,10 +239,12 @@ declare module 'react-native-actions-sheet' {
         maxLength?: number;
         confirmLabel?: string;
       };
-      // Trimmed note on confirm, false on explicit cancel. Backdrop dismissal
-      // resolves undefined, so callers should treat any falsy value as a
-      // cancellation.
-      returnValue: string | false | undefined;
+      // `{ notes }` on confirm, `{ cancelled: true }` on explicit cancel.
+      // Dismissing by backdrop, swipe or back button resolves the payload
+      // object instead, because the library publishes
+      // `data || payloadRef.current` on close. Gate on a string `notes`, never
+      // on truthiness.
+      returnValue: ModNotesResult | undefined;
     }>;
   }
 }


### PR DESCRIPTION
Closes #3383

> **Stacked.** This branch merges in #3385 (mod notes sheet) and #3387 (pin gate), both still open, because it needs the sheet and touches the same file. Merge those two first and I will rebase so the diff reduces to this PR's own commits.

Muting a post is the primary community moderation action and the app had no way to do it. On web it lives in the entry menu (`apps/web/src/features/shared/entry-menu/index.tsx:226` -> `mute-btn/index.tsx`).

The broadcast side was already wired: `src/providers/sdk/mutations/useMutePostMutation.ts` existed with no call sites and the correct SDK signature.

### Changes

- `src/constants/options/post.ts`: `mute-post` and `unmute-post`. The existing `'mute'` entry is untouched, since that is the personal author ignore (`_muteUser` -> `useIgnoreUserMutation`), not a moderator action.
- `src/components/postOptionsModal/container/postOptionsModal.tsx`: gate on the shared `isCommunityModerator` helper against the same community query the pin gate uses, collect the reason through `SheetNames.MOD_NOTES`, broadcast, then invalidate the post query and the `posts/posts-ranked/<community>` predicate.
- `src/config/locales/en-US.json`: `post_dropdown.mute-post` / `unmute-post` and four `community.*` strings for the sheet.

Details that are easy to get wrong here:

- Mute state reads `content.stats.gray` directly rather than the parsed `isMuted`. `getMutedReason` (`src/utils/postParser.tsx:26-41`) also returns `MODERATED` for low-reputation and downvoted posts, so `isMuted` would offer "Unmute" on posts no moderator ever muted.
- Neither mute nor pin is offered on cross-posts. `parsePost` swaps `author` and `permlink` to the original entry but leaves `community` as the wrapper's, so the `{community, author, permlink}` tuple would not match anything hivemind knows about. Both actions build that same tuple, so the guard is hoisted into `_canModerateCommunityPost` and shared. **This changes existing behaviour: community pin/unpin no longer appears on cross-post cards, where it previously did and would have been rejected.** Caught in review by CodeRabbit.
- Dismissing the notes sheet must not broadcast. `react-native-actions-sheet` 0.9.7 publishes `data || payloadRef.current` on close, so a falsy return value is replaced by the payload object, which is truthy. The sheet contract (#3385) returns `{ notes }` / `{ cancelled: true }` and this gates on a string `notes`, so cancel, backdrop, swipe and back all fall through. Caught in review by Codex.
- `MutePostPayload` uses `author`, while `PinPostPayload` uses `account`. The underlying custom_json field is `account` in both cases.

Both actions defer with `await delay(700)` before opening the sheet, matching `delete-post` and `cross-post`, so the new sheet is not swallowed by the options sheet's hide animation.

### Testing

- `yarn test:ci`: 721 passed, 1 skipped, 48 suites.
- `yarn lint`: 0 errors.

Needs a device pass before merge:
- As a moderator, mute a post in your community, confirm it drops out of the community feed and renders as moderated, then unmute and confirm it returns.
- Confirm a non-moderator sees neither action.
- Confirm a cross-post card shows neither mute nor pin.
- Confirm cancelling the reason sheet, and dismissing it by backdrop, swipe and back, all broadcast nothing.
