### PR TITLE
chore: bump @ecency/sdk to 2.3.71 and drop the local community workarounds

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@babel/preset-typescript": "^7.26.0",
     "@babel/runtime": "^7.26.7",
     "@ecency/render-helper": "^2.5.23",
-    "@ecency/sdk": "^2.3.70",
+    "@ecency/sdk": "^2.3.71",
     "@esteemapp/react-native-autocomplete-input": "^4.2.1",
     "@esteemapp/react-native-multi-slider": "^1.1.0",
     "@native-html/iframe-plugin": "^2.6.1",

--- a/src/providers/queries/communityQueries.test.ts
+++ b/src/providers/queries/communityQueries.test.ts
@@ -1,20 +1,9 @@
 import fs from 'fs';
 import path from 'path';
-import {
-  ACTIVITIES_PAGE_SIZE,
-  applyRoleToSubscribersCache,
-  getActivitiesNextPageParam,
-  useCommunityActivitiesQuery,
-  useCommunitySubscribersQuery,
-  SUBSCRIBERS_PAGE_SIZE,
-} from './communityQueries';
+import { applyRoleToSubscribersCache, communitySubscribersQueryKey } from './communityQueries';
 
 describe('communityQueries module surface', () => {
-  it('exports useCommunitySubscribersQuery as a function', () => {
-    expect(typeof useCommunitySubscribersQuery).toBe('function');
-  });
-
-  // The members screen imports this hook through the `providers/queries` barrel.
+  // The members screen imports these through the `providers/queries` barrel.
   // Shipping the module without the re-export resolves that import to undefined
   // and crashes the screen on mount, which neither eslint nor any other test
   // catches. The barrel itself cannot be imported here (it pulls in native
@@ -24,16 +13,16 @@ describe('communityQueries module surface', () => {
     expect(barrel).toMatch(/export \* from '\.\/communityQueries';/);
   });
 
-  it('exports useCommunityActivitiesQuery as a function', () => {
-    expect(typeof useCommunityActivitiesQuery).toBe('function');
-  });
-
-  it("pages at hivemind's list_subscribers cap", () => {
-    // hivemind caps list_subscribers at 100 rows regardless of a larger limit,
-    // and getNextPageParam treats a short page as the end of the list. A page
-    // size above the cap would make every full page look short and stop paging
-    // after the first one.
-    expect(SUBSCRIBERS_PAGE_SIZE).toBeLessThanOrEqual(100);
+  // The cache patch below writes to whatever key this returns, so it has to be
+  // the same key the SDK's subscriber query reads from. Taking it from the SDK
+  // rather than rebuilding it locally is what keeps those two in step.
+  it('takes the subscribers cache key from the SDK', () => {
+    expect(communitySubscribersQueryKey('hive-125125')).toEqual([
+      'communities',
+      'subscribers',
+      'infinite',
+      'hive-125125',
+    ]);
   });
 });
 
@@ -83,38 +72,5 @@ describe('applyRoleToSubscribersCache', () => {
   it('handles an absent or empty cache', () => {
     expect(applyRoleToSubscribersCache(undefined, 'bob', 'mod')).toBeUndefined();
     expect(applyRoleToSubscribersCache({}, 'bob', 'mod')).toEqual({});
-  });
-});
-
-describe('getActivitiesNextPageParam', () => {
-  const page = (n: number) =>
-    Array.from({ length: n }, (_v, i) => ({
-      id: `id-${i}`,
-      msg: '',
-      url: '',
-      date: '',
-      type: 'subscribe',
-    }));
-
-  it('returns the last id when the page is full', () => {
-    expect(getActivitiesNextPageParam(page(ACTIVITIES_PAGE_SIZE))).toBe(
-      `id-${ACTIVITIES_PAGE_SIZE - 1}`,
-    );
-  });
-
-  it('stops on a short page', () => {
-    expect(getActivitiesNextPageParam(page(ACTIVITIES_PAGE_SIZE - 1))).toBeUndefined();
-  });
-
-  it('stops on an empty page', () => {
-    expect(getActivitiesNextPageParam([])).toBeUndefined();
-  });
-
-  // The SDK helper this replaced swallowed fetch errors into [], which both hid
-  // the failure and ended pagination as though the log had run out. The local
-  // query lets the error propagate, so this path is only reached on a genuinely
-  // short page.
-  it('stops on a missing page rather than throwing', () => {
-    expect(getActivitiesNextPageParam(undefined as never)).toBeUndefined();
   });
 });

--- a/src/providers/queries/communityQueries.ts
+++ b/src/providers/queries/communityQueries.ts
@@ -1,64 +1,22 @@
-import { useInfiniteQuery } from '@tanstack/react-query';
-import { bridgeApiCall } from '@ecency/sdk';
-
-export const SUBSCRIBERS_PAGE_SIZE = 100;
+import { QueryKeys, Subscription } from '@ecency/sdk';
 
 /**
- * A subscriber row as hivemind returns it: `[account, role, title, joined]`.
- * Positional, like `community.team`.
- */
-export type SubscriberRow = string[];
-
-/**
- * Paginated community subscriber list.
+ * Cache key for the paged subscriber list.
  *
- * The SDK's `getCommunitySubscribersQueryOptions` issues a single
- * `list_subscribers({ community })` call, and hivemind caps that at 100 rows.
- * Communities are routinely far larger than that (ecency's own has ~11.7k), so
- * a single call silently returns the first 100 accounts alphabetically and
- * presents them as the whole roster. This pages with the documented
- * `last` + `limit` cursor instead, where `last` is the previous page's final
- * account name.
+ * Re-exported from the SDK rather than rebuilt locally so the cache patch below
+ * cannot drift from the query it patches.
  */
-export const communitySubscribersQueryKey = (community: string) => [
-  'communities',
-  'subscribers',
-  'infinite',
-  community,
-];
-
-export const useCommunitySubscribersQuery = (community: string, enabled = true) =>
-  useInfiniteQuery({
-    queryKey: communitySubscribersQueryKey(community),
-    enabled: enabled && !!community,
-    initialPageParam: '',
-    queryFn: async ({ pageParam }) => {
-      const params: Record<string, unknown> = { community, limit: SUBSCRIBERS_PAGE_SIZE };
-      // hivemind treats an empty `last` as a real cursor positioned before the
-      // first account and returns zero rows, so it has to be omitted on the
-      // first page rather than passed as ''. Verified against api.hive.blog:
-      // `{community, limit}` returns 100 rows, `{community, last: '', limit}`
-      // returns 0.
-      if (pageParam) {
-        params.last = pageParam;
-      }
-      return (await bridgeApiCall<SubscriberRow[]>('list_subscribers', params)) ?? [];
-    },
-    getNextPageParam: (lastPage: SubscriberRow[]) => {
-      // A short page means the end of the list. Returning undefined stops paging.
-      if (!lastPage?.length || lastPage.length < SUBSCRIBERS_PAGE_SIZE) {
-        return undefined;
-      }
-      return lastPage[lastPage.length - 1]?.[0];
-    },
-  });
+export const communitySubscribersQueryKey = (community: string) =>
+  QueryKeys.communities.subscribersInfinite(community);
 
 /** Shape of the cached infinite subscribers query. */
 export interface SubscribersCache {
-  pages?: SubscriberRow[][];
+  pages?: Subscription[][];
   pageParams?: unknown[];
 }
 
+// hivemind returns each subscriber row as a positional tuple of
+// [account, role, title, joined].
 const ACCOUNT_INDEX = 0;
 const TITLE_INDEX = 2;
 
@@ -93,60 +51,3 @@ export const applyRoleToSubscribersCache = (
     ),
   };
 };
