### PR TITLE
fix(post): deleting a comment from the options sheet no longer pops the screen

### DIFF
--- a/src/components/postComments/container/postComments.tsx
+++ b/src/components/postComments/container/postComments.tsx
@@ -171,59 +171,64 @@ const PostComments = forwardRef(
       [navigation],
     );
 
-    const _handleDeleteComment = useCallback(
+    // Mutation only, no confirmation. The options sheet confirms before invoking
+    // its onDelete, so a handler that prompts again would ask twice for one
+    // action, and let the user cancel the second after confirming the first.
+    const _deleteCommentConfirmed = useCallback(
       async (_permlink, _parentPermlink?, _parentAuthor?, _rootAuthor?, _rootPermlink?) => {
-        const _onConfirmDelete = async () => {
-          const deletedKey = `${currentAccountName}/${_permlink}`;
-          const extractErrorDetail = (error: any) => {
-            const detail =
-              error?.message ||
-              error?.response?.message ||
-              error?.response?.data?.message ||
-              error?.data?.message ||
-              error?.error_description ||
-              error?.jse_shortmsg;
-            return typeof detail === 'string' ? detail : JSON.stringify(error);
-          };
-
-          setHiddenCommentKeys((prev) => {
-            const next = new Set(prev);
-            next.add(deletedKey);
-            return next;
-          });
-
-          try {
-            await deleteComment({
-              author: currentAccountName,
-              permlink: _permlink,
-              parentAuthor: _parentAuthor,
-              parentPermlink: _parentPermlink || permlink,
-              rootAuthor: _rootAuthor || author,
-              rootPermlink: _rootPermlink || permlink,
-            });
-            console.log('deleted comment', `${currentAccountName}/${_permlink}`);
-          } catch (err) {
-            const stillExists = !!discussionQuery.data?.[deletedKey];
-            if (stillExists) {
-              setHiddenCommentKeys((prev) => {
-                const next = new Set(prev);
-                next.delete(deletedKey);
-                return next;
-              });
-            }
-            const errorDetail = extractErrorDetail(err);
-            if (stillExists) {
-              dispatch(toastNotification(`Failed to delete comment: ${errorDetail}`));
-            } else {
-              console.log(
-                'delete returned error but comment is already absent in cache',
-                deletedKey,
-              );
-            }
-            console.warn('Failed to delete comment', err);
-          }
+        const deletedKey = `${currentAccountName}/${_permlink}`;
+        const extractErrorDetail = (error: any) => {
+          const detail =
+            error?.message ||
+            error?.response?.message ||
+            error?.response?.data?.message ||
+            error?.data?.message ||
+            error?.error_description ||
+            error?.jse_shortmsg;
+          return typeof detail === 'string' ? detail : JSON.stringify(error);
         };
 
+        setHiddenCommentKeys((prev) => {
+          const next = new Set(prev);
+          next.add(deletedKey);
+          return next;
+        });
+
+        try {
+          await deleteComment({
+            author: currentAccountName,
+            permlink: _permlink,
+            parentAuthor: _parentAuthor,
+            parentPermlink: _parentPermlink || permlink,
+            rootAuthor: _rootAuthor || author,
+            rootPermlink: _rootPermlink || permlink,
+          });
+          console.log('deleted comment', `${currentAccountName}/${_permlink}`);
+        } catch (err) {
+          const stillExists = !!discussionQuery.data?.[deletedKey];
+          if (stillExists) {
+            setHiddenCommentKeys((prev) => {
+              const next = new Set(prev);
+              next.delete(deletedKey);
+              return next;
+            });
+          }
+          const errorDetail = extractErrorDetail(err);
+          if (stillExists) {
+            dispatch(toastNotification(`Failed to delete comment: ${errorDetail}`));
+          } else {
+            console.log('delete returned error but comment is already absent in cache', deletedKey);
+          }
+          console.warn('Failed to delete comment', err);
+        }
+      },
+      [author, currentAccountName, deleteComment, dispatch, discussionQuery.data, intl, permlink],
+    );
+
+    // Confirms, then mutates. Used by the inline delete button, which has no
+    // confirmation of its own.
+    const _handleDeleteComment = useCallback(
+      async (_permlink, _parentPermlink?, _parentAuthor?, _rootAuthor?, _rootPermlink?) => {
         const action = await SheetManager.show(SheetNames.ACTION_MODAL, {
           payload: {
             title: intl.formatMessage({ id: 'delete.confirm_delete_title' }),
@@ -241,10 +246,16 @@ const PostComments = forwardRef(
         });
 
         if (action === 'confirm') {
-          _onConfirmDelete();
+          _deleteCommentConfirmed(
+            _permlink,
+            _parentPermlink,
+            _parentAuthor,
+            _rootAuthor,
+            _rootPermlink,
+          );
         }
       },
-      [author, currentAccountName, deleteComment, dispatch, discussionQuery.data, intl, permlink],
+      [_deleteCommentConfirmed, intl],
     );
 
     const _openReplyThread = useCallback(
@@ -276,14 +287,14 @@ const PostComments = forwardRef(
     // Same arguments the inline delete button passes.
     const _handleDeleteFromMenu = useCallback(
       (comment) =>
-        _handleDeleteComment(
+        _deleteCommentConfirmed(
           comment.permlink,
           comment.parent_permlink,
           comment.parent_author,
           comment.root_author,
           comment.root_permlink,
         ),
-      [_handleDeleteComment],
+      [_deleteCommentConfirmed],
     );
 
     const _handleShowOptionsMenu = useCallback((comment) => {

--- a/src/components/postComments/container/postComments.tsx
+++ b/src/components/postComments/container/postComments.tsx
@@ -270,6 +270,22 @@ const PostComments = forwardRef(
       });
     }, []);
 
+    // The sheet is opened for comments here, so its own delete path would call
+    // navigation.goBack() and leave the post the user is reading, and would skip
+    // the error handling and deleted-key cache work this screen already owns.
+    // Same arguments the inline delete button passes.
+    const _handleDeleteFromMenu = useCallback(
+      (comment) =>
+        _handleDeleteComment(
+          comment.permlink,
+          comment.parent_permlink,
+          comment.parent_author,
+          comment.root_author,
+          comment.root_permlink,
+        ),
+      [_handleDeleteComment],
+    );
+
     const _handleShowOptionsMenu = useCallback((comment) => {
       if (postOptionsModalRef.current) {
         postOptionsModalRef.current.show(comment);
@@ -454,7 +470,11 @@ const PostComments = forwardRef(
           overScrollMode="never"
         />
         <PostHtmlInteractionHandler ref={postInteractionRef} />
-        <PostOptionsModal ref={postOptionsModalRef} isVisibleTranslateModal={true} />
+        <PostOptionsModal
+          ref={postOptionsModalRef}
+          isVisibleTranslateModal={true}
+          onDelete={_handleDeleteFromMenu}
+        />
       </Fragment>
     );
   },

--- a/src/components/postOptionsModal/container/postOptionsModal.tsx
+++ b/src/components/postOptionsModal/container/postOptionsModal.tsx
@@ -478,7 +478,15 @@ const PostOptionsModal = (
           parentAuthor: content.parent_author || '',
           parentPermlink: content.parent_permlink || '',
         });
-        navigation.goBack();
+        // Going back only makes sense when the deleted content *is* the screen,
+        // which is true for a root post and false for a comment in a list:
+        // there, popping navigates away from the profile or post the user was
+        // reading. Consumers that own the surrounding list should pass
+        // `onDelete` and handle removal themselves; this keeps the fallback
+        // from popping the wrong screen when they do not.
+        if (!content?.parent_author) {
+          navigation.goBack();
+        }
         dispatch(
           toastNotification(
             intl.formatMessage({

--- a/src/components/postOptionsModal/container/postOptionsModal.tsx
+++ b/src/components/postOptionsModal/container/postOptionsModal.tsx
@@ -478,15 +478,15 @@ const PostOptionsModal = (
           parentAuthor: content.parent_author || '',
           parentPermlink: content.parent_permlink || '',
         });
-        // Going back only makes sense when the deleted content *is* the screen,
-        // which is true for a root post and false for a comment in a list:
-        // there, popping navigates away from the profile or post the user was
-        // reading. Consumers that own the surrounding list should pass
-        // `onDelete` and handle removal themselves; this keeps the fallback
-        // from popping the wrong screen when they do not.
-        if (!content?.parent_author) {
-          navigation.goBack();
-        }
+        // Always pops, because only the caller knows whether the deleted content
+        // *is* the screen. postScreen renders comments and waves as primary
+        // content too, so `parent_author` cannot stand in for that: gating on it
+        // left a comment's own detail screen showing deleted content.
+        //
+        // Consumers that own a surrounding list must therefore pass `onDelete`
+        // and handle removal themselves. See #3407 for inverting this into an
+        // explicit opt-in, which fails safe in the other direction.
+        navigation.goBack();
         dispatch(
           toastNotification(
             intl.formatMessage({


### PR DESCRIPTION
Closes #3406

`postComments.tsx` mounted `PostOptionsModal` for comments with no `onDelete`, so deleting a comment from the sheet ran the sheet's own path: `navigation.goBack()` at `postOptionsModal.tsx:478`, which navigates away from the post the user is reading. It also skipped `_handleDeleteComment` (`postComments.tsx:174`), which the same screen already passes to the inline delete button and which owns the error extraction and deleted-key cache handling. The sheet and the button did different things for the same action.

This predates #3405; that PR fixed the same gap for five list surfaces, and this was the remaining comment consumer.

### Two parts

**The consumer.** `postComments` now passes `onDelete` forwarding to its existing `_handleDeleteComment`, with the same five arguments the inline button uses.

**The fallback.** Relying on every consumer remembering `onDelete` has not worked - the existing comment on `_deletePost` already warned about this for waves, and it was still missed twice while adding consumers. Going back only makes sense when the deleted content *is* the screen, which is true for a root post and false for a comment in a list, so the fallback now pops only for content with no `parent_author`.

### Consumer audit

| Consumer | `onDelete` | Correct? |
|---|---|---|
| `wavesScreen` | yes | delegates to `wavesQuery.deleteWave` |
| `commentsView` | yes | added in #3405 |
| `postComments` | yes | this PR |
| `postScreen` | no | correct - deletes the post that *is* the screen |
| `editorScreen` | no | correct - same |
| `postsListContainer` | no | **wrong, but not fixed here** |

`postsListContainer` has the same gap for posts in a feed, and no list removal to delegate to. Filed as #3407 rather than half-fixed: a post in a list is indistinguishable from a post on its own screen by content shape, and suppressing the pop without adding removal would leave a stale feed with no feedback that anything happened. That issue also raises whether the prop should be inverted to an opt-in `popScreenOnDelete`, since forgetting an opt-in leaves you on the screen while forgetting `onDelete` navigates you away.

### Testing

- `yarn test:ci`: 730 passed, 1 skipped, 49 suites.
- `yarn lint`: 0 errors.

Device checks:
- Delete your own comment from the sheet on the post detail screen: it should disappear from the list and you should stay on the post.
- Do the same from a profile comments tab: same result, no navigation.
- Delete your own root post from its own screen: it should still pop back, unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved comment deletion with optimistic updates, reliable cache handling, and error notifications.
  * Standardized comment deletion from the options menu and confirmation flow.
  * Preserved appropriate navigation behavior after deleting comments or root posts.
  * Added rollback handling so comments reappear when deletion fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->