### PR TITLE
feat(community): moderator entry point and members list

### DIFF
--- a/src/components/communityManageSheet/communityManageSheet.tsx
+++ b/src/components/communityManageSheet/communityManageSheet.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import { Text, TouchableOpacity, View } from 'react-native';
+import { useIntl } from 'react-intl';
+import ActionSheet, { SheetManager, SheetProps } from 'react-native-actions-sheet';
+import EStyleSheet from 'react-native-extended-stylesheet';
+import { Icon } from '../icon';
+
+const FALLBACK_SHEET_ID = 'community_manage';
+
+/** Destinations offered to a community moderator. */
+export type CommunityManageAction = 'members';
+
+interface Row {
+  action: CommunityManageAction;
+  icon: string;
+  iconType: string;
+  labelId: string;
+}
+
+// Rows are added here as each destination screen lands.
+const ROWS: Row[] = [
+  {
+    action: 'members',
+    icon: 'account-group',
+    iconType: 'MaterialCommunityIcons',
+    labelId: 'community.manage_members',
+  },
+];
+
+/**
+ * Moderator entry point for a community, opened from the community header.
+ *
+ * Resolves the `SheetManager.show` promise with `{ action }` on selection.
+ * Dismissing by backdrop, swipe or back resolves the original payload object,
+ * because the library publishes `data || payloadRef.current` on close, so
+ * callers must gate on a known `action` value rather than on truthiness.
+ */
+const CommunityManageSheet: React.FC<SheetProps<'community_manage'>> = ({ sheetId }) => {
+  const intl = useIntl();
+
+  const _select = (action: CommunityManageAction) => {
+    SheetManager.hide(sheetId || FALLBACK_SHEET_ID, { payload: { action } });
+  };
+
+  return (
+    <ActionSheet
+      id={sheetId || FALLBACK_SHEET_ID}
+      gestureEnabled
+      closeOnTouchBackdrop
+      containerStyle={styles.sheetContainer}
+    >
+      <View style={styles.container}>
+        <Text style={styles.title}>{intl.formatMessage({ id: 'community.manage' })}</Text>
+
+        {ROWS.map((row) => (
+          <TouchableOpacity key={row.action} style={styles.row} onPress={() => _select(row.action)}>
+            <Icon
+              iconType={row.iconType}
+              name={row.icon}
+              size={22}
+              style={styles.rowIcon}
+              color={EStyleSheet.value('$primaryDarkGray')}
+            />
+            <Text style={styles.rowLabel}>{intl.formatMessage({ id: row.labelId })}</Text>
+          </TouchableOpacity>
+        ))}
+      </View>
+    </ActionSheet>
+  );
+};
+
+const styles = EStyleSheet.create({
+  sheetContainer: {
+    paddingHorizontal: 0,
+    backgroundColor: '$primaryBackgroundColor',
+  },
+  container: {
+    paddingHorizontal: 20,
+    paddingVertical: 24,
+    paddingBottom: 40,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    color: '$primaryBlack',
+    textAlign: 'center',
+    marginBottom: 16,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 14,
+  },
+  rowIcon: {
+    marginRight: 14,
+  },
+  rowLabel: {
+    fontSize: 16,
+    color: '$primaryBlack',
+  },
+});
+
+export default CommunityManageSheet;

--- a/src/components/communityManageSheet/index.ts
+++ b/src/components/communityManageSheet/index.ts
@@ -1,0 +1,2 @@
+export { default as CommunityManageSheet } from './communityManageSheet';
+export type { CommunityManageAction } from './communityManageSheet';

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -125,6 +125,7 @@ import { HiveAuthBroadcastSheet } from './hiveAuthBroadcastSheet';
 import EmojiPickerSheet from './emojiPickerSheet';
 import { AuthUpgradeSheet } from './authUpgradeSheet';
 import { ModNotesSheet } from './modNotesSheet';
+import { CommunityManageSheet } from './communityManageSheet';
 import TransferFavoritesSheet from './transferFavoritesSheet/transferFavoritesSheet';
 
 // Basic UI Elements
@@ -306,5 +307,6 @@ export {
   EmojiPickerSheet,
   AuthUpgradeSheet,
   ModNotesSheet,
+  CommunityManageSheet,
   TransferFavoritesSheet,
 };

