### PR TITLE
feat(community): edit member roles

### DIFF
--- a/src/components/communityRoleEditSheet/communityRoleEditSheet.tsx
+++ b/src/components/communityRoleEditSheet/communityRoleEditSheet.tsx
@@ -1,0 +1,127 @@
+import React from 'react';
+import { Text, TouchableOpacity, View } from 'react-native';
+import { useIntl } from 'react-intl';
+import ActionSheet, { SheetManager, SheetProps } from 'react-native-actions-sheet';
+import EStyleSheet from 'react-native-extended-stylesheet';
+import { Icon } from '../icon';
+
+const FALLBACK_SHEET_ID = 'community_role_edit';
+
+/**
+ * Result of the sheet.
+ *
+ * An object rather than a bare role string because react-native-actions-sheet
+ * 0.9.7 publishes `data || payloadRef.current` on close, so any falsy return
+ * value is replaced by the original payload object. Callers must gate on a
+ * string `role` rather than on truthiness.
+ */
+export interface CommunityRoleEditResult {
+  role?: string;
+  cancelled?: boolean;
+}
+
+const CommunityRoleEditSheet: React.FC<SheetProps<'community_role_edit'>> = ({
+  sheetId,
+  payload,
+}) => {
+  const intl = useIntl();
+
+  const account = payload?.account ?? '';
+  const currentRole = payload?.currentRole ?? '';
+  const assignableRoles = payload?.assignableRoles ?? [];
+
+  const _close = (result: CommunityRoleEditResult) => {
+    SheetManager.hide(sheetId || FALLBACK_SHEET_ID, { payload: result });
+  };
+
+  return (
+    <ActionSheet
+      id={sheetId || FALLBACK_SHEET_ID}
+      gestureEnabled
+      closeOnTouchBackdrop
+      containerStyle={styles.sheetContainer}
+    >
+      <View style={styles.container}>
+        <Text style={styles.title}>{intl.formatMessage({ id: 'community.set_role' })}</Text>
+        <Text style={styles.subtitle}>{`@${account}`}</Text>
+
+        {assignableRoles.map((role) => {
+          const isCurrent = role === currentRole;
+          return (
+            <TouchableOpacity
+              key={role}
+              style={styles.row}
+              disabled={isCurrent}
+              onPress={() => _close({ role })}
+            >
+              <Text style={[styles.rowLabel, isCurrent && styles.rowLabelCurrent]}>
+                {intl.formatMessage({ id: `community.role_${role}` })}
+              </Text>
+              {isCurrent && (
+                <Icon
+                  iconType="MaterialCommunityIcons"
+                  name="check"
+                  size={20}
+                  color={EStyleSheet.value('$primaryBlue')}
+                />
+              )}
+            </TouchableOpacity>
+          );
+        })}
+
+        <TouchableOpacity style={styles.cancelRow} onPress={() => _close({ cancelled: true })}>
+          <Text style={styles.cancelLabel}>{intl.formatMessage({ id: 'alert.cancel' })}</Text>
+        </TouchableOpacity>
+      </View>
+    </ActionSheet>
+  );
+};
+
+const styles = EStyleSheet.create({
+  sheetContainer: {
+    paddingHorizontal: 0,
+    backgroundColor: '$primaryBackgroundColor',
+  },
+  container: {
+    paddingHorizontal: 20,
+    paddingVertical: 24,
+    paddingBottom: 40,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    color: '$primaryBlack',
+    textAlign: 'center',
+  },
+  subtitle: {
+    fontSize: 14,
+    color: '$primaryDarkGray',
+    textAlign: 'center',
+    marginTop: 4,
+    marginBottom: 16,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingVertical: 14,
+  },
+  rowLabel: {
+    fontSize: 16,
+    color: '$primaryBlack',
+  },
+  rowLabelCurrent: {
+    color: '$primaryDarkGray',
+  },
+  cancelRow: {
+    paddingVertical: 14,
+    marginTop: 8,
+  },
+  cancelLabel: {
+    fontSize: 16,
+    color: '$primaryDarkGray',
+    textAlign: 'center',
+  },
+});
+
+export default CommunityRoleEditSheet;