-
-export const ACTIVITIES_PAGE_SIZE = 50;
-
-/** An activity entry as hivemind returns it. */
-export interface CommunityActivity {
-  id: string;
-  msg: string;
-  url: string;
-  date: string;
-  type: string;
-}
-
-export const communityActivitiesQueryKey = (community: string) => [
-  'communities',
-  'account-notifications',
-  'infinite',
-  community,
-];
-
-/**
- * Resolves the cursor for the next page: the last entry's id, or undefined at
- * the end of the log.
- *
- * A short page means there is nothing after it. Exported so the stop conditions
- * are testable without a network round trip.
- */
-export const getActivitiesNextPageParam = (lastPage: CommunityActivity[]): string | undefined => {
-  if (!lastPage?.length || lastPage.length < ACTIVITIES_PAGE_SIZE) {
-    return undefined;
-  }
-  return lastPage[lastPage.length - 1]?.id;
-};
-
-/**
- * Paginated community activity log.
- *
- * The SDK's `getAccountNotificationsInfiniteQueryOptions` wraps its fetch in
- * `try { ... } catch { return [] }`, so a failed request is indistinguishable
- * from an empty log: `isError` never becomes true, the screen reports "no
- * activity" for an RPC outage, and a failed page ends pagination silently
- * because an empty page yields no cursor. This lets the error surface.
- */
-export const useCommunityActivitiesQuery = (community: string, enabled = true) =>
-  useInfiniteQuery({
-    queryKey: communityActivitiesQueryKey(community),
-    enabled: enabled && !!community,
-    initialPageParam: '',
-    queryFn: async ({ pageParam }) =>
-      (await bridgeApiCall<CommunityActivity[]>('account_notifications', {
-        account: community,
-        limit: ACTIVITIES_PAGE_SIZE,
-        // Unlike list_subscribers, an explicit null here behaves the same as
-        // omitting it, but stay consistent and only send a real cursor.
-        last_id: pageParam || undefined,
-      })) ?? [],
-    getNextPageParam: getActivitiesNextPageParam,
-  });

