### PR TITLE
Fix search filter button crash

### DIFF
--- a/src/components/searchFiltersSheet/searchFiltersSheet.tsx
+++ b/src/components/searchFiltersSheet/searchFiltersSheet.tsx
@@ -1,11 +1,10 @@
 import React, { useCallback, useRef, useState } from 'react';
-import { Text, TextInput, View } from 'react-native';
+import { Text, TextInput, TouchableOpacity, View } from 'react-native';
 import { useIntl } from 'react-intl';
 import ActionSheet, { SheetManager, SheetProps } from 'react-native-actions-sheet';
 import EStyleSheet from 'react-native-extended-stylesheet';
 import { buildSearchQuery, SearchType } from '@ecency/sdk';
 import { MainButton } from '../mainButton';
-import { Tag } from '../basicUIElements';
 import {
   EMPTY_SEARCH_FILTERS,
   type SearchDateOption,
@@ -114,8 +113,10 @@ const SearchFiltersSheet: React.FC<SheetProps<'search_filters'>> = ({ sheetId, p
     </View>
   );
 
-  // Chips rather than a dropdown: every option set here is three or four items,
-  // and the same Tag component already backs the feed's filter bar.
+  // Chips rather than a dropdown: every option set here is three or four items.
+  // Keep these local instead of using the shared Tag component. Tag always calls
+  // useNavigation(), but registered sheets are rendered by SheetProvider outside
+  // the app's NavigationContainer and would throw as soon as this sheet opens.
   const _renderChoice = <T extends string>(
     labelId: string,
     options: T[],
@@ -126,17 +127,22 @@ const SearchFiltersSheet: React.FC<SheetProps<'search_filters'>> = ({ sheetId, p
     <View style={styles.field}>
       <Text style={styles.label}>{intl.formatMessage({ id: labelId })}</Text>
       <View style={styles.chipRow}>
-        {options.map((option) => (
-          <Tag
-            key={option || 'all'}
-            value={option}
-            label={labelFor(option)}
-            isFilter={true}
-            isPin={option === selected}
-            onPress={() => onSelect(option)}
-            style={styles.chip}
-          />
-        ))}
+        {options.map((option) => {
+          const isSelected = option === selected;
+          return (
+            <TouchableOpacity
+              key={option || 'all'}
+              style={[styles.chip, isSelected && styles.selectedChip]}
+              onPress={() => onSelect(option)}
+              accessibilityRole="button"
+              accessibilityState={{ selected: isSelected }}
+            >
+              <Text style={[styles.chipText, isSelected && styles.selectedChipText]}>
+                {labelFor(option)}
+              </Text>
+            </TouchableOpacity>
+          );
+        })}
       </View>
     </View>
   );
@@ -250,6 +256,21 @@ const styles = EStyleSheet.create({
   chip: {
     marginRight: 8,
     marginBottom: 6,
+    minHeight: 32,
+    paddingHorizontal: 12,
+    borderRadius: 16,
+    justifyContent: 'center',
+  },
+  selectedChip: {
+    backgroundColor: '$primaryBlue',
+  },
+  chipText: {
+    color: '$primaryDarkGray',
+    fontSize: 12,
+    fontWeight: 'bold',
+  },
+  selectedChipText: {
+    color: '$pureWhite',
   },
   label: {
     color: '$primaryDarkText',

--- a/src/screens/searchResult/screen/searchResultScreen.tsx
+++ b/src/screens/searchResult/screen/searchResultScreen.tsx
@@ -92,6 +92,7 @@ const SearchResultScreen = ({ navigation }) => {
         </View>
         <IconButton
           style={styles.filterButton}
+          iconStyle={styles.filterIcon}
           iconType="MaterialCommunityIcons"
           name={activeFilterCount > 0 ? 'filter' : 'filter-outline'}
           size={22}

--- a/src/screens/searchResult/screen/searchResultStyles.ts
+++ b/src/screens/searchResult/screen/searchResultStyles.ts
@@ -52,6 +52,11 @@ export default EStyleSheet.create({
     flex: 1,
   },
   filterButton: {
-    paddingHorizontal: 12,
+    marginTop: 20,
+    marginRight: 12,
+    paddingHorizontal: 8,
+  },
+  filterIcon: {
+    color: '$iconColor',
   },
 });


### PR DESCRIPTION
## Summary

- make the advanced search filter icon visible and align its touch target
- render filter choices without requiring navigation context
- preserve translated labels and selected-state accessibility

## Root cause

The shared tag component requested navigation context when the registered filter sheet opened. Registered sheets render outside the app navigation container, causing the sheet to fail during rendering. The filter icon also inherited a dark default color against the dark header.

## Validation

- search filter tests pass
- targeted lint passes with no errors
- diff checks pass