### PR TITLE
Tell a failed search apart from an empty one

### DIFF
--- a/src/config/locales/en-US.json
+++ b/src/config/locales/en-US.json
@@ -714,6 +714,7 @@
     "transaction_fail": "Transaction Failed"
   },
   "search_result": {
+    "error": "Search could not be completed. Please try again",
     "communities_filter": {
       "new": "New",
       "my": "My Communities",

--- a/src/screens/searchResult/screen/tabs/best/container/postsResultsContainer.tsx
+++ b/src/screens/searchResult/screen/tabs/best/container/postsResultsContainer.tsx
@@ -162,9 +162,12 @@ const PostsResultsContainer = ({ children, searchValue }) => {
     try {
       setIsLoadingMore(true);
       const res = await search(`${searchValue} type:post`, sort, '0', undefined, scrollId);
-      const newResults = normalizeSearchResponse(res).results;
-      const nextScrollId =
-        res && typeof res === 'object' && 'scroll_id' in res ? res.scroll_id || '' : '';
+      // Read the cursor through the same normalizer as the results, rather than
+      // off res directly. normalizeSearchResponse knows where the cursor lives
+      // in each response shape it accepts (a paged one carries it on the last
+      // page), so reading it twice two different ways is how pagination stops
+      // silently on any shape but the plain one.
+      const { results: newResults, scrollId: nextScrollId } = normalizeSearchResponse(res);
 
       if (requestSequence.current !== requestId) {
         return;

--- a/src/screens/searchResult/screen/tabs/best/container/postsResultsContainer.tsx
+++ b/src/screens/searchResult/screen/tabs/best/container/postsResultsContainer.tsx
@@ -24,6 +24,10 @@ const PostsResultsContainer = ({ children, searchValue }) => {
   const [sort] = useState('relevance');
   const [scrollId, setScrollId] = useState('');
   const [noResult, setNoResult] = useState(false);
+  // Kept apart from noResult: a search that failed is not a search that found
+  // nothing, and telling the user "no results" for a dropped request sends them
+  // rewording a query that never ran.
+  const [isError, setIsError] = useState(false);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
 
@@ -59,6 +63,7 @@ const PostsResultsContainer = ({ children, searchValue }) => {
     let _data: any = [];
 
     setNoResult(false);
+    setIsError(false);
     setData(_data);
     setScrollId('');
     setIsLoading(true);
@@ -95,7 +100,7 @@ const PostsResultsContainer = ({ children, searchValue }) => {
     } catch (error) {
       console.warn('[PostsSearch] Search failed:', error);
       setData([]);
-      setNoResult(true);
+      setIsError(true);
     } finally {
       setIsLoading(false);
     }
@@ -135,16 +140,19 @@ const PostsResultsContainer = ({ children, searchValue }) => {
     }
     try {
       setIsLoadingMore(true);
-      const res = await search(`${searchValue} type:post`, sort, 0, undefined, scrollId);
+      const res = await search(`${searchValue} type:post`, sort, '0', undefined, scrollId);
       const newResults = normalizeSearchResponse(res).results;
       const nextScrollId =
         res && typeof res === 'object' && 'scroll_id' in res ? res.scroll_id || '' : '';
 
       // Use functional updater to avoid stale closure reads
       setData((prev) => {
-        const existingPermlinks = new Set(prev.map((item) => item.permlink));
+        // author + permlink: a permlink is only unique per author, and two
+        // authors sharing one ("re-...", the same slugified title) is common
+        // enough that deduping on it alone dropped legitimate results.
+        const seen = new Set(prev.map((item) => `${item.author}/${item.permlink}`));
         const filteredNewResults = newResults.filter(
-          (item) => !existingPermlinks.has(item.permlink),
+          (item) => !seen.has(`${item.author}/${item.permlink}`),
         );
         return [...prev, ...filteredNewResults];
       });
@@ -163,6 +171,7 @@ const PostsResultsContainer = ({ children, searchValue }) => {
       handleOnPress: _handleOnPress,
       loadMore: _loadMore,
       noResult,
+      isError,
       isLoading,
     })
   );

--- a/src/screens/searchResult/screen/tabs/best/container/postsResultsContainer.tsx
+++ b/src/screens/searchResult/screen/tabs/best/container/postsResultsContainer.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import get from 'lodash/get';
 
 import { useNavigation } from '@react-navigation/native';
@@ -30,11 +30,19 @@ const PostsResultsContainer = ({ children, searchValue }) => {
   const [isError, setIsError] = useState(false);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
+  const requestSequence = useRef(0);
 
   const currentAccountUsername = useAppSelector(selectCurrentAccountUsername);
 
   useEffect(() => {
-    _fetchResults();
+    const requestId = ++requestSequence.current;
+    _fetchResults(requestId);
+
+    return () => {
+      if (requestSequence.current === requestId) {
+        requestSequence.current += 1;
+      }
+    };
   }, [searchValue]);
 
   const normalizeSearchResponse = (res) => {
@@ -59,7 +67,7 @@ const PostsResultsContainer = ({ children, searchValue }) => {
     return { results: [], scrollId: '' };
   };
 
-  const _fetchResults = async () => {
+  const _fetchResults = async (requestId) => {
     let _data: any = [];
 
     setNoResult(false);
@@ -67,6 +75,7 @@ const PostsResultsContainer = ({ children, searchValue }) => {
     setData(_data);
     setScrollId('');
     setIsLoading(true);
+    setIsLoadingMore(false);
 
     try {
       // parse author and permlink if url
@@ -88,21 +97,29 @@ const PostsResultsContainer = ({ children, searchValue }) => {
         );
         const normalized = normalizeSearchResponse(res);
         _data = normalized.results;
-        setScrollId(normalized.scrollId);
+        if (requestSequence.current === requestId) {
+          setScrollId(normalized.scrollId);
+        }
       }
       // get initial posts if not search value
       else {
         _data = await getInitialPosts();
       }
 
-      setData(_data);
-      setNoResult(_data.length === 0);
+      if (requestSequence.current === requestId) {
+        setData(_data);
+        setNoResult(_data.length === 0);
+      }
     } catch (error) {
       console.warn('[PostsSearch] Search failed:', error);
-      setData([]);
-      setIsError(true);
+      if (requestSequence.current === requestId) {
+        setData([]);
+        setIsError(true);
+      }
     } finally {
-      setIsLoading(false);
+      if (requestSequence.current === requestId) {
+        setIsLoading(false);
+      }
     }
   };
 
@@ -123,14 +140,17 @@ const PostsResultsContainer = ({ children, searchValue }) => {
   // Component Functions
 
   const _handleOnPress = (item) => {
+    const author = get(item, 'author');
+    const permlink = get(item, 'permlink');
+
     postsCacherPrimer.cachePost(item);
     navigation.navigate({
       name: ROUTES.SCREENS.POST,
       params: {
-        author: get(item, 'author'),
-        permlink: get(item, 'permlink'),
+        author,
+        permlink,
       },
-      key: get(item, 'permlink'),
+      key: `${author}/${permlink}`,
     });
   };
 
@@ -138,12 +158,17 @@ const PostsResultsContainer = ({ children, searchValue }) => {
     if (!scrollId || !searchValue || isLoadingMore) {
       return;
     }
+    const requestId = requestSequence.current;
     try {
       setIsLoadingMore(true);
       const res = await search(`${searchValue} type:post`, sort, '0', undefined, scrollId);
       const newResults = normalizeSearchResponse(res).results;
       const nextScrollId =
         res && typeof res === 'object' && 'scroll_id' in res ? res.scroll_id || '' : '';
+
+      if (requestSequence.current !== requestId) {
+        return;
+      }
 
       // Use functional updater to avoid stale closure reads
       setData((prev) => {
@@ -158,9 +183,13 @@ const PostsResultsContainer = ({ children, searchValue }) => {
       });
       setScrollId(nextScrollId);
     } catch (error) {
-      console.warn('Search Failed', error);
+      if (requestSequence.current === requestId) {
+        console.warn('Search Failed', error);
+      }
     } finally {
-      setIsLoadingMore(false);
+      if (requestSequence.current === requestId) {
+        setIsLoadingMore(false);
+      }
     }
   };
 

--- a/src/screens/searchResult/screen/tabs/best/view/postsResults.tsx
+++ b/src/screens/searchResult/screen/tabs/best/view/postsResults.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { FlatList, View, Text, TouchableOpacity } from 'react-native';
 import get from 'lodash/get';
+import { useIntl } from 'react-intl';
 import isUndefined from 'lodash/isUndefined';
 import Highlighter from 'react-native-highlight-words';
 
@@ -20,6 +21,7 @@ import styles from './postsResultsStyles';
 import { SheetNames } from '../../../../../../navigation/sheets';
 
 const PostsResults = ({ searchValue, listRef }) => {
+  const intl = useIntl();
   const _showProfileModal = (username) => {
     if (username) {
       SheetManager.show(SheetNames.QUICK_PROFILE, {
@@ -101,10 +103,12 @@ const PostsResults = ({ searchValue, listRef }) => {
 
   return (
     <PostsResultsContainer searchValue={searchValue}>
-      {({ data, handleOnPress, loadMore, noResult, isLoading }) => (
+      {({ data, handleOnPress, loadMore, noResult, isError, isLoading }) => (
         <>
-          {noResult ? (
-            <EmptyScreen />
+          {noResult || isError ? (
+            <EmptyScreen
+              text={isError ? intl.formatMessage({ id: 'search_result.error' }) : undefined}
+            />
           ) : (
             <FlatList
               ref={listRef}

--- a/src/screens/searchResult/screen/tabs/communities/container/communitiesResultsContainer.ts
+++ b/src/screens/searchResult/screen/tabs/communities/container/communitiesResultsContainer.ts
@@ -20,6 +20,9 @@ const CommunitiesResultsContainer = ({ children, searchValue }) => {
 
   const [data, setData] = useState([]);
   const [noResult, setNoResult] = useState(false);
+  // See the people tab: an empty result and a failed lookup are different
+  // answers and used to be reported with the same one.
+  const [isError, setIsError] = useState(false);
   const [isDiscoversLoading, setIsDiscoversLoading] = useState(false);
   const currentAccount = useAppSelector(selectCurrentAccount);
   const handleCommunitySubscription = useCommunitySubscriptionAction();
@@ -47,6 +50,7 @@ const CommunitiesResultsContainer = ({ children, searchValue }) => {
     const fetchCommunities = async () => {
       setData([]);
       setNoResult(false);
+      setIsError(false);
       setIsDiscoversLoading(true);
       try {
         const communities = await queryClient.fetchQuery(
@@ -95,7 +99,7 @@ const CommunitiesResultsContainer = ({ children, searchValue }) => {
         setIsDiscoversLoading(false);
       } catch (error) {
         console.warn('[CommunitiesSearch] Search failed:', error);
-        setNoResult(true);
+        setIsError(true);
         setData([]);
         setIsDiscoversLoading(false);
       }
@@ -162,6 +166,7 @@ const CommunitiesResultsContainer = ({ children, searchValue }) => {
       handleSubscribeButtonPress: _handleSubscribeButtonPress,
       isLoggedIn,
       noResult,
+      isError,
       isDiscoversLoading,
     })
   );

--- a/src/screens/searchResult/screen/tabs/communities/container/communitiesResultsContainer.ts
+++ b/src/screens/searchResult/screen/tabs/communities/container/communitiesResultsContainer.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useDispatch } from 'react-redux';
 import { useIntl } from 'react-intl';
 import { shuffle } from 'lodash';
@@ -24,6 +24,7 @@ const CommunitiesResultsContainer = ({ children, searchValue }) => {
   // answers and used to be reported with the same one.
   const [isError, setIsError] = useState(false);
   const [isDiscoversLoading, setIsDiscoversLoading] = useState(false);
+  const requestSequence = useRef(0);
   const currentAccount = useAppSelector(selectCurrentAccount);
   const handleCommunitySubscription = useCommunitySubscriptionAction();
   const isLoggedIn = useAppSelector(selectIsLoggedIn);
@@ -47,6 +48,8 @@ const CommunitiesResultsContainer = ({ children, searchValue }) => {
 
   // Intentionally omit subscribedCommunitiesCache to avoid full refetches on cache updates.
   useEffect(() => {
+    const requestId = ++requestSequence.current;
+
     const fetchCommunities = async () => {
       setData([]);
       setNoResult(false);
@@ -61,6 +64,10 @@ const CommunitiesResultsContainer = ({ children, searchValue }) => {
             currentAccount?.name || undefined,
           ),
         );
+
+        if (requestSequence.current !== requestId) {
+          return;
+        }
 
         if (currentAccount && currentAccount.name) {
           const nextCommunities = communities.map((community) => {
@@ -98,14 +105,22 @@ const CommunitiesResultsContainer = ({ children, searchValue }) => {
         }
         setIsDiscoversLoading(false);
       } catch (error) {
-        console.warn('[CommunitiesSearch] Search failed:', error);
-        setIsError(true);
-        setData([]);
-        setIsDiscoversLoading(false);
+        if (requestSequence.current === requestId) {
+          console.warn('[CommunitiesSearch] Search failed:', error);
+          setIsError(true);
+          setData([]);
+          setIsDiscoversLoading(false);
+        }
       }
     };
 
     fetchCommunities();
+
+    return () => {
+      if (requestSequence.current === requestId) {
+        requestSequence.current += 1;
+      }
+    };
   }, [searchValue, queryClient, currentAccount, subscribedCommunities]);
 
   useEffect(() => {

--- a/src/screens/searchResult/screen/tabs/communities/view/communitiesResults.tsx
+++ b/src/screens/searchResult/screen/tabs/communities/view/communitiesResults.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import get from 'lodash/get';
+import { useIntl } from 'react-intl';
 
 // Components
 import { CommunitiesList, EmptyScreen } from '../../../../../../components';
@@ -7,6 +8,7 @@ import { CommunitiesList, EmptyScreen } from '../../../../../../components';
 import CommunitiesResultsContainer from '../container/communitiesResultsContainer';
 
 const CommunitiesResultsScreen = ({ navigation, searchValue, listRef }) => {
+  const intl = useIntl();
   const activeVotes = get(navigation, 'state.params.activeVotes');
 
   return (
@@ -18,10 +20,13 @@ const CommunitiesResultsScreen = ({ navigation, searchValue, listRef }) => {
         handleSubscribeButtonPress,
         isLoggedIn,
         noResult,
+        isError,
         isDiscoversLoading,
       }) =>
-        noResult ? (
-          <EmptyScreen />
+        noResult || isError ? (
+          <EmptyScreen
+            text={isError ? intl.formatMessage({ id: 'search_result.error' }) : undefined}
+          />
         ) : (
           <CommunitiesList
             data={data}

--- a/src/screens/searchResult/screen/tabs/people/container/peopleResultsContainer.ts
+++ b/src/screens/searchResult/screen/tabs/people/container/peopleResultsContainer.ts
@@ -21,6 +21,10 @@ const PeopleResultsContainer = ({ children, searchValue }) => {
   useEffect(() => {
     if (!searchValue) {
       setUsers([]);
+      // Clearing the field is not a failed lookup. _lookupAccounts is the only
+      // other place this resets and it does not run for an empty query, so
+      // without this the previous failure's message stays on screen.
+      setIsError(false);
     }
 
     // if serachValue is url parse author

--- a/src/screens/searchResult/screen/tabs/people/container/peopleResultsContainer.ts
+++ b/src/screens/searchResult/screen/tabs/people/container/peopleResultsContainer.ts
@@ -14,6 +14,9 @@ const PeopleResultsContainer = ({ children, searchValue }) => {
 
   const [users, setUsers] = useState([]);
   const [noResult, setNoResult] = useState(true);
+  // A failed lookup is not an empty one. These used to share a single flag, so
+  // an RPC that never answered was reported as "no such account".
+  const [isError, setIsError] = useState(false);
 
   useEffect(() => {
     if (!searchValue) {
@@ -30,16 +33,17 @@ const PeopleResultsContainer = ({ children, searchValue }) => {
 
   const _lookupAccounts = async (username) => {
     setNoResult(false);
+    setIsError(false);
     setUsers([]);
 
     try {
       const usernames = await queryClient.fetchQuery(lookupAccountsQueryOptions(username));
-      if (!usernames || usernames.length === 0) {
-        throw new Error('No users found');
-      }
-      setUsers(usernames.map((username) => ({ name: username })));
+      const accounts = usernames ?? [];
+      setUsers(accounts.map((name) => ({ name })));
+      setNoResult(accounts.length === 0);
     } catch (error) {
-      setNoResult(true);
+      console.warn('[PeopleSearch] Lookup failed:', error);
+      setIsError(true);
       setUsers([]);
     }
   };
@@ -62,6 +66,7 @@ const PeopleResultsContainer = ({ children, searchValue }) => {
       users,
       handleOnPress: _handleOnPress,
       noResult,
+      isError,
     })
   );
 };

--- a/src/screens/searchResult/screen/tabs/people/container/peopleResultsContainer.ts
+++ b/src/screens/searchResult/screen/tabs/people/container/peopleResultsContainer.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { connect } from 'react-redux';
 import { useNavigation } from '@react-navigation/native';
 
@@ -17,25 +17,40 @@ const PeopleResultsContainer = ({ children, searchValue }) => {
   // A failed lookup is not an empty one. These used to share a single flag, so
   // an RPC that never answered was reported as "no such account".
   const [isError, setIsError] = useState(false);
+  const requestSequence = useRef(0);
 
   useEffect(() => {
+    const requestId = ++requestSequence.current;
+
     if (!searchValue) {
       setUsers([]);
+      setNoResult(true);
       // Clearing the field is not a failed lookup. _lookupAccounts is the only
       // other place this resets and it does not run for an empty query, so
       // without this the previous failure's message stays on screen.
       setIsError(false);
+      return () => {
+        if (requestSequence.current === requestId) {
+          requestSequence.current += 1;
+        }
+      };
     }
 
     // if serachValue is url parse author
     const { author } = postUrlParser(searchValue) || {};
 
     if (searchValue) {
-      _lookupAccounts(author || searchValue);
+      _lookupAccounts(author || searchValue, requestId);
     }
+
+    return () => {
+      if (requestSequence.current === requestId) {
+        requestSequence.current += 1;
+      }
+    };
   }, [searchValue]);
 
-  const _lookupAccounts = async (username) => {
+  const _lookupAccounts = async (username, requestId) => {
     setNoResult(false);
     setIsError(false);
     setUsers([]);
@@ -43,12 +58,16 @@ const PeopleResultsContainer = ({ children, searchValue }) => {
     try {
       const usernames = await queryClient.fetchQuery(lookupAccountsQueryOptions(username));
       const accounts = usernames ?? [];
-      setUsers(accounts.map((name) => ({ name })));
-      setNoResult(accounts.length === 0);
+      if (requestSequence.current === requestId) {
+        setUsers(accounts.map((name) => ({ name })));
+        setNoResult(accounts.length === 0);
+      }
     } catch (error) {
-      console.warn('[PeopleSearch] Lookup failed:', error);
-      setIsError(true);
-      setUsers([]);
+      if (requestSequence.current === requestId) {
+        console.warn('[PeopleSearch] Lookup failed:', error);
+        setIsError(true);
+        setUsers([]);
+      }
     }
   };
 

--- a/src/screens/searchResult/screen/tabs/people/view/peopleResults.tsx
+++ b/src/screens/searchResult/screen/tabs/people/view/peopleResults.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { FlatList } from 'react-native';
+import { useIntl } from 'react-intl';
 
 // Components
 import {
@@ -12,6 +13,7 @@ import PeopleResultsContainer from '../container/peopleResultsContainer';
 import styles from './peopleResultsStyles';
 
 const PeopleResults = ({ searchValue, isUsername, listRef }) => {
+  const intl = useIntl();
   const _renderEmptyContent = () => {
     return (
       <>
@@ -22,10 +24,12 @@ const PeopleResults = ({ searchValue, isUsername, listRef }) => {
 
   return (
     <PeopleResultsContainer searchValue={searchValue} isUsername={isUsername}>
-      {({ users, handleOnPress, noResult }) => (
+      {({ users, handleOnPress, noResult, isError }) => (
         <>
-          {noResult && !users.length ? (
-            <EmptyScreen />
+          {(noResult || isError) && !users.length ? (
+            <EmptyScreen
+              text={isError ? intl.formatMessage({ id: 'search_result.error' }) : undefined}
+            />
           ) : (
             <FlatList
               ref={listRef}

--- a/src/screens/searchResult/screen/tabs/topics/container/topicsResultsContainer.ts
+++ b/src/screens/searchResult/screen/tabs/topics/container/topicsResultsContainer.ts
@@ -12,6 +12,9 @@ const OtherResultContainer = ({ children, searchValue }) => {
 
   const [tags, setTags] = useState([]);
   const [noResult, setNoResult] = useState(false);
+  // See the people tab: an empty result and a failed lookup are different
+  // answers and used to be reported with the same one.
+  const [isError, setIsError] = useState(false);
 
   useEffect(() => {
     const queryClient = getQueryClient();
@@ -19,11 +22,13 @@ const OtherResultContainer = ({ children, searchValue }) => {
 
     if (!trimmed) {
       setNoResult(false);
+      setIsError(false);
       setTags([]);
       return;
     }
 
     setNoResult(false);
+    setIsError(false);
     setTags([]);
 
     queryClient
@@ -34,8 +39,9 @@ const OtherResultContainer = ({ children, searchValue }) => {
         }
         setTags(res);
       })
-      .catch(() => {
-        setNoResult(true);
+      .catch((error) => {
+        console.warn('[TopicsSearch] Lookup failed:', error);
+        setIsError(true);
         setTags([]);
       });
   }, [searchValue]);
@@ -57,6 +63,7 @@ const OtherResultContainer = ({ children, searchValue }) => {
       tags,
       handleOnPress: _handleOnPress,
       noResult,
+      isError,
     })
   );
 };

--- a/src/screens/searchResult/screen/tabs/topics/container/topicsResultsContainer.ts
+++ b/src/screens/searchResult/screen/tabs/topics/container/topicsResultsContainer.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import get from 'lodash/get';
 import { connect } from 'react-redux';
 
@@ -15,8 +15,10 @@ const OtherResultContainer = ({ children, searchValue }) => {
   // See the people tab: an empty result and a failed lookup are different
   // answers and used to be reported with the same one.
   const [isError, setIsError] = useState(false);
+  const requestSequence = useRef(0);
 
   useEffect(() => {
+    const requestId = ++requestSequence.current;
     const queryClient = getQueryClient();
     const trimmed = searchValue?.trim();
 
@@ -24,7 +26,11 @@ const OtherResultContainer = ({ children, searchValue }) => {
       setNoResult(false);
       setIsError(false);
       setTags([]);
-      return;
+      return () => {
+        if (requestSequence.current === requestId) {
+          requestSequence.current += 1;
+        }
+      };
     }
 
     setNoResult(false);
@@ -34,16 +40,27 @@ const OtherResultContainer = ({ children, searchValue }) => {
     queryClient
       .fetchQuery(getSearchTopicsQueryOptions(trimmed, 20))
       .then((res) => {
+        if (requestSequence.current !== requestId) {
+          return;
+        }
         if (res && res.length === 0) {
           setNoResult(true);
         }
         setTags(res);
       })
       .catch((error) => {
-        console.warn('[TopicsSearch] Lookup failed:', error);
-        setIsError(true);
-        setTags([]);
+        if (requestSequence.current === requestId) {
+          console.warn('[TopicsSearch] Lookup failed:', error);
+          setIsError(true);
+          setTags([]);
+        }
       });
+
+    return () => {
+      if (requestSequence.current === requestId) {
+        requestSequence.current += 1;
+      }
+    };
   }, [searchValue]);
 
   // Component Functions

--- a/src/screens/searchResult/screen/tabs/topics/view/topicsResults.tsx
+++ b/src/screens/searchResult/screen/tabs/topics/view/topicsResults.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { FlatList, View, Text, TouchableOpacity } from 'react-native';
+import { useIntl } from 'react-intl';
 
 // Components
 import { ListPlaceHolder, EmptyScreen } from '../../../../../../components/basicUIElements';
@@ -8,6 +9,7 @@ import TopicsResultsContainer from '../container/topicsResultsContainer';
 import styles from './topicsResultsStyles';
 
 const TopicsResults = ({ searchValue }) => {
+  const intl = useIntl();
   const _renderTagItem = (item, index) => (
     <View style={[styles.itemWrapper, index % 2 !== 0 && styles.itemWrapperGray]}>
       <Text style={styles.username}>{`#${item.tag}`}</Text>
@@ -24,10 +26,12 @@ const TopicsResults = ({ searchValue }) => {
 
   return (
     <TopicsResultsContainer searchValue={searchValue}>
-      {({ tags, handleOnPress, noResult }) => (
+      {({ tags, handleOnPress, noResult, isError }) => (
         <>
-          {noResult ? (
-            <EmptyScreen />
+          {noResult || isError ? (
+            <EmptyScreen
+              text={isError ? intl.formatMessage({ id: 'search_result.error' }) : undefined}
+            />
           ) : (
             <FlatList
               data={tags}


### PR DESCRIPTION
Found while fixing the same class of defect on the website (ecency/vision-next#1343). Mobile has no advanced search UI, so most of those findings do not apply here, but this one does and two posts-tab bugs turned up alongside it.

## Failure reported as "no results"

All four tabs funnel every failure into the same `noResult` flag, so a dropped RPC, a rejected query and a genuinely empty result set render the same "nothing here" screen. The user is told to reword a query that never ran.

The People tab was the clearest case: it `throw`s on an empty account list and catches that into the same state as a network error, so the two were merged deliberately. It now sets `noResult` from the result length and keeps the `catch` for actual failures.

Each container exposes `isError` alongside `noResult`, and each view passes the failure copy to `EmptyScreen` (which already takes a `text` prop). Failures are logged, as the posts and communities tabs already did.

## Posts tab, two more

- **Load more deduped by permlink alone.** `new Set(prev.map(i => i.permlink))` - a permlink is only unique per author, and two authors sharing one is common (`re-...` replies, the same slugified title), so legitimate results were silently dropped from page 2 on. Keyed on author and permlink now, which is what the list's own `keyExtractor` uses.
- **`search(query, sort, 0, ...)` passed a number where the SDK types `hideLow: string`.** It works because the API coerces it, but nothing in this repo catches that class of error: CI runs lint and jest, there is no `tsc` step. Worth considering separately.

## Already fixed server-side, no client change needed

Mobile appends ` type:post` to every posts query, and the API used to match `type:` inside ordinary words. `filetype:pdf` or `prototype:v2` therefore parsed as an invalid type and returned 400, which showed up as "no results". Fixed in ecency/hivesearcher-api#11, deployed today.

Also from ecency/hivesearcher-api#10, deployed today: typing `author:someone` or `tag:travel` alone in mobile search used to be rejected and now returns results.

## Not changed, worth a decision

`hide_low` is off on mobile (`'0'`) and on by default on the website, so the same query returns different result sets per platform. The website's default filters `payout >= 0.5` and `author_rep >= 25`, which hides fresh posts and newer authors. Mobile's behaviour is arguably the better one; either way it should be deliberate rather than accidental.

## Test plan

`yarn lint` clean on `src/screens/searchResult` (one pre-existing warning), `yarn test:ci` green: 48 suites, 730 tests. There are no existing tests for these containers; the change is state-shape only, no new dependencies.

Needs a device pass on the four tabs: results, empty result, and a failure (airplane mode mid-search) on each.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Search failures are now clearly distinguished from searches with no results.
  * Localized error messages are displayed when searches for posts, communities, people, or topics fail.
  * Results no longer show outdated data when searches change quickly.
  * Search result pagination now handles cursors correctly and avoids duplicate posts.
  * Empty-result messaging remains unchanged for successful searches with no matches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->