--- a/src/components/communityRoleEditSheet/index.ts
+++ b/src/components/communityRoleEditSheet/index.ts
@@ -1,0 +1,2 @@
+export { default as CommunityRoleEditSheet } from './communityRoleEditSheet';
+export type { CommunityRoleEditResult } from './communityRoleEditSheet';

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -127,6 +127,7 @@ import EmojiPickerSheet from './emojiPickerSheet';
 import { AuthUpgradeSheet } from './authUpgradeSheet';
 import { ModNotesSheet } from './modNotesSheet';
 import { CommunityManageSheet } from './communityManageSheet';
+import { CommunityRoleEditSheet } from './communityRoleEditSheet';
 import TransferFavoritesSheet from './transferFavoritesSheet/transferFavoritesSheet';
 
 // Basic UI Elements
@@ -310,5 +311,6 @@ export {
   AuthUpgradeSheet,
   ModNotesSheet,
   CommunityManageSheet,
+  CommunityRoleEditSheet,
   TransferFavoritesSheet,
 };

--- a/src/config/locales/en-US.json
+++ b/src/config/locales/en-US.json
@@ -188,6 +188,7 @@
     "unmute_post_reason": "Why is this being restored?",
     "manage": "Manage community",
     "manage_members": "Members and roles",
+    "set_role": "Set role",
     "members": "members",
     "no_members": "No members found",
     "members_incomplete": "Some members could not be loaded. Pull to refresh.",

--- a/src/navigation/sheets.tsx
+++ b/src/navigation/sheets.tsx
@@ -20,9 +20,11 @@ import {
   TransferFavoritesSheet,
   ModNotesSheet,
   CommunityManageSheet,
+  CommunityRoleEditSheet,
 } from '../components';
 import type { ModNotesResult } from '../components/modNotesSheet/modNotesSheet';
 import type { CommunityManageAction } from '../components/communityManageSheet/communityManageSheet';
+import type { CommunityRoleEditResult } from '../components/communityRoleEditSheet/communityRoleEditSheet';
 import { ShareIntentSheet } from '../components/shareIntentSheet';
 import SignConfirmSheet from '../screens/dappBrowser/components/signConfirmSheet';
 import ReceiveQrSheet from '../components/receiveQrSheet/receiveQrSheet';
@@ -57,6 +59,7 @@ export enum SheetNames {
   TRANSFER_FAVORITES = 'transfer_favorites',
   MOD_NOTES = 'mod_notes',
   COMMUNITY_MANAGE = 'community_manage',
+  COMMUNITY_ROLE_EDIT = 'community_role_edit',
 }
 
 registerSheet(SheetNames.POST_TRANSLATION, PostTranslationModal);
@@ -84,6 +87,7 @@ registerSheet(SheetNames.BALANCE_ANALYTICS, BalanceAnalyticsSheet);
 registerSheet(SheetNames.TRANSFER_FAVORITES, TransferFavoritesSheet);
 registerSheet(SheetNames.MOD_NOTES, ModNotesSheet);
 registerSheet(SheetNames.COMMUNITY_MANAGE, CommunityManageSheet);
+registerSheet(SheetNames.COMMUNITY_ROLE_EDIT, CommunityRoleEditSheet);
 
 // We extend some of the types here to give us great intellisense
 // across the app for all registered sheets.
@@ -264,6 +268,18 @@ declare module 'react-native-actions-sheet' {
       // `data || payloadRef.current` on close, so match on a known action
       // rather than on truthiness.
       returnValue: { action?: CommunityManageAction } | undefined;
+    }>;
+    [SheetNames.COMMUNITY_ROLE_EDIT]: SheetDefinition<{
+      payload: {
+        account: string;
+        currentRole: string;
+        assignableRoles: string[];
+      };
+      // `{ role }` on selection, `{ cancelled: true }` on cancel. A backdrop,
+      // swipe or back dismissal resolves the payload object instead, because
+      // the library publishes `data || payloadRef.current` on close. Gate on a
+      // string `role`, never on truthiness.
+      returnValue: CommunityRoleEditResult | undefined;
     }>;
   }
 }

