### PR TITLE
fix(feed): deleting a post from a list no longer pops the feed

### DIFF
--- a/src/components/postOptionsModal/container/postOptionsModal.tsx
+++ b/src/components/postOptionsModal/container/postOptionsModal.tsx
@@ -259,8 +259,15 @@ const PostOptionsModal = (
     // downvote made the option silently disappear), which surfaced as
     // "I can't delete this wave" when a duplicate had any vote at all.
     const _netRshares = Number(content.net_rshares ?? 0);
+    // Withheld on cross-posts for the same reason as mute and pin: `parsePost`
+    // swaps author and permlink to the original entry, so `content` here is the
+    // ORIGINAL, not the wrapper the user is looking at. On a self cross-post the
+    // author check passes and deleting would destroy the original post while
+    // leaving the wrapper, which is not what "delete" on that card means. Delete
+    // the original from its own card or screen instead.
     const _canDeletePost =
       currentAccount.name === content.author &&
+      !content.crosspostMeta &&
       !content.is_paidout &&
       !content.children &&
       _netRshares <= 0;

--- a/src/components/postsList/container/postsListContainer.tsx
+++ b/src/components/postsList/container/postsListContainer.tsx
@@ -41,6 +41,12 @@ interface postsListContainerProps extends FlatListProps<any> {
   isRefreshing: boolean;
   pageType: 'main' | 'profile' | 'ownProfile' | 'community';
   showQuickReplyModal: (post: any) => void;
+  /**
+   * Delete handler owned by whoever owns the list. Without it the options sheet
+   * falls back to its own path, which calls navigation.goBack() and pops the
+   * feed screen, and never removes the post from the feed cache.
+   */
+  onDeletePost?: (content: any) => void | Promise<void>;
 }
 
 let _onEndReachedCalledDuringMomentum = true;
@@ -55,6 +61,7 @@ const postsListContainer = (
     isLoading,
     pageType,
     showQuickReplyModal,
+    onDeletePost,
     refreshControl: _refreshControl,
     extraData: propsExtraData,
     ...props
@@ -301,7 +308,7 @@ const postsListContainer = (
         {...props}
       />
       <UpvotePopover ref={upvotePopoverRef} />
-      <PostOptionsModal ref={postDropdownRef} pageType={pageType} />
+      <PostOptionsModal ref={postDropdownRef} pageType={pageType} onDelete={onDeletePost} />
     </Fragment>
   );
 };

--- a/src/components/tabbedPosts/view/postsTabContent.tsx
+++ b/src/components/tabbedPosts/view/postsTabContent.tsx
@@ -215,6 +215,7 @@ const PostsTabContent = ({
       <PostsList
         ref={postsListRef}
         posts={feedQuery.data}
+        onDeletePost={feedQuery.deletePost}
         isFeedScreen={isFeedScreen}
         promotedPosts={!skipPromotedPosts ? promotedPostsQuery.data || [] : []}
         onLoadPosts={(shouldReset) => {

--- a/src/providers/queries/postQueries/feedQueries.ts
+++ b/src/providers/queries/postQueries/feedQueries.ts
@@ -243,11 +243,16 @@ export const useFeedQuery = ({
         }
         return {
           ...oldData,
+          // Guarded like `select` above: a page is not assumed to be an array,
+          // and an unguarded filter here would throw and abort the whole cache
+          // update rather than skipping one page.
           pages: oldData.pages.map((page) =>
-            page.filter(
-              (post) =>
-                !(post?.author === currentAccount.name && post?.permlink === content.permlink),
-            ),
+            Array.isArray(page)
+              ? page.filter(
+                  (post) =>
+                    !(post?.author === currentAccount.name && post?.permlink === content.permlink),
+                )
+              : page,
           ),
         };
       });

--- a/src/providers/queries/postQueries/feedQueries.ts
+++ b/src/providers/queries/postQueries/feedQueries.ts
@@ -6,7 +6,6 @@ import {
   getPostsRankedInfiniteQueryOptions,
   getAccountPostsInfiniteQueryOptions,
   getPromotedPostsQuery,
-  getPostQueryOptions,
   useDeleteComment,
 } from '@ecency/sdk';
 import { useIntl } from 'react-intl';
@@ -30,6 +29,18 @@ interface FeedQueryParams {
   pinnedPermlink?: string;
 }
 
+/**
+ * `author/permlink` of posts deleted during this app session.
+ *
+ * Module level rather than component state on purpose. The delete broadcasts
+ * async, so hivemind has not indexed it yet and any query refetching in that
+ * window returns the post again. Component state is lost when the screen
+ * unmounts, so leaving a profile and returning was enough to bring a deleted
+ * post back. Keeping it here suppresses the row whatever any cache holds,
+ * without forcing a fetch that would lose the race anyway.
+ */
+const deletedPostKeys = new Set<string>();
+
 export const useFeedQuery = ({
   feedUsername,
   filterKey,
@@ -42,14 +53,15 @@ export const useFeedQuery = ({
   const appStateSubRef = useRef<NativeEventSubscription | null>(null);
 
   const [isRefreshing, setIsRefreshing] = useState(false);
-  // `author/permlink` of posts deleted in this session. Applied to the assembled
-  // list rather than only the feed cache, because the list is assembled from
-  // more than that cache and the cache holds *raw* posts:
+  // Bumped when a delete lands, to re-run the memo below against the module set
+  // above. It is applied to the assembled list rather than only the feed cache,
+  // because the list is assembled from more than that cache and the cache holds
+  // *raw* posts:
   //  - the pinned post comes from its own query and is prepended
   //  - `select` parses a shallow copy, so a cross-post's cached author/permlink
   //    are the wrapper's while the rendered ones are the original's
   // Matching on the displayed identity is what the user actually acted on.
-  const [deletedKeys, setDeletedKeys] = useState<Set<string>>(() => new Set());
+  const [deletedVersion, setDeletedVersion] = useState(0);
 
   const cache = useAppSelector((state) => state.cache);
   const cacheRef = useRef(cache);
@@ -206,9 +218,10 @@ export const useFeedQuery = ({
       _data.filter(
         (post) =>
           (mutesSet ? !mutesSet.has(post?.author) : true) &&
-          !deletedKeys.has(`${post?.author}/${post?.permlink}`),
+          !deletedPostKeys.has(`${post?.author}/${post?.permlink}`),
       ),
-    [mutesSet, _data, deletedKeys],
+
+    [mutesSet, _data, deletedVersion],
   );
 
   /**
@@ -258,26 +271,14 @@ export const useFeedQuery = ({
         };
       });
 
-      // The pinned post is served from its own query, not the feed cache, so it
-      // has to be cleared there too. `deletedKeys` below only hides it for the
-      // life of this hook: leaving the profile and returning would remount with
-      // an empty set and prepend the still-cached pinned post again.
-      if (
-        pinnedPermlink &&
-        content.permlink === pinnedPermlink &&
-        content.author === feedUsername
-      ) {
-        const { queryKey: pinnedKey } = getPostQueryOptions(
-          feedUsername,
-          pinnedPermlink,
-          currentAccount?.name,
-        );
-        queryClient.setQueryData(pinnedKey, null);
-      }
-
-      // Covers cross-post rows, whose cached identity is the wrapper's while the
-      // rendered one is the original's, and keeps removal immediate elsewhere.
-      setDeletedKeys((prev) => new Set(prev).add(`${content.author}/${content.permlink}`));
+      // Deliberately does not clear the pinned post's own query. Emptying it
+      // forces a refetch, and the delete broadcasts async, so that refetch
+      // returns the not-yet-indexed post and puts it straight back. Recording
+      // the key suppresses the row whatever any cache still holds, and covers
+      // the cross-post case too, where the cached identity is the wrapper's
+      // while the rendered one is the original's.
+      deletedPostKeys.add(`${content.author}/${content.permlink}`);
+      setDeletedVersion((v) => v + 1);
 
       dispatch(toastNotification(intl.formatMessage({ id: 'alert.removed' })));
     },
@@ -289,8 +290,6 @@ export const useFeedQuery = ({
       queryClient,
       dispatch,
       intl,
-      pinnedPermlink,
-      feedUsername,
     ],
   );
 

--- a/src/providers/queries/postQueries/feedQueries.ts
+++ b/src/providers/queries/postQueries/feedQueries.ts
@@ -41,6 +41,14 @@ export const useFeedQuery = ({
   const appStateSubRef = useRef<NativeEventSubscription | null>(null);
 
   const [isRefreshing, setIsRefreshing] = useState(false);
+  // `author/permlink` of posts deleted in this session. Applied to the assembled
+  // list rather than only the feed cache, because the list is assembled from
+  // more than that cache and the cache holds *raw* posts:
+  //  - the pinned post comes from its own query and is prepended
+  //  - `select` parses a shallow copy, so a cross-post's cached author/permlink
+  //    are the wrapper's while the rendered ones are the original's
+  // Matching on the displayed identity is what the user actually acted on.
+  const [deletedKeys, setDeletedKeys] = useState<Set<string>>(() => new Set());
 
   const cache = useAppSelector((state) => state.cache);
   const cacheRef = useRef(cache);
@@ -193,8 +201,13 @@ export const useFeedQuery = ({
   // Apply mute filtering — Set for O(1) lookup instead of O(n) indexOf
   const mutesSet = useMemo(() => (isArray(mutes) ? new Set(mutes) : null), [mutes]);
   const _filteredData = useMemo(
-    () => _data.filter((post) => (mutesSet ? !mutesSet.has(post?.author) : true)),
-    [mutesSet, _data],
+    () =>
+      _data.filter(
+        (post) =>
+          (mutesSet ? !mutesSet.has(post?.author) : true) &&
+          !deletedKeys.has(`${post?.author}/${post?.permlink}`),
+      ),
+    [mutesSet, _data, deletedKeys],
   );
 
   /**
@@ -238,6 +251,10 @@ export const useFeedQuery = ({
           ),
         };
       });
+
+      // Covers the pinned post and cross-post wrappers, which the cache patch
+      // above cannot reach.
+      setDeletedKeys((prev) => new Set(prev).add(`${content.author}/${content.permlink}`));
 
       dispatch(toastNotification(intl.formatMessage({ id: 'alert.removed' })));
     },

--- a/src/providers/queries/postQueries/feedQueries.ts
+++ b/src/providers/queries/postQueries/feedQueries.ts
@@ -6,6 +6,7 @@ import {
   getPostsRankedInfiniteQueryOptions,
   getAccountPostsInfiniteQueryOptions,
   getPromotedPostsQuery,
+  getPostQueryOptions,
   useDeleteComment,
 } from '@ecency/sdk';
 import { useIntl } from 'react-intl';
@@ -257,8 +258,25 @@ export const useFeedQuery = ({
         };
       });
 
-      // Covers the pinned post and cross-post wrappers, which the cache patch
-      // above cannot reach.
+      // The pinned post is served from its own query, not the feed cache, so it
+      // has to be cleared there too. `deletedKeys` below only hides it for the
+      // life of this hook: leaving the profile and returning would remount with
+      // an empty set and prepend the still-cached pinned post again.
+      if (
+        pinnedPermlink &&
+        content.permlink === pinnedPermlink &&
+        content.author === feedUsername
+      ) {
+        const { queryKey: pinnedKey } = getPostQueryOptions(
+          feedUsername,
+          pinnedPermlink,
+          currentAccount?.name,
+        );
+        queryClient.setQueryData(pinnedKey, null);
+      }
+
+      // Covers cross-post rows, whose cached identity is the wrapper's while the
+      // rendered one is the original's, and keeps removal immediate elsewhere.
       setDeletedKeys((prev) => new Set(prev).add(`${content.author}/${content.permlink}`));
 
       dispatch(toastNotification(intl.formatMessage({ id: 'alert.removed' })));
@@ -271,6 +289,8 @@ export const useFeedQuery = ({
       queryClient,
       dispatch,
       intl,
+      pinnedPermlink,
+      feedUsername,
     ],
   );
 

--- a/src/providers/queries/postQueries/feedQueries.ts
+++ b/src/providers/queries/postQueries/feedQueries.ts
@@ -1,4 +1,4 @@
-import { useInfiniteQuery, useQuery, useQueryClient } from '@tanstack/react-query';
+import { InfiniteData, useInfiniteQuery, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { unionBy, isArray } from 'lodash';
 import { AppState, NativeEventSubscription } from 'react-native';
@@ -6,9 +6,13 @@ import {
   getPostsRankedInfiniteQueryOptions,
   getAccountPostsInfiniteQueryOptions,
   getPromotedPostsQuery,
+  useDeleteComment,
 } from '@ecency/sdk';
+import { useIntl } from 'react-intl';
 import QUERIES from '../queryKeys';
-import { useAppSelector } from '../../../hooks';
+import { useAppDispatch, useAppSelector } from '../../../hooks';
+import { toastNotification } from '../../../redux/actions/uiAction';
+import { useAuthContext } from '../../sdk';
 import filterNsfwPost from '../../../utils/filterNsfwPost';
 import { useGetPostQuery } from './postQueries';
 import { selectNsfw, selectCurrentAccount } from '../../../redux/selectors';
@@ -43,6 +47,11 @@ export const useFeedQuery = ({
   const currentAccount = useAppSelector(selectCurrentAccount);
   const nsfw = useAppSelector(selectNsfw);
   const mutes = currentAccount?.mutes || [];
+
+  const intl = useIntl();
+  const dispatch = useAppDispatch();
+  const authContext = useAuthContext();
+  const sdkDeleteMutation = useDeleteComment(currentAccount?.name, authContext, 'async');
 
   const pinnedPostQuery = useGetPostQuery({
     author: feedUsername,
@@ -188,12 +197,68 @@ export const useFeedQuery = ({
     [mutesSet, _data],
   );
 
+  /**
+   * Deletes a post and prunes it from this feed's cache.
+   *
+   * The options sheet's own delete path calls `navigation.goBack()`, which on a
+   * feed pops the screen the list is on, and it never touches the feed cache, so
+   * the deleted post stays visible. Consumers pass this as `onDelete` so the
+   * sheet delegates instead.
+   *
+   * The cache is patched rather than invalidated because the delete broadcasts
+   * async: `mutateAsync` resolves on mempool acceptance, so a refetch issued
+   * here would return pre-transaction state and bring the post straight back.
+   */
+  const deletePost = useCallback(
+    async (content: any) => {
+      if (!currentAccount?.name || !content?.permlink) {
+        return;
+      }
+
+      await sdkDeleteMutation.mutateAsync({
+        author: currentAccount.name,
+        permlink: content.permlink,
+        parentAuthor: content.parent_author || '',
+        parentPermlink: content.parent_permlink || '',
+      });
+
+      // Match author as well as permlink: a permlink is only unique per author,
+      // so filtering on it alone could drop someone else's post.
+      queryClient.setQueryData<InfiniteData<any[]>>(queryOptions.queryKey, (oldData) => {
+        if (!oldData?.pages) {
+          return oldData;
+        }
+        return {
+          ...oldData,
+          pages: oldData.pages.map((page) =>
+            page.filter(
+              (post) =>
+                !(post?.author === currentAccount.name && post?.permlink === content.permlink),
+            ),
+          ),
+        };
+      });
+
+      dispatch(toastNotification(intl.formatMessage({ id: 'alert.removed' })));
+    },
+    [
+      currentAccount?.name,
+      // mutateAsync is stable across renders; the mutation result object is not.
+      sdkDeleteMutation.mutateAsync,
+      queryOptions.queryKey,
+      queryClient,
+      dispatch,
+      intl,
+    ],
+  );
+
   return {
     data: _filteredData,
     isRefreshing,
     isLoading: feedQuery.isLoading,
     fetchNextPage: feedQuery.fetchNextPage,
     refresh: _refresh,
+    deletePost,
   };
 };
 


### PR DESCRIPTION
Closes #3407

`postsListContainer` mounted the options sheet with no `onDelete`, so deleting a post from a feed ran the sheet's own path: `navigation.goBack()` popped the feed screen, and nothing removed the post, so it stayed visible until something refetched. Reachable on your own profile feed, where `_canDeletePost` is satisfied.

### Where the removal belongs

The container receives `posts` as a prop and does not own the list, so it cannot remove anything itself. The owner is `useFeedQuery`, which is where `deletePost` now lives, modelled on `wavesQueries.deleteWave`:

- broadcast the delete
- prune the post from that feed's infinite-query cache, **matching author as well as permlink** since a permlink is only unique per author
- toast

Wired through as `onDeletePost`: `postsTabContent` -> `postsListContainer` -> the sheet's `onDelete`.

**The cache is patched, not invalidated.** The delete broadcasts async, so `mutateAsync` resolves on mempool acceptance and a refetch issued at that point returns pre-transaction state, bringing the post straight back. Same reason `deleteWave` patches, and the same trap as the `setRole` cache work in #3397.

### Consumer audit

This is the last list consumer. I checked what each screen actually renders this time, not just which pass the prop, since that narrower check is what let the #3408 regression through.

| Consumer | `onDelete` | Verdict |
|---|---|---|
| `wavesScreen` | yes | delegates to `wavesQuery.deleteWave` |
| `commentsView` | yes | #3405 |
| `postComments` | yes | #3406 |
| `postsListContainer` | yes | this PR |
| `postScreen` | no | correct - renders the post *or comment* as primary content, so the pop is right |
| `editorScreen` | no | correct - the content being edited |

Every consumer owning a surrounding list now delegates, and the fallback is only reached where popping is genuinely correct.

### Deliberately not in this PR

The sheet still pops **by default**, which is the footgun behind all three occurrences. Inverting it to an explicit opt-in is filed as #3409 rather than bundled here: there is no active bug once this lands, and the last attempt to harden that default inside a bug-fix PR (#3408's `parent_author` gate) caused a regression. It deserves its own change and its own review.

### Testing

- `yarn test:ci`: 730 passed, 1 skipped, 49 suites.
- `yarn lint`: 0 errors.

Device checks:
- On your own profile feed, delete an eligible post from the options sheet. It should disappear from the list and you should stay on the feed.
- Confirm it does not reappear on scroll or tab switch, which is what an invalidate-instead-of-patch would have caused.
- Confirm deleting a post from its own screen still navigates back, unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to delete posts directly from feed views.
  * Feed content updates automatically after a post is removed, including previously loaded results.
  * A localized status notification is displayed after successful deletion.
  * Deletion validates account access and the selected post before processing.

* **Bug Fixes**
  * Prevented deletion of original posts represented by cross-post content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->