--- a/src/config/locales/en-US.json
+++ b/src/config/locales/en-US.json
@@ -185,7 +185,17 @@
     "mute_post_title": "Mute this post",
     "unmute_post_title": "Unmute this post",
     "mute_post_reason": "Why is this being muted?",
-    "unmute_post_reason": "Why is this being restored?"
+    "unmute_post_reason": "Why is this being restored?",
+    "manage": "Manage community",
+    "manage_members": "Members and roles",
+    "members": "members",
+    "no_members": "No members found",
+    "role_owner": "Owner",
+    "role_admin": "Admin",
+    "role_mod": "Mod",
+    "role_member": "Member",
+    "role_guest": "Guest",
+    "role_muted": "Muted"
   },
   "trade": {
     "swap_for": "Swapping {fromAmount} for {toAmount}",

--- a/src/config/locales/en-US.json
+++ b/src/config/locales/en-US.json
@@ -190,6 +190,8 @@
     "manage_members": "Members and roles",
     "members": "members",
     "no_members": "No members found",
+    "members_incomplete": "Some members could not be loaded. Pull to refresh.",
+    "members_load_failed": "Could not load members. Pull to refresh.",
     "role_owner": "Owner",
     "role_admin": "Admin",
     "role_mod": "Mod",

--- a/src/constants/routeNames.ts
+++ b/src/constants/routeNames.ts
@@ -33,6 +33,7 @@ const ROUTES = {
     ACCOUNT_BOOST: `AccountBoost${SCREEN_SUFFIX}`,
     COMMUNITY: `Community${SCREEN_SUFFIX}`,
     COMMUNITIES: `Communities${SCREEN_SUFFIX}`,
+    COMMUNITY_MEMBERS: `CommunityMembers${SCREEN_SUFFIX}`,
     WEB_BROWSER: `WebBrowser${SCREEN_SUFFIX}`,
     REFER: `Refer${SCREEN_SUFFIX}`,
     QR: `QR${SCREEN_SUFFIX}`,

--- a/src/navigation/sheets.tsx
+++ b/src/navigation/sheets.tsx
@@ -18,8 +18,10 @@ import {
   ComposeTranslateModal,
   TransferFavoritesSheet,
   ModNotesSheet,
+  CommunityManageSheet,
 } from '../components';
 import type { ModNotesResult } from '../components/modNotesSheet/modNotesSheet';
+import type { CommunityManageAction } from '../components/communityManageSheet/communityManageSheet';
 import { ShareIntentSheet } from '../components/shareIntentSheet';
 import SignConfirmSheet from '../screens/dappBrowser/components/signConfirmSheet';
 import ReceiveQrSheet from '../components/receiveQrSheet/receiveQrSheet';
@@ -52,6 +54,7 @@ export enum SheetNames {
   BALANCE_ANALYTICS = 'balance_analytics',
   TRANSFER_FAVORITES = 'transfer_favorites',
   MOD_NOTES = 'mod_notes',
+  COMMUNITY_MANAGE = 'community_manage',
 }
 
 registerSheet(SheetNames.POST_TRANSLATION, PostTranslationModal);
@@ -77,6 +80,7 @@ registerSheet(SheetNames.RECEIVE_QR, ReceiveQrSheet);
 registerSheet(SheetNames.BALANCE_ANALYTICS, BalanceAnalyticsSheet);
 registerSheet(SheetNames.TRANSFER_FAVORITES, TransferFavoritesSheet);
 registerSheet(SheetNames.MOD_NOTES, ModNotesSheet);
+registerSheet(SheetNames.COMMUNITY_MANAGE, CommunityManageSheet);
 
 // We extend some of the types here to give us great intellisense
 // across the app for all registered sheets.
@@ -245,6 +249,13 @@ declare module 'react-native-actions-sheet' {
       // `data || payloadRef.current` on close. Gate on a string `notes`, never
       // on truthiness.
       returnValue: ModNotesResult | undefined;
+    }>;
+    [SheetNames.COMMUNITY_MANAGE]: SheetDefinition<{
+      // `{ action }` on selection. Dismissing by backdrop, swipe or back
+      // resolves the payload object instead, because the library publishes
+      // `data || payloadRef.current` on close, so match on a known action
+      // rather than on truthiness.
+      returnValue: { action?: CommunityManageAction } | undefined;
     }>;
   }
 }