--- a/src/screens/communityActivities/screen/communityActivitiesScreen.tsx
+++ b/src/screens/communityActivities/screen/communityActivitiesScreen.tsx
@@ -4,13 +4,18 @@ import { useIntl } from 'react-intl';
 import { useNavigation } from '@react-navigation/native';
 import { gestureHandlerRootHOC } from 'react-native-gesture-handler';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { AccountNotification, getAccountNotificationsInfiniteQueryOptions } from '@ecency/sdk';
+import { useInfiniteQuery } from '@tanstack/react-query';
+
 import { BasicHeader, UserAvatar } from '../../../components';
 import ROUTES from '../../../constants/routeNames';
 import { useAppSelector } from '../../../hooks';
-import { CommunityActivity, useCommunityActivitiesQuery } from '../../../providers/queries';
+
 import { selectIsDarkTheme } from '../../../redux/selectors';
 import { getTimeFromNow } from '../../../utils/time';
 import styles from '../styles/communityActivitiesScreen.styles';
+
+const PAGE_SIZE = 50;
 
 // A set_props entry embeds the whole props payload in its message, which runs to
 // hundreds of characters. Cap the row rather than let one entry dominate the list.
@@ -28,9 +33,12 @@ const CommunityActivitiesScreen = ({ route }) => {
 
   const isDarkTheme = useAppSelector(selectIsDarkTheme);
 
-  const activitiesQuery = useCommunityActivitiesQuery(communityId);
+  const activitiesQuery = useInfiniteQuery({
+    ...getAccountNotificationsInfiniteQueryOptions(communityId, PAGE_SIZE),
+    enabled: !!communityId,
+  });
 
-  const activities: CommunityActivity[] = useMemo(
+  const activities: AccountNotification[] = useMemo(
     () => activitiesQuery.data?.pages?.flat() ?? [],
     [activitiesQuery.data],
   );
@@ -61,7 +69,7 @@ const CommunityActivitiesScreen = ({ route }) => {
    * drops any entry without a mention; here they still render, just without
    * links, so the log stays complete.
    */
-  const _renderMessage = (activity: CommunityActivity) => {
+  const _renderMessage = (activity: AccountNotification) => {
     const parts = activity.msg.split(new RegExp(`(${MENTION_REGEX.source})`, 'gi'));
 
     return (
@@ -92,7 +100,7 @@ const CommunityActivitiesScreen = ({ route }) => {
     );
   };
 
-  const _renderItem = ({ item }: { item: CommunityActivity }) => {
+  const _renderItem = ({ item }: { item: AccountNotification }) => {
     // The acting account is the first mention; entries without one (rare) still
     // render, just without an avatar.
     const actor = item.msg.match(MENTION_REGEX)?.[0]?.slice(1).split('/')[0];

--- a/src/screens/communityMembers/screen/communityMembersScreen.tsx
+++ b/src/screens/communityMembers/screen/communityMembersScreen.tsx
@@ -10,11 +10,16 @@ import {
 } from 'react-native';
 import { useIntl } from 'react-intl';
 import { useNavigation } from '@react-navigation/native';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useInfiniteQuery, useQuery, useQueryClient } from '@tanstack/react-query';
 import { gestureHandlerRootHOC } from 'react-native-gesture-handler';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { SheetManager } from 'react-native-actions-sheet';
-import { getCommunityQueryOptions, ROLES, roleMap } from '@ecency/sdk';
+import {
+  getCommunityQueryOptions,
+  getCommunitySubscribersInfiniteQueryOptions,
+  ROLES,
+  roleMap,
+} from '@ecency/sdk';
 
 import { BasicHeader, UserListItem } from '../../../components';
 import ROUTES from '../../../constants/routeNames';
@@ -26,7 +31,6 @@ import { getCommunityRole } from '../../../utils/communityModeration';
 import {
   applyRoleToSubscribersCache,
   communitySubscribersQueryKey,
-  useCommunitySubscribersQuery,
 } from '../../../providers/queries';
 import { selectCurrentAccount, selectIsDarkTheme } from '../../../redux/selectors';
 import { isCommunity } from '../../../utils/communityValidation';
@@ -71,7 +75,10 @@ const CommunityMembersScreen = ({ route }) => {
   const communityQuery = useQuery(
     getCommunityQueryOptions(communityId, currentAccount?.name, !!communityId),
   );
-  const subscribersQuery = useCommunitySubscribersQuery(communityId);
+  const subscribersQuery = useInfiniteQuery({
+    ...getCommunitySubscribersInfiniteQueryOptions(communityId),
+    enabled: !!communityId,
+  });
 
   const members: Member[] = useMemo(() => {
     const byAccount = new Map<string, Member>();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1210,10 +1210,10 @@
     url "^0.11.0"
     xss "^1.0.9"
 
-"@ecency/sdk@^2.3.70":
-  version "2.3.70"
-  resolved "https://registry.yarnpkg.com/@ecency/sdk/-/sdk-2.3.70.tgz#1792eee050286e494cba7abea78bed9b6f0becf0"
-  integrity sha512-XGPendeMGtfR6FIudr2QutMvk2EfoVb0tx6hG2sD0UPqoZFg2y7Xrpli6Q7X92iJQPtN4xp1+k6HXHMfYrDO8Q==
+"@ecency/sdk@^2.3.71":
+  version "2.3.71"
+  resolved "https://registry.yarnpkg.com/@ecency/sdk/-/sdk-2.3.71.tgz#c4acec3de7520fb8a814126ff1c0c8b406b9a8e9"
+  integrity sha512-DNzLpH5yRML4gLthcz3NYKFeul8xf8esSOw1ACFN4oZnbS+UBsu0ozZUN89Ctsw3qYs+9GaU54Nw9u1RbXsPVA==
   dependencies:
     "@noble/ciphers" "^2.1.1"
     "@noble/curves" "^2.0.1"


### PR DESCRIPTION
Bumps `@ecency/sdk` 2.3.70 -> 2.3.71 and removes the two local queries that existed only to route around the broken SDK helpers, now fixed in vision-next #1293.

Verified 2.3.71 is published (`npm view @ecency/sdk version` -> `2.3.71`) and that the fixes are actually in the shipped dist, not just merged source: the new export is present in `dist/browser/index.d.ts`, and the `try/catch` is gone from `dist/node/index.cjs`.

### UI changes needed: two, both simplifications

**Subscribers.** `useCommunitySubscribersQuery` deleted; the members screen now uses `getCommunitySubscribersInfiniteQueryOptions`. The SDK pages `list_subscribers` with the `last` cursor and omits it on the first page, which is exactly what the local version did.

Its cache key is **identical** to the local one (`["communities","subscribers","infinite",<community>]`), so the `setRole` cache patch keeps working with no change. Checked against the installed package rather than assumed.

**Activities.** `useCommunityActivitiesQuery` deleted; the activity screen now uses `getAccountNotificationsInfiniteQueryOptions`. The SDK no longer swallows fetch errors into an empty page, so the error state the screen already renders is reachable through the SDK query. `getNextPageParam` also stops on a short page rather than only an empty one, matching what the local version did.

### What stays, and why

`applyRoleToSubscribersCache` remains. The SDK patches the community `team` optimistically after `setRole` but never touches the subscriber list, which is what the roster falls back to once a demotion drops an account off the team. Without it a demoted moderator keeps their old chip and stays editable against stale data.

Its key now comes from `QueryKeys.communities.subscribersInfinite` rather than being rebuilt locally, so the patch cannot drift from the query it patches. Added a test asserting the key, since a silent drift there would leave the patch writing to a cache nobody reads.

Net **178 lines removed, 50 added**.

### Testing

- `yarn test:ci`: 730 passed, 1 skipped, 49 suites.
- `yarn lint`: 0 errors.
- Live check of the SDK's paging via the installed package: two consecutive pages, 200 unique accounts, cursor `null` then `"abu78"`, first page correctly omitting `last`.
- Grepped for dangling references to every removed export: none.

Device checks:
- Members list: scroll past 100 and confirm further pages load.
- Change a role and confirm the chip updates immediately, then survives a pull-to-refresh.
- Activity log: scroll past 50 and confirm paging; if you can force an RPC failure, confirm the error state renders rather than "No activity yet".


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated community member and activity data loading through the latest SDK integration.
  * Added infinite scrolling support for community subscribers.
  * Improved community activity pagination with larger pages and continued refresh and error handling.

* **Bug Fixes**
  * Improved consistency and reliability of community subscriber and activity data retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->