### PR TITLE
feat(community): community settings screen

### DIFF
--- a/src/components/communityManageSheet/communityManageSheet.tsx
+++ b/src/components/communityManageSheet/communityManageSheet.tsx
@@ -8,13 +8,15 @@ import { Icon } from '../icon';
 const FALLBACK_SHEET_ID = 'community_manage';
 
 /** Destinations offered to a community moderator. */
-export type CommunityManageAction = 'members';
+export type CommunityManageAction = 'members' | 'settings';
 
 interface Row {
   action: CommunityManageAction;
   icon: string;
   iconType: string;
   labelId: string;
+  /** Rendered only when the viewer can actually use the destination. */
+  requires?: 'settings';
 }
 
 // Rows are added here as each destination screen lands.
@@ -24,6 +26,13 @@ const ROWS: Row[] = [
     icon: 'account-group',
     iconType: 'MaterialCommunityIcons',
     labelId: 'community.manage_members',
+  },
+  {
+    action: 'settings',
+    icon: 'cog-outline',
+    iconType: 'MaterialCommunityIcons',
+    labelId: 'community.manage_settings',
+    requires: 'settings',
   },
 ];
 
@@ -35,8 +44,12 @@ const ROWS: Row[] = [
  * because the library publishes `data || payloadRef.current` on close, so
  * callers must gate on a known `action` value rather than on truthiness.
  */
-const CommunityManageSheet: React.FC<SheetProps<'community_manage'>> = ({ sheetId }) => {
+const CommunityManageSheet: React.FC<SheetProps<'community_manage'>> = ({ sheetId, payload }) => {
   const intl = useIntl();
+
+  // Editing community props is owner and admin only, so a plain mod is not
+  // offered a screen where every field would be read-only.
+  const rows = ROWS.filter((row) => row.requires !== 'settings' || !!payload?.canEditSettings);
 
   const _select = (action: CommunityManageAction) => {
     SheetManager.hide(sheetId || FALLBACK_SHEET_ID, { payload: { action } });
@@ -52,7 +65,7 @@ const CommunityManageSheet: React.FC<SheetProps<'community_manage'>> = ({ sheetI
       <View style={styles.container}>
         <Text style={styles.title}>{intl.formatMessage({ id: 'community.manage' })}</Text>
 
-        {ROWS.map((row) => (
+        {rows.map((row) => (
           <TouchableOpacity key={row.action} style={styles.row} onPress={() => _select(row.action)}>
             <Icon
               iconType={row.iconType}

--- a/src/config/locales/en-US.json
+++ b/src/config/locales/en-US.json
@@ -188,6 +188,7 @@
     "unmute_post_reason": "Why is this being restored?",
     "manage": "Manage community",
     "manage_members": "Members and roles",
+    "manage_settings": "Community settings",
     "set_role": "Set role",
     "members": "members",
     "no_members": "No members found",
@@ -1793,5 +1794,18 @@
     "placeholder": "Reason (visible to other moderators)",
     "confirm": "Confirm",
     "cancel": "Cancel"
+  },
+  "community_settings": {
+    "title_header": "Community settings",
+    "title_label": "Title",
+    "about": "About",
+    "lang": "Language",
+    "description": "Description",
+    "rules": "Rules",
+    "nsfw": "Not safe for work",
+    "save": "Save",
+    "required": "Required",
+    "title_length": "Between {min} and {max} characters",
+    "owner_admin_only": "Only the owner and admins can change these settings."
   }
 }

--- a/src/constants/routeNames.ts
+++ b/src/constants/routeNames.ts
@@ -34,6 +34,7 @@ const ROUTES = {
     COMMUNITY: `Community${SCREEN_SUFFIX}`,
     COMMUNITIES: `Communities${SCREEN_SUFFIX}`,
     COMMUNITY_MEMBERS: `CommunityMembers${SCREEN_SUFFIX}`,
+    COMMUNITY_SETTINGS: `CommunitySettings${SCREEN_SUFFIX}`,
     WEB_BROWSER: `WebBrowser${SCREEN_SUFFIX}`,
     REFER: `Refer${SCREEN_SUFFIX}`,
     QR: `QR${SCREEN_SUFFIX}`,

--- a/src/navigation/sheets.tsx
+++ b/src/navigation/sheets.tsx
@@ -263,6 +263,9 @@ declare module 'react-native-actions-sheet' {
       returnValue: ModNotesResult | undefined;
     }>;
     [SheetNames.COMMUNITY_MANAGE]: SheetDefinition<{
+      payload?: {
+        canEditSettings?: boolean;
+      };
       // `{ action }` on selection. Dismissing by backdrop, swipe or back
       // resolves the payload object instead, because the library publishes
       // `data || payloadRef.current` on close, so match on a known action

--- a/src/navigation/stackNavigator.tsx
+++ b/src/navigation/stackNavigator.tsx
@@ -29,6 +29,7 @@ import {
   TagResult,
   Community,
   CommunityMembers,
+  CommunitySettings,
   Communities,
   WebBrowser,
   ReferScreen,
@@ -70,6 +71,7 @@ const MainStackNavigator = () => {
       <MainStack.Screen name={ROUTES.SCREENS.ACCOUNT_BOOST} component={AccountBoost} />
       <MainStack.Screen name={ROUTES.SCREENS.COMMUNITY} component={Community} />
       <MainStack.Screen name={ROUTES.SCREENS.COMMUNITY_MEMBERS} component={CommunityMembers} />
+      <MainStack.Screen name={ROUTES.SCREENS.COMMUNITY_SETTINGS} component={CommunitySettings} />
       <MainStack.Screen name={ROUTES.SCREENS.COMMUNITIES} component={Communities} />
       <MainStack.Screen name={ROUTES.SCREENS.REFER} component={ReferScreen} />
       <MainStack.Screen name={ROUTES.SCREENS.ASSET_DETAILS} component={AssetDetails} />

--- a/src/screens/community/container/communityContainer.ts
+++ b/src/screens/community/container/communityContainer.ts
@@ -3,7 +3,7 @@ import { connect, useDispatch } from 'react-redux';
 import { useIntl } from 'react-intl';
 
 import { useNavigation } from '@react-navigation/native';
-import { getCommunityQueryOptions } from '@ecency/sdk';
+import { getCommunityQueryOptions, ROLES } from '@ecency/sdk';
 import { useQuery } from '@tanstack/react-query';
 
 import ROUTES from '../../../constants/routeNames';
@@ -11,7 +11,7 @@ import { updateSubscribedCommunitiesCache } from '../../../redux/actions/cacheAc
 import { statusMessage } from '../../../redux/constants/communitiesConstants';
 import { selectCurrentAccount, selectIsLoggedIn } from '../../../redux/selectors';
 import { useAppSelector, useCommunitySubscriptionAction } from '../../../hooks';
-import { isCommunityModerator } from '../../../utils/communityModeration';
+import { getCommunityRole, isCommunityModerator } from '../../../utils/communityModeration';
 
 const CommunityContainer = ({ tag, children, currentAccount, isLoggedIn }) => {
   const navigation = useNavigation();
@@ -93,6 +93,12 @@ const CommunityContainer = ({ tag, children, currentAccount, isLoggedIn }) => {
   // in that list is overwritable.
   const isModerator = isCommunityModerator(data?.team, currentAccount?.name);
 
+  // Editing community props is owner and admin only, so a mod is not offered a
+  // settings screen where every field would be read-only.
+  const canEditSettings = [ROLES.OWNER, ROLES.ADMIN].includes(
+    getCommunityRole(data?.team, currentAccount?.name) ?? '',
+  );
+
   return (
     children &&
     children({
@@ -102,6 +108,7 @@ const CommunityContainer = ({ tag, children, currentAccount, isLoggedIn }) => {
       isSubscribed,
       isLoggedIn,
       isModerator,
+      canEditSettings,
     })
   );
 };

--- a/src/screens/community/screen/communityScreen.tsx
+++ b/src/screens/community/screen/communityScreen.tsx
@@ -67,24 +67,37 @@ const CommunityScreen = ({ route }) => {
   };
 
   const _handleManagePress = useCallback(
-    async (data) => {
-      const result = await SheetManager.show(SheetNames.COMMUNITY_MANAGE);
+    async (data, canEdit) => {
+      const result = await SheetManager.show(SheetNames.COMMUNITY_MANAGE, {
+        payload: { canEditSettings: canEdit },
+      });
 
       // Only a selection carries a known action. Backdrop, swipe and back
       // dismissals resolve the sheet's payload object instead, so match on the
       // action rather than on truthiness.
-      if (result?.action !== 'members') {
-        return;
-      }
+      const params = {
+        communityId: data?.name || tag,
+        communityTitle: data?.title || '',
+      };
 
-      navigation.navigate({
-        name: ROUTES.SCREENS.COMMUNITY_MEMBERS,
-        key: `community_members_${tag}`,
-        params: {
-          communityId: data?.name || tag,
-          communityTitle: data?.title || '',
-        },
-      });
+      switch (result?.action) {
+        case 'members':
+          navigation.navigate({
+            name: ROUTES.SCREENS.COMMUNITY_MEMBERS,
+            key: `community_members_${tag}`,
+            params,
+          });
+          break;
+        case 'settings':
+          navigation.navigate({
+            name: ROUTES.SCREENS.COMMUNITY_SETTINGS,
+            key: `community_settings_${tag}`,
+            params,
+          });
+          break;
+        default:
+          break;
+      }
     },
     [navigation, tag],
   );
@@ -98,6 +111,7 @@ const CommunityScreen = ({ route }) => {
         isSubscribed,
         isLoggedIn,
         isModerator,
+        canEditSettings,
       }) => (
         <SafeAreaView style={styles.container}>
           <BasicHeader
@@ -107,7 +121,7 @@ const CommunityScreen = ({ route }) => {
             enableViewModeToggle={true}
             rightIconName={isModerator ? 'shield-account-outline' : undefined}
             iconType="MaterialCommunityIcons"
-            handleRightIconPress={() => _handleManagePress(data)}
+            handleRightIconPress={() => _handleManagePress(data, canEditSettings)}
           />
           {data ? (
             <CollapsibleCard

--- a/src/screens/communitySettings/index.ts
+++ b/src/screens/communitySettings/index.ts
@@ -1,0 +1,4 @@
+import CommunitySettings from './screen/communitySettingsScreen';
+
+export { CommunitySettings };
+export default CommunitySettings;

--- a/src/screens/communitySettings/screen/communitySettingsScreen.tsx
+++ b/src/screens/communitySettings/screen/communitySettingsScreen.tsx
@@ -1,0 +1,204 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { Alert, Text, View } from 'react-native';
+import { useIntl } from 'react-intl';
+import { useNavigation } from '@react-navigation/native';
+import { useQuery } from '@tanstack/react-query';
+import { gestureHandlerRootHOC } from 'react-native-gesture-handler';
+import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import EStyleSheet from 'react-native-extended-stylesheet';
+import { getCommunityQueryOptions, ROLES } from '@ecency/sdk';
+
+import { BasicHeader, FormInput, MainButton, ToggleSwitch } from '../../../components';
+import { useAppDispatch, useAppSelector } from '../../../hooks';
+import { useUpdateCommunityMutation } from '../../../providers/sdk/mutations';
+import { toastNotification } from '../../../redux/actions/uiAction';
+import { selectCurrentAccount } from '../../../redux/selectors';
+import { getCommunityRole } from '../../../utils/communityModeration';
+import styles from '../styles/communitySettingsScreen.styles';
+
+// Editing community properties is owner and admin only. Mods are deliberately
+// excluded, matching web, so this does not reuse isCommunityModerator.
+const SETTINGS_ROLES: string[] = [ROLES.OWNER, ROLES.ADMIN];
+
+// Same bounds web enforces, so a community edited on either client stays valid.
+const TITLE_MIN = 3;
+const TITLE_MAX = 20;
+
+interface FormState {
+  title: string;
+  about: string;
+  lang: string;
+  description: string;
+  flag_text: string;
+  is_nsfw: boolean;
+}
+
+const EMPTY_FORM: FormState = {
+  title: '',
+  about: '',
+  lang: '',
+  description: '',
+  flag_text: '',
+  is_nsfw: false,
+};
+
+const CommunitySettingsScreen = ({ route }) => {
+  const intl = useIntl();
+  const navigation = useNavigation();
+  const dispatch = useAppDispatch();
+
+  const communityId: string = route.params?.communityId ?? '';
+
+  const currentAccount = useAppSelector(selectCurrentAccount);
+  const updateCommunityMutation = useUpdateCommunityMutation(communityId);
+
+  const communityQuery = useQuery(
+    getCommunityQueryOptions(communityId, currentAccount?.name, !!communityId),
+  );
+
+  const [form, setForm] = useState<FormState>(EMPTY_FORM);
+  const [isSaving, setIsSaving] = useState(false);
+
+  // Seed once the community resolves. Keyed on the community payload rather than
+  // on mount, since the screen can open before the query settles.
+  useEffect(() => {
+    const { data } = communityQuery;
+    if (!data) {
+      return;
+    }
+    setForm({
+      title: data.title ?? '',
+      about: data.about ?? '',
+      lang: data.lang ?? '',
+      description: data.description ?? '',
+      flag_text: data.flag_text ?? '',
+      is_nsfw: !!data.is_nsfw,
+    });
+  }, [communityQuery.data]);
+
+  const canEdit = useMemo(
+    () =>
+      SETTINGS_ROLES.includes(
+        getCommunityRole(communityQuery.data?.team, currentAccount?.name) ?? '',
+      ),
+    [communityQuery.data, currentAccount?.name],
+  );
+
+  const titleError = useMemo(() => {
+    const title = form.title.trim();
+    if (!title) {
+      return intl.formatMessage({ id: 'community_settings.required' });
+    }
+    if (title.length < TITLE_MIN || title.length > TITLE_MAX) {
+      return intl.formatMessage(
+        { id: 'community_settings.title_length' },
+        { min: TITLE_MIN, max: TITLE_MAX },
+      );
+    }
+    return '';
+  }, [form.title, intl]);
+
+  const isValid = !titleError && !!form.about.trim() && !!form.lang.trim();
+
+  const _set = (key: keyof FormState) => (value: string | boolean) =>
+    setForm((prev) => ({ ...prev, [key]: value }));
+
+  const _handleSave = async () => {
+    if (!isValid || isSaving) {
+      return;
+    }
+    setIsSaving(true);
+    try {
+      // Trimmed on the way out, as web does. Whitespace-only values would pass
+      // hivemind and render as blank.
+      await updateCommunityMutation.mutateAsync({
+        title: form.title.trim(),
+        about: form.about.trim(),
+        lang: form.lang.trim(),
+        description: form.description.trim(),
+        flag_text: form.flag_text.trim(),
+        is_nsfw: form.is_nsfw,
+      });
+      dispatch(toastNotification(intl.formatMessage({ id: 'alert.successful' })));
+      navigation.goBack();
+    } catch (err) {
+      Alert.alert(intl.formatMessage({ id: 'alert.fail' }), (err as Error)?.message || String(err));
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const _renderField = (
+    key: keyof FormState,
+    labelId: string,
+    { multiline = false, error = '' }: { multiline?: boolean; error?: string } = {},
+  ) => (
+    <View style={styles.field}>
+      <Text style={styles.label}>{intl.formatMessage({ id: labelId })}</Text>
+      <FormInput
+        wrapperStyle={styles.formStyle}
+        isValid={!error}
+        height={multiline ? 90 : 40}
+        multiline={multiline}
+        numberOfLines={multiline ? 4 : 1}
+        onChange={_set(key)}
+        isEditable={canEdit}
+        type="none"
+        value={form[key] as string}
+        inputStyle={styles.input}
+      />
+      {!!error && <Text style={styles.error}>{error}</Text>}
+    </View>
+  );
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <BasicHeader title={intl.formatMessage({ id: 'community_settings.title_header' })} />
+
+      {!canEdit && !communityQuery.isLoading && (
+        <Text style={styles.notice}>
+          {intl.formatMessage({ id: 'community_settings.owner_admin_only' })}
+        </Text>
+      )}
+
+      <KeyboardAwareScrollView
+        contentContainerStyle={styles.contentContainer}
+        enableOnAndroid={true}
+      >
+        {_renderField('title', 'community_settings.title_label', { error: titleError })}
+        {_renderField('about', 'community_settings.about', {
+          error: form.about.trim() ? '' : intl.formatMessage({ id: 'community_settings.required' }),
+        })}
+        {_renderField('lang', 'community_settings.lang', {
+          error: form.lang.trim() ? '' : intl.formatMessage({ id: 'community_settings.required' }),
+        })}
+        {_renderField('description', 'community_settings.description', { multiline: true })}
+        {/* hivemind calls this flag_text; both clients surface it as the rules. */}
+        {_renderField('flag_text', 'community_settings.rules', { multiline: true })}
+
+        <View style={styles.toggleRow}>
+          <Text style={styles.label}>{intl.formatMessage({ id: 'community_settings.nsfw' })}</Text>
+          <ToggleSwitch
+            isOn={form.is_nsfw}
+            onColor={EStyleSheet.value('$primaryBlue')}
+            offColor={EStyleSheet.value('$primaryLightGray')}
+            onToggle={(value) => canEdit && _set('is_nsfw')(value)}
+          />
+        </View>
+
+        {canEdit && (
+          <MainButton
+            style={styles.saveButton}
+            onPress={_handleSave}
+            isLoading={isSaving}
+            isDisable={!isValid || isSaving}
+            text={intl.formatMessage({ id: 'community_settings.save' })}
+          />
+        )}
+      </KeyboardAwareScrollView>
+    </SafeAreaView>
+  );
+};
+
+export default gestureHandlerRootHOC(CommunitySettingsScreen);

--- a/src/screens/communitySettings/styles/communitySettingsScreen.styles.ts
+++ b/src/screens/communitySettings/styles/communitySettingsScreen.styles.ts
@@ -1,0 +1,53 @@
+import EStyleSheet from 'react-native-extended-stylesheet';
+
+export default EStyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '$primaryBackgroundColor',
+  },
+  contentContainer: {
+    paddingHorizontal: 16,
+    paddingVertical: 16,
+    paddingBottom: 48,
+  },
+  notice: {
+    marginHorizontal: 16,
+    marginTop: 12,
+    padding: 12,
+    borderRadius: 8,
+    backgroundColor: '$primaryLightBackground',
+    color: '$primaryDarkGray',
+    fontSize: 13,
+  },
+  field: {
+    marginBottom: 16,
+  },
+  label: {
+    fontSize: 14,
+    color: '$primaryDarkGray',
+    marginBottom: 6,
+  },
+  formStyle: {
+    backgroundColor: '$primaryLightBackground',
+    borderRadius: 8,
+  },
+  input: {
+    color: '$primaryBlack',
+    paddingHorizontal: 12,
+  },
+  error: {
+    marginTop: 4,
+    color: '$primaryRed',
+    fontSize: 12,
+  },
+  toggleRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: 24,
+  },
+  saveButton: {
+    alignSelf: 'flex-end',
+    width: 140,
+  },
+});

--- a/src/screens/index.ts
+++ b/src/screens/index.ts
@@ -28,6 +28,7 @@ import Register from './register/registerScreen';
 import TagResult from './tagResult';
 import { Community } from './community';
 import { CommunityMembers } from './communityMembers';
+import { CommunitySettings } from './communitySettings';
 import Communities from './communities';
 import ReferScreen from './referScreen/referScreen';
 import AssetDetails from './assetDetails';
@@ -74,6 +75,7 @@ export {
   TagResult,
   Community,
   CommunityMembers,
+  CommunitySettings,
   Communities,
   WebBrowser,
   ReferScreen,


### PR DESCRIPTION
Closes #3392

Uses the `updateCommunity` wrapper fixed in #3395, and adds the second row to the Manage sheet from #3396.

Mobile rendered `data.description` read-only on the community screen and offered no way to edit anything. Web has `community-settings/index.tsx`.

### Changes

- `src/screens/communitySettings/` - form over `CommunityProps`: title, about, language, description, rules, NSFW.
- `src/components/communityManageSheet/` - second row, capability-gated.
- Community container exposes `canEditSettings`; route registered in `routeNames`, `stackNavigator`, `screens/index`.

### Validation

Matched to web (`apps/web/.../community-settings/index.tsx:24-38`) so a community edited from either client stays valid: title required and 3-20 characters, `about` and `lang` required, everything trimmed on the way out. Whitespace-only values would otherwise pass hivemind and render blank.

`flag_text` is surfaced as **Rules**, which is what both clients call it.

### Gating

Owner and admin only, matching `apps/web/.../community-card/index.tsx:45-48`. Mods are excluded, so this deliberately does **not** reuse `isCommunityModerator`.

The Manage sheet withholds the row entirely rather than routing a mod to a screen where every field is read-only. The screen still renders read-only with a notice if reached another way, since a role can change under a cached view.

### Out of scope

Default beneficiary (only settable when signed in as the community account) and avatar/cover editing. Web's avatar gate is defective - it checks the saved-accounts list while the mutation broadcasts `account_update2` for the *active* user - so it should not be ported as is.

### Testing

- `yarn test:ci`: 731 passed, 1 skipped, 49 suites.
- `yarn lint`: 0 errors.

Needs a device pass:
- As owner or admin, change the title and confirm it persists after the community refetches.
- Confirm the save button stays disabled for a 2-character title, an empty about, and an empty language.
- As a plain mod, confirm the Manage sheet shows no settings row.
- Confirm the NSFW toggle round-trips.

One caveat worth knowing when testing: `updateProps` broadcasts async, so hivemind may not have indexed the change by the time the screen pops. A pull-to-refresh on the community may be needed to see it, same class of issue noted on #3397.