--- a/src/navigation/stackNavigator.tsx
+++ b/src/navigation/stackNavigator.tsx
@@ -28,6 +28,7 @@ import {
   AccountBoost,
   TagResult,
   Community,
+  CommunityMembers,
   Communities,
   WebBrowser,
   ReferScreen,
@@ -68,6 +69,7 @@ const MainStackNavigator = () => {
       <MainStack.Screen name={ROUTES.SCREENS.PERKS} component={Perks} />
       <MainStack.Screen name={ROUTES.SCREENS.ACCOUNT_BOOST} component={AccountBoost} />
       <MainStack.Screen name={ROUTES.SCREENS.COMMUNITY} component={Community} />
+      <MainStack.Screen name={ROUTES.SCREENS.COMMUNITY_MEMBERS} component={CommunityMembers} />
       <MainStack.Screen name={ROUTES.SCREENS.COMMUNITIES} component={Communities} />
       <MainStack.Screen name={ROUTES.SCREENS.REFER} component={ReferScreen} />
       <MainStack.Screen name={ROUTES.SCREENS.ASSET_DETAILS} component={AssetDetails} />

--- a/src/providers/queries/communityQueries.test.ts
+++ b/src/providers/queries/communityQueries.test.ts
@@ -1,0 +1,27 @@
+import fs from 'fs';
+import path from 'path';
+import { useCommunitySubscribersQuery, SUBSCRIBERS_PAGE_SIZE } from './communityQueries';
+
+describe('communityQueries module surface', () => {
+  it('exports useCommunitySubscribersQuery as a function', () => {
+    expect(typeof useCommunitySubscribersQuery).toBe('function');
+  });
+
+  // The members screen imports this hook through the `providers/queries` barrel.
+  // Shipping the module without the re-export resolves that import to undefined
+  // and crashes the screen on mount, which neither eslint nor any other test
+  // catches. The barrel itself cannot be imported here (it pulls in native
+  // modules through sdk-config), so assert the re-export at the source level.
+  it('is re-exported from the queries barrel', () => {
+    const barrel = fs.readFileSync(path.join(__dirname, 'index.ts'), 'utf8');
+    expect(barrel).toMatch(/export \* from '\.\/communityQueries';/);
+  });
+
+  it("pages at hivemind's list_subscribers cap", () => {
+    // hivemind caps list_subscribers at 100 rows regardless of a larger limit,
+    // and getNextPageParam treats a short page as the end of the list. A page
+    // size above the cap would make every full page look short and stop paging
+    // after the first one.
+    expect(SUBSCRIBERS_PAGE_SIZE).toBeLessThanOrEqual(100);
+  });
+});

--- a/src/providers/queries/communityQueries.ts
+++ b/src/providers/queries/communityQueries.ts
@@ -1,0 +1,47 @@
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { bridgeApiCall } from '@ecency/sdk';
+
+export const SUBSCRIBERS_PAGE_SIZE = 100;
+
+/**
+ * A subscriber row as hivemind returns it: `[account, role, title, joined]`.
+ * Positional, like `community.team`.
+ */
+export type SubscriberRow = string[];
+
+/**
+ * Paginated community subscriber list.
+ *
+ * The SDK's `getCommunitySubscribersQueryOptions` issues a single
+ * `list_subscribers({ community })` call, and hivemind caps that at 100 rows.
+ * Communities are routinely far larger than that (ecency's own has ~11.7k), so
+ * a single call silently returns the first 100 accounts alphabetically and
+ * presents them as the whole roster. This pages with the documented
+ * `last` + `limit` cursor instead, where `last` is the previous page's final
+ * account name.
+ */
+export const useCommunitySubscribersQuery = (community: string, enabled = true) =>
+  useInfiniteQuery({
+    queryKey: ['communities', 'subscribers', 'infinite', community],
+    enabled: enabled && !!community,
+    initialPageParam: '',
+    queryFn: async ({ pageParam }) => {
+      const params: Record<string, unknown> = { community, limit: SUBSCRIBERS_PAGE_SIZE };
+      // hivemind treats an empty `last` as a real cursor positioned before the
+      // first account and returns zero rows, so it has to be omitted on the
+      // first page rather than passed as ''. Verified against api.hive.blog:
+      // `{community, limit}` returns 100 rows, `{community, last: '', limit}`
+      // returns 0.
+      if (pageParam) {
+        params.last = pageParam;
+      }
+      return (await bridgeApiCall<SubscriberRow[]>('list_subscribers', params)) ?? [];
+    },
+    getNextPageParam: (lastPage: SubscriberRow[]) => {
+      // A short page means the end of the list. Returning undefined stops paging.
+      if (!lastPage?.length || lastPage.length < SUBSCRIBERS_PAGE_SIZE) {
+        return undefined;
+      }
+      return lastPage[lastPage.length - 1]?.[0];
+    },
+  });

--- a/src/providers/queries/index.ts
+++ b/src/providers/queries/index.ts
@@ -139,3 +139,4 @@ export * from './proposalQueries';
 export * from './proQueries';
 export * from './statsQueries';
 export * from './searchQueries';
+export * from './communityQueries';

--- a/src/screens/community/container/communityContainer.ts
+++ b/src/screens/community/container/communityContainer.ts
@@ -11,6 +11,7 @@ import { updateSubscribedCommunitiesCache } from '../../../redux/actions/cacheAc
 import { statusMessage } from '../../../redux/constants/communitiesConstants';
 import { selectCurrentAccount, selectIsLoggedIn } from '../../../redux/selectors';
 import { useAppSelector, useCommunitySubscriptionAction } from '../../../hooks';
+import { isCommunityModerator } from '../../../utils/communityModeration';
 
 const CommunityContainer = ({ tag, children, currentAccount, isLoggedIn }) => {
   const navigation = useNavigation();
@@ -87,6 +88,11 @@ const CommunityContainer = ({ tag, children, currentAccount, isLoggedIn }) => {
     });
   };
 
+  // Moderator authority comes from the community team, not from the Redux
+  // subscription list: it does not depend on being subscribed, and the role slot
+  // in that list is overwritable.
+  const isModerator = isCommunityModerator(data?.team, currentAccount?.name);
+
   return (
     children &&
     children({
@@ -95,6 +101,7 @@ const CommunityContainer = ({ tag, children, currentAccount, isLoggedIn }) => {
       handleNewPostButtonPress: _handleNewPostButtonPress,
       isSubscribed,
       isLoggedIn,
+      isModerator,
     })
   );
 };

--- a/src/screens/community/screen/communityScreen.tsx
+++ b/src/screens/community/screen/communityScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { View, Text, ScrollView } from 'react-native';
 import { useIntl } from 'react-intl';
 
@@ -6,6 +6,8 @@ import { useIntl } from 'react-intl';
 import { gestureHandlerRootHOC } from 'react-native-gesture-handler';
 import { TabItem } from 'components/tabbedPosts/types/tabbedPosts.types';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { SheetManager } from 'react-native-actions-sheet';
+import { useNavigation } from '@react-navigation/native';
 import { CollapsibleCard, BasicHeader, TabbedPosts } from '../../../components';
 import { Tag, ProfileSummaryPlaceHolder } from '../../../components/basicUIElements';
 
@@ -15,12 +17,15 @@ import CommunityContainer from '../container/communityContainer';
 import styles from './communityStyles';
 
 import { COMMUNITY_SCREEN_FILTER_MAP, getDefaultFilters } from '../../../constants/options/filters';
+import ROUTES from '../../../constants/routeNames';
+import { SheetNames } from '../../../navigation/sheets';
 import { useAppSelector } from '../../../hooks';
 
 const CommunityScreen = ({ route }) => {
   const tag = route.params?.tag ?? '';
   const filter = route.params?.filter ?? '';
   const intl = useIntl();
+  const navigation = useNavigation();
   const [isExpanded, setIsExpanded] = useState(true);
 
   const communityTabs = useAppSelector(
@@ -61,6 +66,29 @@ const CommunityScreen = ({ route }) => {
     }
   };
 
+  const _handleManagePress = useCallback(
+    async (data) => {
+      const result = await SheetManager.show(SheetNames.COMMUNITY_MANAGE);
+
+      // Only a selection carries a known action. Backdrop, swipe and back
+      // dismissals resolve the sheet's payload object instead, so match on the
+      // action rather than on truthiness.
+      if (result?.action !== 'members') {
+        return;
+      }
+
+      navigation.navigate({
+        name: ROUTES.SCREENS.COMMUNITY_MEMBERS,
+        key: `community_members_${tag}`,
+        params: {
+          communityId: data?.name || tag,
+          communityTitle: data?.title || '',
+        },
+      });
+    },
+    [navigation, tag],
+  );
+
   return (
     <CommunityContainer tag={tag}>
       {({
@@ -69,6 +97,7 @@ const CommunityScreen = ({ route }) => {
         handleNewPostButtonPress,
         isSubscribed,
         isLoggedIn,
+        isModerator,
       }) => (
         <SafeAreaView style={styles.container}>
           <BasicHeader
@@ -76,6 +105,9 @@ const CommunityScreen = ({ route }) => {
               id: 'community.community',
             })}`}
             enableViewModeToggle={true}
+            rightIconName={isModerator ? 'shield-account-outline' : undefined}
+            iconType="MaterialCommunityIcons"
+            handleRightIconPress={() => _handleManagePress(data)}
           />
           {data ? (
             <CollapsibleCard

--- a/src/screens/communityMembers/index.ts
+++ b/src/screens/communityMembers/index.ts
@@ -1,0 +1,4 @@
+import CommunityMembers from './screen/communityMembersScreen';
+
+export { CommunityMembers };
+export default CommunityMembers;

--- a/src/screens/communityMembers/screen/communityMembersScreen.tsx
+++ b/src/screens/communityMembers/screen/communityMembersScreen.tsx
@@ -1,0 +1,158 @@
+import React, { useMemo } from 'react';
+import { ActivityIndicator, FlatList, RefreshControl, Text, View } from 'react-native';
+import { useIntl } from 'react-intl';
+import { useNavigation } from '@react-navigation/native';
+import { useQuery } from '@tanstack/react-query';
+import { gestureHandlerRootHOC } from 'react-native-gesture-handler';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { getCommunityQueryOptions, getCommunitySubscribersQueryOptions, ROLES } from '@ecency/sdk';
+
+import { BasicHeader, UserListItem } from '../../../components';
+import ROUTES from '../../../constants/routeNames';
+import { useAppSelector } from '../../../hooks';
+import { selectCurrentAccount, selectIsDarkTheme } from '../../../redux/selectors';
+import { isCommunity } from '../../../utils/communityValidation';
+import styles from '../styles/communityMembersScreen.styles';
+
+// hivemind returns both `community.team` and the subscriber list as positional
+// tuples of [account, role, title]. Never index these inline elsewhere; the
+// helpers in utils/communityModeration.ts exist for that reason.
+const ACCOUNT_INDEX = 0;
+const ROLE_INDEX = 1;
+const TITLE_INDEX = 2;
+
+// Order the list the way the roster reads: authority first, then everyone else.
+const ROLE_ORDER: Record<string, number> = {
+  [ROLES.OWNER]: 0,
+  [ROLES.ADMIN]: 1,
+  [ROLES.MOD]: 2,
+  [ROLES.MEMBER]: 3,
+  [ROLES.GUEST]: 4,
+  [ROLES.MUTED]: 5,
+};
+
+interface Member {
+  account: string;
+  role: string;
+  title: string;
+}
+
+const CommunityMembersScreen = ({ route }) => {
+  const intl = useIntl();
+  const navigation = useNavigation();
+
+  const communityId: string = route.params?.communityId ?? '';
+  const communityTitle: string = route.params?.communityTitle ?? '';
+
+  const currentAccount = useAppSelector(selectCurrentAccount);
+  const isDarkTheme = useAppSelector(selectIsDarkTheme);
+
+  const communityQuery = useQuery(
+    getCommunityQueryOptions(communityId, currentAccount?.name, !!communityId),
+  );
+  const subscribersQuery = useQuery({
+    ...getCommunitySubscribersQueryOptions(communityId),
+    enabled: !!communityId,
+  });
+
+  const members: Member[] = useMemo(() => {
+    const byAccount = new Map<string, Member>();
+
+    const add = (tuple?: string[]) => {
+      const account = tuple?.[ACCOUNT_INDEX];
+      // The community account itself appears in its own team. It is not a
+      // person and has no role worth showing, so drop it as web does.
+      if (!account || isCommunity(account)) {
+        return;
+      }
+      // The team carries the authoritative role, so it wins over the
+      // subscriber entry for the same account.
+      if (byAccount.has(account)) {
+        return;
+      }
+      byAccount.set(account, {
+        account,
+        role: tuple?.[ROLE_INDEX] || ROLES.GUEST,
+        title: tuple?.[TITLE_INDEX] || '',
+      });
+    };
+
+    (communityQuery.data?.team || []).forEach(add);
+    (subscribersQuery.data || []).forEach(add);
+
+    return [...byAccount.values()].sort((a, b) => {
+      const rank = (ROLE_ORDER[a.role] ?? 99) - (ROLE_ORDER[b.role] ?? 99);
+      return rank !== 0 ? rank : a.account.localeCompare(b.account);
+    });
+  }, [communityQuery.data, subscribersQuery.data]);
+
+  const isLoading = communityQuery.isLoading || subscribersQuery.isLoading;
+
+  const _refresh = () => {
+    communityQuery.refetch();
+    subscribersQuery.refetch();
+  };
+
+  const _handleOnUserPress = (username: string) => {
+    navigation.navigate({
+      name: ROUTES.SCREENS.PROFILE,
+      key: username,
+      params: { username },
+    });
+  };
+
+  const _renderRoleChip = (member: Member) => (
+    <View style={styles.roleChip}>
+      <Text style={styles.roleChipText}>
+        {intl.formatMessage({ id: `community.role_${member.role}` })}
+      </Text>
+    </View>
+  );
+
+  const _renderItem = ({ item, index }: { item: Member; index: number }) => (
+    <UserListItem
+      index={index}
+      username={item.account}
+      description={item.title}
+      handleOnPress={() => _handleOnUserPress(item.account)}
+      rightItemRenderer={() => _renderRoleChip(item)}
+    />
+  );
+
+  const _renderEmpty = () => {
+    if (isLoading) {
+      return <ActivityIndicator style={styles.loading} />;
+    }
+    return (
+      <Text style={styles.emptyText}>{intl.formatMessage({ id: 'community.no_members' })}</Text>
+    );
+  };
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <BasicHeader
+        title={`${communityTitle || communityId} ${intl.formatMessage({
+          id: 'community.members',
+        })}`}
+      />
+      <FlatList
+        data={members}
+        keyExtractor={(item) => item.account}
+        renderItem={_renderItem}
+        ListEmptyComponent={_renderEmpty}
+        refreshControl={
+          <RefreshControl
+            refreshing={communityQuery.isRefetching || subscribersQuery.isRefetching}
+            onRefresh={_refresh}
+            progressBackgroundColor="#357CE6"
+            tintColor={!isDarkTheme ? '#357ce6' : '#96c0ff'}
+            titleColor="#fff"
+            colors={['#fff']}
+          />
+        }
+      />
+    </SafeAreaView>
+  );
+};
+
+export default gestureHandlerRootHOC(CommunityMembersScreen);

--- a/src/screens/communityMembers/screen/communityMembersScreen.tsx
+++ b/src/screens/communityMembers/screen/communityMembersScreen.tsx
@@ -5,16 +5,17 @@ import { useNavigation } from '@react-navigation/native';
 import { useQuery } from '@tanstack/react-query';
 import { gestureHandlerRootHOC } from 'react-native-gesture-handler';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { getCommunityQueryOptions, getCommunitySubscribersQueryOptions, ROLES } from '@ecency/sdk';
+import { getCommunityQueryOptions, ROLES } from '@ecency/sdk';
 
 import { BasicHeader, UserListItem } from '../../../components';
 import ROUTES from '../../../constants/routeNames';
 import { useAppSelector } from '../../../hooks';
+import { useCommunitySubscribersQuery } from '../../../providers/queries';
 import { selectCurrentAccount, selectIsDarkTheme } from '../../../redux/selectors';
 import { isCommunity } from '../../../utils/communityValidation';
 import styles from '../styles/communityMembersScreen.styles';
 
-// hivemind returns both `community.team` and the subscriber list as positional
+// hivemind returns both `community.team` and each subscriber row as positional
 // tuples of [account, role, title]. Never index these inline elsewhere; the
 // helpers in utils/communityModeration.ts exist for that reason.
 const ACCOUNT_INDEX = 0;
@@ -50,10 +51,7 @@ const CommunityMembersScreen = ({ route }) => {
   const communityQuery = useQuery(
     getCommunityQueryOptions(communityId, currentAccount?.name, !!communityId),
   );
-  const subscribersQuery = useQuery({
-    ...getCommunitySubscribersQueryOptions(communityId),
-    enabled: !!communityId,
-  });
+  const subscribersQuery = useCommunitySubscribersQuery(communityId);
 
   const members: Member[] = useMemo(() => {
     const byAccount = new Map<string, Member>();
@@ -78,7 +76,7 @@ const CommunityMembersScreen = ({ route }) => {
     };
 
     (communityQuery.data?.team || []).forEach(add);
-    (subscribersQuery.data || []).forEach(add);
+    (subscribersQuery.data?.pages?.flat() || []).forEach(add);
 
     return [...byAccount.values()].sort((a, b) => {
       const rank = (ROLE_ORDER[a.role] ?? 99) - (ROLE_ORDER[b.role] ?? 99);
@@ -87,10 +85,20 @@ const CommunityMembersScreen = ({ route }) => {
   }, [communityQuery.data, subscribersQuery.data]);
 
   const isLoading = communityQuery.isLoading || subscribersQuery.isLoading;
+  // Surfaced separately from the empty case: a failed query also yields zero
+  // rows, and rendering "no members" for it reads as an authoritative answer
+  // when the roster is simply unknown.
+  const isError = communityQuery.isError || subscribersQuery.isError;
 
   const _refresh = () => {
     communityQuery.refetch();
     subscribersQuery.refetch();
+  };
+
+  const _loadMore = () => {
+    if (subscribersQuery.hasNextPage && !subscribersQuery.isFetchingNextPage) {
+      subscribersQuery.fetchNextPage();
+    }
   };
 
   const _handleOnUserPress = (username: string) => {
@@ -124,8 +132,27 @@ const CommunityMembersScreen = ({ route }) => {
       return <ActivityIndicator style={styles.loading} />;
     }
     return (
-      <Text style={styles.emptyText}>{intl.formatMessage({ id: 'community.no_members' })}</Text>
+      <Text style={styles.emptyText}>
+        {intl.formatMessage({
+          id: isError ? 'community.members_load_failed' : 'community.no_members',
+        })}
+      </Text>
     );
+  };
+
+  const _renderFooter = () => {
+    if (subscribersQuery.isFetchingNextPage) {
+      return <ActivityIndicator style={styles.loading} />;
+    }
+    // A partially loaded roster must not read as complete.
+    if (isError && members.length > 0) {
+      return (
+        <Text style={styles.footerNote}>
+          {intl.formatMessage({ id: 'community.members_incomplete' })}
+        </Text>
+      );
+    }
+    return null;
   };
 
   return (
@@ -140,6 +167,9 @@ const CommunityMembersScreen = ({ route }) => {
         keyExtractor={(item) => item.account}
         renderItem={_renderItem}
         ListEmptyComponent={_renderEmpty}
+        ListFooterComponent={_renderFooter}
+        onEndReachedThreshold={0.5}
+        onEndReached={_loadMore}
         refreshControl={
           <RefreshControl
             refreshing={communityQuery.isRefetching || subscribersQuery.isRefetching}

--- a/src/screens/communityMembers/styles/communityMembersScreen.styles.ts
+++ b/src/screens/communityMembers/styles/communityMembersScreen.styles.ts
@@ -1,0 +1,28 @@
+import EStyleSheet from 'react-native-extended-stylesheet';
+
+export default EStyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '$primaryBackgroundColor',
+  },
+  loading: {
+    marginTop: 32,
+  },
+  emptyText: {
+    marginTop: 32,
+    textAlign: 'center',
+    color: '$primaryDarkGray',
+    fontSize: 14,
+  },
+  roleChip: {
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    borderRadius: 12,
+    backgroundColor: '$primaryLightBackground',
+  },
+  roleChipText: {
+    fontSize: 12,
+    color: '$primaryDarkGray',
+    textTransform: 'capitalize',
+  },
+});

--- a/src/screens/communityMembers/styles/communityMembersScreen.styles.ts
+++ b/src/screens/communityMembers/styles/communityMembersScreen.styles.ts
@@ -14,6 +14,13 @@ export default EStyleSheet.create({
     color: '$primaryDarkGray',
     fontSize: 14,
   },
+  footerNote: {
+    paddingVertical: 16,
+    paddingHorizontal: 20,
+    textAlign: 'center',
+    color: '$primaryDarkGray',
+    fontSize: 12,
+  },
   roleChip: {
     paddingHorizontal: 10,
     paddingVertical: 4,

--- a/src/screens/index.ts
+++ b/src/screens/index.ts
@@ -27,6 +27,7 @@ import AccountBoost from './accountBoost/screen/accountBoostScreen';
 import Register from './register/registerScreen';
 import TagResult from './tagResult';
 import { Community } from './community';
+import { CommunityMembers } from './communityMembers';
 import Communities from './communities';
 import ReferScreen from './referScreen/referScreen';
 import AssetDetails from './assetDetails';
@@ -72,6 +73,7 @@ export {
   ChatThread,
   TagResult,
   Community,
+  CommunityMembers,
   Communities,
   WebBrowser,
   ReferScreen,


### PR DESCRIPTION
Closes #3390

The community screen had no way in to any moderation surface. Web has `/roles/<c>`, `/subscribers/<c>` and `/activities/<c>`; mobile had none, and `getCommunitySubscribersQueryOptions` had zero call sites.

### Changes

**Entry point.** `BasicHeader` on the community screen now renders a `rightIconName`, but only when the viewer is a moderator of that community. `CommunityContainer` derives `isModerator` from the community team via `isCommunityModerator`, reusing the query it already runs. Tapping it opens `SheetNames.COMMUNITY_MANAGE`.

The sheet is a row-per-destination list, so #3392 and #3393 are additions to `ROWS` rather than a rewire. It has one row today.

**Members screen** (`src/screens/communityMembers/`). Merges `community.team` with `getCommunitySubscribersQueryOptions(name)`:

- Both come back as positional tuples, not objects.
- The team entry wins on conflict, since it carries the authoritative role while a subscriber entry may not.
- The community account is dropped from its own roster, as web does (`community-subscribers/index.tsx:38`).
- Rows sort by authority (`owner` > `admin` > `mod` > `member` > `guest` > `muted`) then alphabetically, so the roster reads top-down.
- Rendered with `UserListItem`, role chip via `rightItemRenderer`, tap routes to the profile.

Read-only. Role editing is #3391 so this can land and be tested on its own.

Moderator gating here is for UI only. Nothing on this screen mutates, and the underlying routes are public on web, so the gate is on the entry point rather than the data.

### Testing

- `yarn test:ci`: 721 passed, 1 skipped, 48 suites.
- `yarn lint`: 0 errors.

Note on typechecking: `tsc` cannot run against this repo's `tsconfig.json` at all (`TS5098`, pre-existing), and CI gates on lint + jest only. I checked the new files under an ad-hoc config and every error that surfaced also reproduces on untouched files - `UserListItem` and `BasicHeader` prop errors reproduce on `reblogScreen.tsx`, and the `keyof Sheets` error reproduces on every existing sheet including `auth_upgrade` and `mod_notes`.

Needs a device pass: confirm the header icon appears for a moderator and is absent for a normal member and a logged-out viewer, that the roster shows roles correctly, and that dismissing the Manage sheet by backdrop, swipe and back navigates nowhere.
