### PR TITLE
fix(community): correct argument order in setRole and updateCommunity wrappers

### DIFF
--- a/src/providers/sdk/mutations/index.ts
+++ b/src/providers/sdk/mutations/index.ts
@@ -56,6 +56,9 @@ export { useEngineMarketOrderMutation } from './useEngineMarketOrderMutation';
 // Community
 export { useSubscribeCommunityMutation } from './useSubscribeCommunityMutation';
 export { useUnsubscribeCommunityMutation } from './useUnsubscribeCommunityMutation';
+// These two take a `community` argument, unlike every other wrapper here. The SDK
+// bakes the community into the mutation key, so it cannot move into the payload.
+// Do not "fix" them back to the zero-argument shape.
 export { useSetCommunityRoleMutation } from './useSetCommunityRoleMutation';
 export { useUpdateCommunityMutation } from './useUpdateCommunityMutation';
 

--- a/src/providers/sdk/mutations/useSetCommunityRoleMutation.ts
+++ b/src/providers/sdk/mutations/useSetCommunityRoleMutation.ts
@@ -1,7 +1,12 @@
 import { useSetCommunityRole } from '@ecency/sdk';
 import { useMutationAuth } from './common';
 
-export function useSetCommunityRoleMutation() {
+/**
+ * Unlike the other wrappers here this one takes an argument. The SDK signature is
+ * `(community, username, auth, broadcastMode)` and it bakes `community` into the
+ * mutation key, so it cannot be moved into the payload.
+ */
+export function useSetCommunityRoleMutation(community: string) {
   const { username, authContext } = useMutationAuth();
-  return useSetCommunityRole(username, authContext);
+  return useSetCommunityRole(community, username, authContext, 'async');
 }

--- a/src/providers/sdk/mutations/useUpdateCommunityMutation.ts
+++ b/src/providers/sdk/mutations/useUpdateCommunityMutation.ts
@@ -1,7 +1,12 @@
 import { useUpdateCommunity } from '@ecency/sdk';
 import { useMutationAuth } from './common';
 
-export function useUpdateCommunityMutation() {
+/**
+ * Unlike the other wrappers here this one takes an argument. The SDK signature is
+ * `(community, username, auth, broadcastMode)` and it bakes `community` into the
+ * mutation key, so it cannot be moved into the payload.
+ */
+export function useUpdateCommunityMutation(community: string) {
   const { username, authContext } = useMutationAuth();
-  return useUpdateCommunity(username, authContext);
+  return useUpdateCommunity(community, username, authContext, 'async');
 }


### PR DESCRIPTION
Closes #3389

`useSetCommunityRoleMutation` and `useUpdateCommunityMutation` both called their SDK hook as:

```ts
return useSetCommunityRole(username, authContext);
```

but the signature is `(community, username, auth, broadcastMode)` (`@ecency/sdk` dist `index.d.ts:5876` and `:5932`). So `community` received the username, `username` received the AuthContext object, and no adapter was passed. Neither wrapper could sign.

Both have zero call sites today, which is why this went unnoticed. It blocks #3391 and #3392.

### Changes

- Both wrappers now take `community` and pass `(community, username, authContext, 'async')`.
- Comment in the barrel explaining why these two break the zero-argument convention the other wrappers follow: the SDK bakes `community` into the mutation key, so it cannot move into the payload.

No behaviour change anywhere today, since nothing calls them yet.

### Testing

- `yarn test:ci`: 721 passed, 1 skipped.
- `yarn lint`: 0 errors.
- Typechecked both files against the installed SDK types.

Exercised for real by #3391 and #3392.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved community role and profile update mutations by associating requests with the correct community.
  * Enabled asynchronous broadcasting for these community updates.
  * Improved subscription and unsubscription mutation handling for community-specific operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->