### PR TITLE
feat(comments): replace the legacy options menu with the post options sheet

### DIFF
--- a/src/components/comments/container/commentsContainer.tsx
+++ b/src/components/comments/container/commentsContainer.tsx
@@ -1,17 +1,13 @@
 import React, { useState, useEffect } from 'react';
-import { Platform } from 'react-native';
 import { connect } from 'react-redux';
 import { injectIntl } from 'react-intl';
 import get from 'lodash/get';
 
-import { postBodySummary } from '@ecency/render-helper';
 import { useNavigation } from '@react-navigation/native';
 import { SheetManager } from 'react-native-actions-sheet';
 import { getDiscussionsQueryOptions, useDeleteComment } from '@ecency/sdk';
 import { useQueryClient } from '@tanstack/react-query';
 // Services and Actions
-import { writeToClipboard } from '../../../utils/clipboard';
-import { stripCategoryFromPostPath } from '../../../utils/post';
 import { toastNotification } from '../../../redux/actions/uiAction';
 
 // Constants
@@ -34,7 +30,6 @@ const CommentsContainer = ({
   currentAccount,
   comments,
   dispatch,
-  intl,
   commentCount,
   isLoggedIn,
   commentNumber,
@@ -274,32 +269,6 @@ const CommentsContainer = ({
     });
   };
 
-  const _handleOnPressCommentMenu = (index, selectedComment) => {
-    const _showCopiedToast = () => {
-      dispatch(
-        toastNotification(
-          intl.formatMessage({
-            id: 'alert.copied',
-          }),
-        ),
-      );
-    };
-
-    if (index === 0) {
-      // Normalize legacy `/<category>/@author/permlink…` to the canonical
-      // `/@author/permlink…` form that ecency.com now treats as canonical
-      // (the legacy form is 302'd to this one).
-      const _commentPath = stripCategoryFromPostPath(get(selectedComment, 'url'));
-      writeToClipboard(`https://ecency.com${_commentPath}`).then(_showCopiedToast);
-    }
-    if (index === 1) {
-      const body = postBodySummary(selectedComment.markdownBody, null, Platform.OS);
-      writeToClipboard(body).then(_showCopiedToast);
-    } else if (index === 2) {
-      _openReplyThread(selectedComment);
-    }
-  };
-
   return (
     <CommentsView
       key={selectedFilter}
@@ -318,7 +287,6 @@ const CommentsContainer = ({
       isLoggedIn={isLoggedIn}
       fetchPost={fetchPost}
       handleDeleteComment={_handleDeleteComment}
-      handleOnPressCommentMenu={_handleOnPressCommentMenu}
       handleOnOptionsPress={handleOnOptionsPress}
       handleOnUserPress={_handleOnUserPress}
       isOwnProfile={isOwnProfile}

--- a/src/components/comments/view/commentsView.tsx
+++ b/src/components/comments/view/commentsView.tsx
@@ -1,4 +1,4 @@
-import React, { useState, Fragment, useRef } from 'react';
+import React, { Fragment, useRef } from 'react';
 import { Text } from 'react-native';
 import get from 'lodash/get';
 import { useIntl } from 'react-intl';
@@ -6,8 +6,7 @@ import EStyleSheet from 'react-native-extended-stylesheet';
 
 // Components
 import { FlashList } from '@shopify/flash-list';
-import { Comment, TextButton, UpvotePopover } from '../..';
-import { OptionsModal } from '../../atoms';
+import { Comment, PostOptionsModal, TextButton, UpvotePopover } from '../..';
 import { PostHtmlInteractionHandler } from '../../postHtmlRenderer';
 
 // Styles
@@ -24,7 +23,6 @@ const CommentsView = ({
   fetchPost,
   handleDeleteComment,
   handleOnEditPress,
-  handleOnPressCommentMenu,
   handleOnReplyPress,
   handleOnUserPress,
   handleOnVotersPress,
@@ -46,18 +44,20 @@ const CommentsView = ({
   onTagPress,
   onAuthorPress,
 }) => {
-  const [selectedComment, setSelectedComment] = useState(null);
   const intl = useIntl();
-  const commentMenu = useRef<any>();
+  // Surfaces that pass `handleOnOptionsPress` (waves) route to their own sheet.
+  // Everywhere else used to fall back to a four-item menu with no delete, edit,
+  // report or moderation action; it now gets the same sheet the post detail
+  // screen uses.
+  const postOptionsModalRef = useRef<any>(null);
   const upvotePopoverRef = useRef();
   const postInteractionRef = useRef(null);
 
   const _openCommentMenu = (item) => {
     if (handleOnOptionsPress) {
       handleOnOptionsPress(item);
-    } else if (commentMenu.current) {
-      setSelectedComment(item);
-      commentMenu.current.show();
+    } else if (postOptionsModalRef.current) {
+      postOptionsModalRef.current.show(item);
     }
   };
 
@@ -73,11 +73,6 @@ const CommentsView = ({
     }
   };
 
-  const _onMenuItemPress = (index) => {
-    handleOnPressCommentMenu(index, selectedComment);
-    setSelectedComment(null);
-  };
-
   const _onUpvotePress = ({ content, sourceRef, showPayoutDetails, onVotingStart }) => {
     if (upvotePopoverRef.current) {
       const postType = isWavesHost(content.parent_author) ? PostTypes.WAVE : PostTypes.COMMENT;
@@ -91,13 +86,6 @@ const CommentsView = ({
       });
     }
   };
-
-  const menuItems = [
-    intl.formatMessage({ id: 'post.copy_link' }),
-    intl.formatMessage({ id: 'post.copy_text' }),
-    intl.formatMessage({ id: 'post.open_thread' }),
-    intl.formatMessage({ id: 'alert.cancel' }),
-  ];
 
   if (!hideManyCommentsButton && hasManyComments) {
     return (
@@ -186,12 +174,10 @@ const CommentsView = ({
         {...flatListProps}
       />
       {!handleOnOptionsPress && (
-        <OptionsModal
-          ref={commentMenu}
-          options={menuItems}
-          title={get(selectedComment, 'summary')}
-          cancelButtonIndex={3}
-          onPress={_onMenuItemPress}
+        <PostOptionsModal
+          ref={postOptionsModalRef}
+          isVisibleTranslateModal={true}
+          onOpenThread={_openReplyThread}
         />
       )}
       <UpvotePopover ref={upvotePopoverRef} />

--- a/src/components/comments/view/commentsView.tsx
+++ b/src/components/comments/view/commentsView.tsx
@@ -61,6 +61,19 @@ const CommentsView = ({
     }
   };
 
+  // Without this the sheet falls back to its own delete, which calls
+  // navigation.goBack() and would pop the profile or bot-comments screen the
+  // list is embedded in. It would also skip the in-place list removal and, on
+  // waves, the container's wave-specific delete path.
+  const _handleDeleteFromMenu = (item) =>
+    handleDeleteComment(
+      item.permlink,
+      item.parent_permlink,
+      item.parent_author,
+      item.root_author,
+      item.root_permlink,
+    );
+
   const _openReplyThread = (item) => {
     if (item && openReplyThread) {
       openReplyThread(item);
@@ -178,6 +191,7 @@ const CommentsView = ({
           ref={postOptionsModalRef}
           isVisibleTranslateModal={true}
           onOpenThread={_openReplyThread}
+          onDelete={_handleDeleteFromMenu}
         />
       )}
       <UpvotePopover ref={upvotePopoverRef} />

--- a/src/components/postOptionsModal/container/postOptionsModal.tsx
+++ b/src/components/postOptionsModal/container/postOptionsModal.tsx
@@ -245,10 +245,13 @@ const PostOptionsModal = (
     // offer "unmute" on posts no moderator ever muted.
     const _isMutedInCommunity = !!content && !!content.stats?.gray;
 
-    // Carried over from the legacy comment menu. Copying the text needs a body
-    // to copy; opening a thread only means something where a handler was given.
-    const _canCopyText = !!content?.markdownBody;
-    const _canOpenThread = !!onOpenThread;
+    // Carried over from the legacy comment menu, so both are scoped to comments
+    // rather than widening the post detail sheet. A comment is anything with a
+    // parent; copying the text also needs a body to copy, and opening a thread
+    // only means something where a handler was given.
+    const _isCommentContent = !!content && (content.depth > 0 || !!content.parent_author);
+    const _canCopyText = _isCommentContent && !!content?.markdownBody;
+    const _canOpenThread = _isCommentContent && !!onOpenThread;
 
     // check if post can be deleted
     // Hive's on-chain rule is: no children AND no net positive rshares. Using
@@ -852,8 +855,14 @@ const PostOptionsModal = (
       case 'copy-text': {
         // The legacy comment menu copied a plain-text summary rather than raw
         // markdown, so links and images do not come through as syntax.
+        // writeToClipboard returns false for empty text, and the summary can be
+        // empty where the body is only an image or markup, so the success toast
+        // has to follow the result rather than the attempt.
         const _body = postBodySummary(content.markdownBody, null, Platform.OS);
-        await writeToClipboard(_body);
+        const _copied = await writeToClipboard(_body);
+        if (!_copied) {
+          break;
+        }
         alertTimer.current = setTimeout(() => {
           dispatch(toastNotification(intl.formatMessage({ id: 'alert.copied' })));
           alertTimer.current = null;

--- a/src/components/postOptionsModal/container/postOptionsModal.tsx
+++ b/src/components/postOptionsModal/container/postOptionsModal.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useRef, forwardRef, useImperativeHandle } from 'react';
-import { Alert, Share, Text, TouchableHighlight } from 'react-native';
+import { Alert, Platform, Share, Text, TouchableHighlight } from 'react-native';
 import { useIntl } from 'react-intl';
 import get from 'lodash/get';
 import EStyleSheet from 'react-native-extended-stylesheet';
@@ -16,6 +16,7 @@ import {
   parseProfileMetadata,
   useDeleteComment,
 } from '@ecency/sdk';
+import { postBodySummary } from '@ecency/render-helper';
 import { useAuthContext } from '../../../providers/sdk';
 import {
   useReblogMutation,
@@ -74,9 +75,18 @@ interface Props {
    * disappears from the feed.
    */
   onDelete?: (content: any) => void | Promise<void>;
+  /**
+   * Optional thread handler. When provided, the "open-thread" action is offered
+   * and delegates here. Only comment surfaces can open a thread, so the option
+   * is hidden wherever this is absent.
+   */
+  onOpenThread?: (content: any) => void;
 }
 
-const PostOptionsModal = ({ pageType, isWave, isVisibleTranslateModal, onDelete }: Props, ref) => {
+const PostOptionsModal = (
+  { pageType, isWave, isVisibleTranslateModal, onDelete, onOpenThread }: Props,
+  ref,
+) => {
   const intl = useIntl();
   const dispatch = useAppDispatch();
   const navigation = useNavigation();
@@ -235,6 +245,11 @@ const PostOptionsModal = ({ pageType, isWave, isVisibleTranslateModal, onDelete 
     // offer "unmute" on posts no moderator ever muted.
     const _isMutedInCommunity = !!content && !!content.stats?.gray;
 
+    // Carried over from the legacy comment menu. Copying the text needs a body
+    // to copy; opening a thread only means something where a handler was given.
+    const _canCopyText = !!content?.markdownBody;
+    const _canOpenThread = !!onOpenThread;
+
     // check if post can be deleted
     // Hive's on-chain rule is: no children AND no net positive rshares. Using
     // `active_votes.length` was stricter than the chain (a self-vote or a
@@ -301,6 +316,10 @@ const PostOptionsModal = ({ pageType, isWave, isVisibleTranslateModal, onDelete 
           return _canMuteCommunityPost && !_isMutedInCommunity;
         case 'unmute-post':
           return _canMuteCommunityPost && _isMutedInCommunity;
+        case 'copy-text':
+          return _canCopyText;
+        case 'open-thread':
+          return _canOpenThread;
         case 'translate':
           return isVisibleTranslateModal;
         case 'delete-post':
@@ -830,6 +849,23 @@ const PostOptionsModal = ({ pageType, isWave, isVisibleTranslateModal, onDelete 
         }, 300);
         break;
       }
+      case 'copy-text': {
+        // The legacy comment menu copied a plain-text summary rather than raw
+        // markdown, so links and images do not come through as syntax.
+        const _body = postBodySummary(content.markdownBody, null, Platform.OS);
+        await writeToClipboard(_body);
+        alertTimer.current = setTimeout(() => {
+          dispatch(toastNotification(intl.formatMessage({ id: 'alert.copied' })));
+          alertTimer.current = null;
+        }, 300);
+        break;
+      }
+      case 'open-thread':
+        // Deferred like the other cases that leave this sheet, so the
+        // navigation is not swallowed by the sheet's own hide animation.
+        await delay(700);
+        onOpenThread?.(content);
+        break;
 
       case 'reblog':
         _reblog(false);

--- a/src/config/locales/en-US.json
+++ b/src/config/locales/en-US.json
@@ -238,6 +238,8 @@
     "cross-post": "Cross Post",
     "pin-blog": "Pin to blog",
     "copy": "copy link",
+    "copy-text": "copy text",
+    "open-thread": "open thread",
     "unpin-community": "Unpin from community",
     "mute-post": "Mute post",
     "unmute-post": "Unmute post",

--- a/src/constants/options/post.ts
+++ b/src/constants/options/post.ts
@@ -2,6 +2,11 @@ export default [
   'cross-post',
   'promote',
   'copy',
+  // Comment surfaces only. Carried over from the legacy comment menu that
+  // PostOptionsModal replaced, which offered copy-link, copy-text and
+  // open-thread and nothing else.
+  'copy-text',
+  'open-thread',
   'reply',
   'translate',
   'reblog',


### PR DESCRIPTION
Closes #3394

Five comment surfaces never used `PostOptionsModal`. They fell back to the menu in `commentsView.tsx`, which offered four items: copy link, copy text, open thread, cancel.

- `src/screens/botComments/screen/botComments.tsx`
- `src/components/commentsDisplay/view/commentsDisplayView.tsx`
- `src/components/commentsModal/container/commentsModal.tsx`
- `src/components/profile/children/wavesTabContent.tsx`
- `src/components/profile/children/commentsTabContent.tsx`

On those screens a comment had **no** delete, edit, report, pin, translate, bookmark or moderation action. The fallback now mounts `PostOptionsModal`, so they get what the post detail screen already had. Surfaces that pass `handleOnOptionsPress` (waves) keep routing to their own sheet, unchanged.

### The two actions that would have been silently dropped

`PostOptionsModal` had no equivalent for two of the legacy menu's items, so a straight swap would have quietly removed them. Both are added instead:

- **`copy-text`** copies a plain-text summary via `postBodySummary`, so links and images do not come through as raw markdown, matching the old behaviour exactly. Offered wherever the content has a body.
- **`open-thread`** is delegated through a new optional `onOpenThread` prop and only offered where a handler is given, since only comment surfaces can open a thread. It defers with `await delay(700)` like the other cases that leave the sheet.

Labels go in `post_dropdown` lowercase, matching the block: the sheet uppercases at render.

### Things worth knowing, not changed here

- **The sheet offers `reblog` and `cross-post` on comments.** That is pre-existing: post detail comments already route through `PostOptionsModal`, so those have been shown on comments all along. This change makes them visible on five more surfaces. Gating them on `depth === 0` would be a behaviour change to the post detail screen too, so it belongs in its own issue rather than riding along here.
- **`commentsModal` is documented as draft.** Its own source note says actions "do not respond as expected since most of action rely on modals and action sheets which causes a conflict". That conflict is unchanged: the legacy `OptionsModal` was also an `ActionSheet`, so this swaps one nested sheet for another. Not fixed, not made worse.

### Cleanup

`_handleOnPressCommentMenu` and the `handleOnPressCommentMenu` prop are removed, along with four imports in `commentsContainer` that only it used.

### Testing

- `yarn test:ci`: 730 passed, 1 skipped, 49 suites.
- `yarn lint`: 0 errors.
- Grepped for dangling references to the removed prop: none.

Device checks, ideally on a profile comments tab and the waves tab:
- Confirm the sheet opens with the full action set rather than four items.
- Confirm copy link and copy text both work, and that copy text is plain, not markdown.
- Confirm open thread navigates, and that it is absent on the post detail screen where no handler is passed.
- Confirm delete only appears on your own comment, and that it works.
- As a community moderator, confirm mute/unmute now appears on comments on these surfaces.
- Confirm the waves tab still uses its own sheet and is unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added options to copy post text and open a discussion thread from comment views.
  * Added localized labels for the new post actions.
* **Changes**
  * Comment actions now use the post options modal, while existing deletion and navigation behavior remains available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->