--- a/src/providers/queries/communityQueries.test.ts
+++ b/src/providers/queries/communityQueries.test.ts
@@ -1,6 +1,10 @@
 import fs from 'fs';
 import path from 'path';
-import { useCommunitySubscribersQuery, SUBSCRIBERS_PAGE_SIZE } from './communityQueries';
+import {
+  applyRoleToSubscribersCache,
+  useCommunitySubscribersQuery,
+  SUBSCRIBERS_PAGE_SIZE,
+} from './communityQueries';
 
 describe('communityQueries module surface', () => {
   it('exports useCommunitySubscribersQuery as a function', () => {
@@ -23,5 +27,54 @@ describe('communityQueries module surface', () => {
     // size above the cap would make every full page look short and stop paging
     // after the first one.
     expect(SUBSCRIBERS_PAGE_SIZE).toBeLessThanOrEqual(100);
+  });
+});
+
+describe('applyRoleToSubscribersCache', () => {
+  // hivemind rows are [account, role, title, joined].
+  const cache = {
+    pages: [
+      [
+        ['alice', 'mod', 'Head mod', '2024-01-01T00:00:00'],
+        ['bob', 'guest', '', '2024-02-01T00:00:00'],
+      ],
+      [['carol', 'member', '', '2024-03-01T00:00:00']],
+    ],
+    pageParams: ['', 'bob'],
+  };
+
+  it('rewrites the role on the matching account only', () => {
+    const next = applyRoleToSubscribersCache(cache, 'bob', 'mod');
+    expect(next?.pages?.[0][1]).toEqual(['bob', 'mod', '', '2024-02-01T00:00:00']);
+    expect(next?.pages?.[0][0]).toEqual(['alice', 'mod', 'Head mod', '2024-01-01T00:00:00']);
+  });
+
+  it('reaches accounts on later pages', () => {
+    const next = applyRoleToSubscribersCache(cache, 'carol', 'muted');
+    expect(next?.pages?.[1][0]).toEqual(['carol', 'muted', '', '2024-03-01T00:00:00']);
+  });
+
+  it('preserves the rest of the tuple, including title and joined date', () => {
+    const next = applyRoleToSubscribersCache(cache, 'alice', 'admin');
+    expect(next?.pages?.[0][0]).toEqual(['alice', 'admin', 'Head mod', '2024-01-01T00:00:00']);
+  });
+
+  it('keeps pageParams so paging continues from the same cursor', () => {
+    expect(applyRoleToSubscribersCache(cache, 'bob', 'mod')?.pageParams).toEqual(['', 'bob']);
+  });
+
+  it('does not mutate the cached object', () => {
+    const snapshot = JSON.parse(JSON.stringify(cache));
+    applyRoleToSubscribersCache(cache, 'bob', 'muted');
+    expect(cache).toEqual(snapshot);
+  });
+
+  it('is a no-op for an account that is not cached', () => {
+    expect(applyRoleToSubscribersCache(cache, 'nobody', 'mod')).toEqual(cache);
+  });
+
+  it('handles an absent or empty cache', () => {
+    expect(applyRoleToSubscribersCache(undefined, 'bob', 'mod')).toBeUndefined();
+    expect(applyRoleToSubscribersCache({}, 'bob', 'mod')).toEqual({});
   });
 });

--- a/src/providers/queries/communityQueries.ts
+++ b/src/providers/queries/communityQueries.ts
@@ -20,9 +20,16 @@ export type SubscriberRow = string[];
  * `last` + `limit` cursor instead, where `last` is the previous page's final
  * account name.
  */
+export const communitySubscribersQueryKey = (community: string) => [
+  'communities',
+  'subscribers',
+  'infinite',
+  community,
+];
+
 export const useCommunitySubscribersQuery = (community: string, enabled = true) =>
   useInfiniteQuery({
-    queryKey: ['communities', 'subscribers', 'infinite', community],
+    queryKey: communitySubscribersQueryKey(community),
     enabled: enabled && !!community,
     initialPageParam: '',
     queryFn: async ({ pageParam }) => {
@@ -45,3 +52,44 @@ export const useCommunitySubscribersQuery = (community: string, enabled = true) 
       return lastPage[lastPage.length - 1]?.[0];
     },
   });
+
+/** Shape of the cached infinite subscribers query. */
+export interface SubscribersCache {
+  pages?: SubscriberRow[][];
+  pageParams?: unknown[];
+}
+
+const ACCOUNT_INDEX = 0;
+const TITLE_INDEX = 2;
+
+/**
+ * Rewrites one account's role in the cached subscriber pages, preserving the
+ * rest of each tuple.
+ *
+ * Used after a successful setRole instead of invalidating. setRole broadcasts
+ * async, so mutateAsync resolves on mempool acceptance and any refetch issued
+ * now returns pre-transaction state from hivemind. The SDK patches the cached
+ * community `team` for the same reason, but never touches the subscriber list,
+ * which is what the roster falls back to once a demotion drops an account off
+ * the team.
+ */
+export const applyRoleToSubscribersCache = (
+  cached: SubscribersCache | undefined,
+  account: string,
+  role: string,
+): SubscribersCache | undefined => {
+  if (!cached?.pages) {
+    return cached;
+  }
+
+  return {
+    ...cached,
+    pages: cached.pages.map((page) =>
+      page.map((tuple) =>
+        tuple?.[ACCOUNT_INDEX] === account
+          ? [tuple[ACCOUNT_INDEX], role, ...tuple.slice(TITLE_INDEX)]
+          : tuple,
+      ),
+    ),
+  };
+};

--- a/src/screens/communityMembers/screen/communityMembersScreen.tsx
+++ b/src/screens/communityMembers/screen/communityMembersScreen.tsx
@@ -23,7 +23,11 @@ import { SheetNames } from '../../../navigation/sheets';
 import { useSetCommunityRoleMutation } from '../../../providers/sdk/mutations';
 import { toastNotification } from '../../../redux/actions/uiAction';
 import { getCommunityRole } from '../../../utils/communityModeration';
-import { useCommunitySubscribersQuery } from '../../../providers/queries';
+import {
+  applyRoleToSubscribersCache,
+  communitySubscribersQueryKey,
+  useCommunitySubscribersQuery,
+} from '../../../providers/queries';
 import { selectCurrentAccount, selectIsDarkTheme } from '../../../redux/selectors';
 import { isCommunity } from '../../../utils/communityValidation';
 import styles from '../styles/communityMembersScreen.styles';
@@ -158,10 +162,21 @@ const CommunityMembersScreen = ({ route }) => {
     try {
       await setCommunityRoleMutation.mutateAsync({ account: member.account, role });
       dispatch(toastNotification(intl.formatMessage({ id: 'alert.successful' })));
-      // The team drives both the roster and the gate above, so it has to refetch.
-      queryClient.invalidateQueries({
-        queryKey: getCommunityQueryOptions(communityId, currentAccount?.name).queryKey,
-      });
+
+      // Deliberately no invalidation here. The SDK's useSetCommunityRole already
+      // patches the cached `team` optimistically and invalidates the community
+      // query itself, and setRole broadcasts async: mutateAsync resolves on
+      // mempool acceptance, so anything refetched now returns pre-transaction
+      // state from hivemind and undoes the optimistic value.
+      //
+      // The subscriber roster is the gap. The SDK never touches it, and it is
+      // what the list falls back to when a demotion drops an account off the
+      // team, so it would keep serving the old role and keep the row editable
+      // against stale data. Patch it in place for the same reason: refetching
+      // would race indexing.
+      queryClient.setQueryData(communitySubscribersQueryKey(communityId), (cached) =>
+        applyRoleToSubscribersCache(cached, member.account, role),
+      );
     } catch (err) {
       Alert.alert(intl.formatMessage({ id: 'alert.fail' }), (err as Error)?.message || String(err));
     }

--- a/src/screens/communityMembers/screen/communityMembersScreen.tsx
+++ b/src/screens/communityMembers/screen/communityMembersScreen.tsx
@@ -1,15 +1,28 @@
 import React, { useMemo } from 'react';
-import { ActivityIndicator, FlatList, RefreshControl, Text, View } from 'react-native';
+import {
+  ActivityIndicator,
+  Alert,
+  FlatList,
+  RefreshControl,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
 import { useIntl } from 'react-intl';
 import { useNavigation } from '@react-navigation/native';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { gestureHandlerRootHOC } from 'react-native-gesture-handler';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { getCommunityQueryOptions, ROLES } from '@ecency/sdk';
+import { SheetManager } from 'react-native-actions-sheet';
+import { getCommunityQueryOptions, ROLES, roleMap } from '@ecency/sdk';
 
 import { BasicHeader, UserListItem } from '../../../components';
 import ROUTES from '../../../constants/routeNames';
-import { useAppSelector } from '../../../hooks';
+import { useAppDispatch, useAppSelector } from '../../../hooks';
+import { SheetNames } from '../../../navigation/sheets';
+import { useSetCommunityRoleMutation } from '../../../providers/sdk/mutations';
+import { toastNotification } from '../../../redux/actions/uiAction';
+import { getCommunityRole } from '../../../utils/communityModeration';
 import { useCommunitySubscribersQuery } from '../../../providers/queries';
 import { selectCurrentAccount, selectIsDarkTheme } from '../../../redux/selectors';
 import { isCommunity } from '../../../utils/communityValidation';
@@ -45,8 +58,11 @@ const CommunityMembersScreen = ({ route }) => {
   const communityId: string = route.params?.communityId ?? '';
   const communityTitle: string = route.params?.communityTitle ?? '';
 
+  const dispatch = useAppDispatch();
+  const queryClient = useQueryClient();
   const currentAccount = useAppSelector(selectCurrentAccount);
   const isDarkTheme = useAppSelector(selectIsDarkTheme);
+  const setCommunityRoleMutation = useSetCommunityRoleMutation(communityId);
 
   const communityQuery = useQuery(
     getCommunityQueryOptions(communityId, currentAccount?.name, !!communityId),
@@ -84,6 +100,14 @@ const CommunityMembersScreen = ({ route }) => {
     });
   }, [communityQuery.data, subscribersQuery.data]);
 
+  // hivemind only lets you assign roles strictly below your own, and only to
+  // accounts already below you. roleMap encodes the first half; the second is
+  // why a row is editable only when the target's current role is assignable.
+  const assignableRoles: string[] = useMemo(
+    () => roleMap[getCommunityRole(communityQuery.data?.team, currentAccount?.name) ?? ''] ?? [],
+    [communityQuery.data, currentAccount?.name],
+  );
+
   const isLoading = communityQuery.isLoading || subscribersQuery.isLoading;
   // Surfaced separately from the empty case: a failed query also yields zero
   // rows, and rendering "no members" for it reads as an authoritative answer
@@ -109,13 +133,55 @@ const CommunityMembersScreen = ({ route }) => {
     });
   };
 
-  const _renderRoleChip = (member: Member) => (
-    <View style={styles.roleChip}>
-      <Text style={styles.roleChipText}>
-        {intl.formatMessage({ id: `community.role_${member.role}` })}
-      </Text>
-    </View>
-  );
+  const _canEdit = (member: Member) =>
+    assignableRoles.length > 0 &&
+    member.account !== currentAccount?.name &&
+    assignableRoles.includes(member.role);
+
+  const _handleEditRole = async (member: Member) => {
+    const result = await SheetManager.show(SheetNames.COMMUNITY_ROLE_EDIT, {
+      payload: {
+        account: member.account,
+        currentRole: member.role,
+        assignableRoles,
+      },
+    });
+
+    // Only a selection carries a string role. Cancel resolves { cancelled },
+    // and a backdrop, swipe or back dismissal resolves the payload object,
+    // because the library publishes `data || payloadRef.current` on close.
+    const role = typeof result?.role === 'string' ? result.role : '';
+    if (!role || role === member.role) {
+      return;
+    }
+
+    try {
+      await setCommunityRoleMutation.mutateAsync({ account: member.account, role });
+      dispatch(toastNotification(intl.formatMessage({ id: 'alert.successful' })));
+      // The team drives both the roster and the gate above, so it has to refetch.
+      queryClient.invalidateQueries({
+        queryKey: getCommunityQueryOptions(communityId, currentAccount?.name).queryKey,
+      });
+    } catch (err) {
+      Alert.alert(intl.formatMessage({ id: 'alert.fail' }), (err as Error)?.message || String(err));
+    }
+  };
+
+  const _renderRoleChip = (member: Member) => {
+    const chip = (
+      <View style={[styles.roleChip, _canEdit(member) && styles.roleChipEditable]}>
+        <Text style={styles.roleChipText}>
+          {intl.formatMessage({ id: `community.role_${member.role}` })}
+        </Text>
+      </View>
+    );
+
+    if (!_canEdit(member)) {
+      return chip;
+    }
+
+    return <TouchableOpacity onPress={() => _handleEditRole(member)}>{chip}</TouchableOpacity>;
+  };
 
   const _renderItem = ({ item, index }: { item: Member; index: number }) => (
     <UserListItem

--- a/src/screens/communityMembers/styles/communityMembersScreen.styles.ts
+++ b/src/screens/communityMembers/styles/communityMembersScreen.styles.ts
@@ -27,6 +27,10 @@ export default EStyleSheet.create({
     borderRadius: 12,
     backgroundColor: '$primaryLightBackground',
   },
+  roleChipEditable: {
+    borderWidth: 1,
+    borderColor: '$primaryBlue',
+  },
   roleChipText: {
     fontSize: 12,
     color: '$primaryDarkGray',


### PR DESCRIPTION
Closes #3391

Builds on #3395 (wrapper fix) and #3396 (members list).

### Permission model

hivemind's rule has two halves, and the SDK's `roleMap` only encodes one of them:

```
owner -> [admin, mod, member, guest, muted]
admin -> [mod, member, guest, muted]
mod   -> [member, guest, muted]
```

That is what you may **grant**. The other half is who you may **act on**, which falls out of the same table: a row is editable only when the target's current role is itself in your assignable set. So an admin cannot touch another admin or the owner, a mod cannot touch an admin, and nobody can change the owner (`owner` appears in no list). This mirrors web's model.

Own row is excluded as well, so a moderator cannot demote themselves by accident. Web does not do this; say the word if you would rather match it exactly.

### Changes

- `src/components/communityRoleEditSheet/` - role picker, current role marked and non-selectable.
- `src/screens/communityMembers/screen/communityMembersScreen.tsx` - editable rows get an outlined chip; tapping the chip opens the picker, tapping the name still opens the profile. On success the community query is invalidated, since its `team` drives both the roster and the gate above.
- Registered in the sheet registry and both barrels, plus `community.set_role`.

The sheet returns `{ role }` or `{ cancelled: true }` rather than a bare role string, for the same reason as the mod notes sheet: `react-native-actions-sheet` 0.9.7 publishes `data || payloadRef.current` on close, so a falsy value is replaced by the payload object and would read as a selection.

Gating is advisory. hivemind rejects an unauthorised `setRole` regardless.

### Testing

- `yarn test:ci`: 724 passed, 1 skipped, 49 suites.
- `yarn lint`: 0 errors.

Unrelated note for anyone testing locally: `development` now needs `expo-audio` (added by the editor dictation merge) or every suite fails at `jest.setup.ts`. A plain `yarn install` fixes it.

Needs a device pass, ideally with two accounts at different levels:
- As a mod, confirm member/guest/muted rows are editable and admin/owner rows are not.
- As an admin, confirm another admin is not editable but a mod is.
- Confirm your own row is never editable.
- Confirm cancel, backdrop, swipe and back all broadcast nothing.
- After a successful change, confirm the chip updates without a manual refresh.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Community members with appropriate permissions can now edit eligible member roles.
  * Role editing displays the account, current role, and available role options.
  * Added confirmation feedback for successful or failed role updates.
  * Updated subscriber role displays immediately after successful changes.
  * Interactive role indicators now use updated visual styling.
* **Localization**
  * Added the “Set role” label in English.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->