### PR TITLE
Bump @ecency/sdk to 2.3.75

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@babel/preset-typescript": "^7.26.0",
     "@babel/runtime": "^7.26.7",
     "@ecency/render-helper": "^2.5.23",
-    "@ecency/sdk": "^2.3.74",
+    "@ecency/sdk": "^2.3.75",
     "@esteemapp/react-native-autocomplete-input": "^4.2.1",
     "@esteemapp/react-native-multi-slider": "^1.1.0",
     "@native-html/iframe-plugin": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@babel/preset-typescript": "^7.26.0",
     "@babel/runtime": "^7.26.7",
     "@ecency/render-helper": "^2.5.23",
-    "@ecency/sdk": "^2.3.71",
+    "@ecency/sdk": "^2.3.74",
     "@esteemapp/react-native-autocomplete-input": "^4.2.1",
     "@esteemapp/react-native-multi-slider": "^1.1.0",
     "@native-html/iframe-plugin": "^2.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1210,10 +1210,10 @@
     url "^0.11.0"
     xss "^1.0.9"
 
-"@ecency/sdk@^2.3.74":
-  version "2.3.74"
-  resolved "https://registry.yarnpkg.com/@ecency/sdk/-/sdk-2.3.74.tgz#6eb04ccbacf578c468dfec299718d71bc077369a"
-  integrity sha512-7NZyDRGmtC+1UMuCUz0DEmXwLHTMcoyANBRGRHshdELRQuS16UCuttTZISx1dYl0a6H3OZnU6T/+clLpdo71fQ==
+"@ecency/sdk@^2.3.75":
+  version "2.3.75"
+  resolved "https://registry.yarnpkg.com/@ecency/sdk/-/sdk-2.3.75.tgz#091ab47492e535279628c3406427d4aa94415d0e"
+  integrity sha512-j3KgaIEQt+/VmZH3JwAC9mETgQviOBEQAdafarcR+nlcL8ckZXnmPLI1E6/OFIPr044uTLrVAEEfOlX+opsHdA==
   dependencies:
     "@noble/ciphers" "^2.1.1"
     "@noble/curves" "^2.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1210,10 +1210,10 @@
     url "^0.11.0"
     xss "^1.0.9"
 
-"@ecency/sdk@^2.3.71":
-  version "2.3.71"
-  resolved "https://registry.yarnpkg.com/@ecency/sdk/-/sdk-2.3.71.tgz#c4acec3de7520fb8a814126ff1c0c8b406b9a8e9"
-  integrity sha512-DNzLpH5yRML4gLthcz3NYKFeul8xf8esSOw1ACFN4oZnbS+UBsu0ozZUN89Ctsw3qYs+9GaU54Nw9u1RbXsPVA==
+"@ecency/sdk@^2.3.74":
+  version "2.3.74"
+  resolved "https://registry.yarnpkg.com/@ecency/sdk/-/sdk-2.3.74.tgz#6eb04ccbacf578c468dfec299718d71bc077369a"
+  integrity sha512-7NZyDRGmtC+1UMuCUz0DEmXwLHTMcoyANBRGRHshdELRQuS16UCuttTZISx1dYl0a6H3OZnU6T/+clLpdo71fQ==
   dependencies:
     "@noble/ciphers" "^2.1.1"
     "@noble/curves" "^2.0.1"


### PR DESCRIPTION
Picks up the search fixes this app had been missing. Follows ecency/vision-next#1345, #1348 and #1351.

Originally targeted 2.3.74; retargeted to 2.3.75 because 2.3.74 shipped with a hole this app would have hit (see below). Taking both releases in one bump rather than shipping the defect and bumping again.

## Why it matters here

The post search calls `searchQueryOptions`. Until 2.3.74 that path still threw a bare `Search failed: <status>`, so:

- the container could not tell a rejected query from an empty result set, the same failure/empty conflation #3411 fixed on the UI side - the SDK half was still missing
- a 400 that can never succeed was retried three times first, costing four requests over several seconds before the user saw anything

## What lands with 2.3.75

- **`searchQueryOptions` and the controversial/rising query** keep the backend's explanation of a rejected query on the error (`Maximum 5 tags!`, `Query is empty! ...`) and share the retry rule: no retry for a 4xx that rejects the query itself, normal backoff for 408 and 429.
- **A 2xx that is not a `SearchResponse` now rejects** instead of being cached as one. That covers both an unparseable body (an HTML page from a proxy) and valid JSON of the wrong shape (`null`, `"maintenance"`, `{"error":"..."}`). On mobile either would have reached the container as a non-response and surfaced as a phantom "no results" through its `catch`.
- **The response body is read once**, so a non-JSON gateway error keeps its text as a diagnostic instead of being silently dropped.

## Scope

Range and lockfile move together rather than leaving a caret to drift on some later unrelated install. `yarn.lock` shows one changed resolution - no other dependency moved.

## Test plan

`yarn lint` clean on `src/screens/searchResult` (one pre-existing warning), `yarn test:ci` green: 48 suites, 730 tests.

Because this repo has no `tsc` step in CI, I checked the installed declarations against every SDK call the search screens make - `search`, `searchQueryOptions`, `lookupAccountsQueryOptions`, `getCommunitiesQueryOptions`, `getSearchTopicsQueryOptions` - all unchanged and matching what the containers pass, including `hideLow: string`.

I also exercised the **published dist** directly rather than relying on the source tests in vision-next, since dist is compiled separately:

```
PASS  200 valid SearchResponse   -> resolve
PASS  200 null                   -> reject
PASS  200 bare string            -> reject
PASS  200 error object           -> reject
PASS  200 array                  -> reject
PASS  200 html (unparseable)     -> reject
PASS  400 with body              -> reject (status=400, data preserved)
```

And confirmed the retry budget resolves correctly for React Native. `isServer` is `typeof window === "undefined"`, and RN defines `window`, so mobile gets the browser budget rather than the SSR one: 400/404 no retry, 408/429/503/network retry, capped at 3.

Worth a device pass on the four search tabs, since the SDK is on the path for all of them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Ecency SDK dependency to a newer version for improved compatibility and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->