### PR TITLE
Use reanimated exiting animations for inputSupportModal close

### DIFF
--- a/src/components/organisms/inputSupportModal/container/inputSupportModal.tsx
+++ b/src/components/organisms/inputSupportModal/container/inputSupportModal.tsx
@@ -13,13 +13,21 @@ export interface InputSupportModalProps {
 export const InputSupportModal = ({ children, visible, onClose }: InputSupportModalProps) => {
   // Reanimated defers the unmount until the exiting animations below finish,
   // so rendering can track `visible` directly with no delayed-hide state.
+  // iOS-only gating per 2d26cc4: declarative entering/exiting on
+  // conditionally-mounted views race Fabric's transaction merging on Android
+  // ("Unable to find viewState for tag" native crash); Android shows/hides
+  // instantly instead.
   return visible ? (
     <Portal>
-      <Animated.View entering={FadeIn} exiting={FadeOut} style={styles.container}>
+      <Animated.View
+        entering={Platform.OS === 'ios' ? FadeIn : undefined}
+        exiting={Platform.OS === 'ios' ? FadeOut : undefined}
+        style={styles.container}
+      >
         <Animated.View
           style={{ flex: 1 }}
-          entering={SlideInUp.easing(Easing.ease)}
-          exiting={SlideOutDown.easing(Easing.ease)}
+          entering={Platform.OS === 'ios' ? SlideInUp.easing(Easing.ease) : undefined}
+          exiting={Platform.OS === 'ios' ? SlideOutDown.easing(Easing.ease) : undefined}
         >
           <View style={{ flex: 1 }} onTouchEnd={onClose} />
 

--- a/src/components/organisms/inputSupportModal/container/inputSupportModal.tsx
+++ b/src/components/organisms/inputSupportModal/container/inputSupportModal.tsx
@@ -13,34 +13,39 @@ export interface InputSupportModalProps {
 export const InputSupportModal = ({ children, visible, onClose }: InputSupportModalProps) => {
   // Reanimated defers the unmount until the exiting animations below finish,
   // so rendering can track `visible` directly with no delayed-hide state.
+  // The Portal stays mounted with the conditional inside: exit interception
+  // needs the non-animated parent to survive while the animated children are
+  // removed.
   // iOS-only gating per 2d26cc4: declarative entering/exiting on
   // conditionally-mounted views race Fabric's transaction merging on Android
   // ("Unable to find viewState for tag" native crash); Android shows/hides
   // instantly instead.
-  return visible ? (
+  return (
     <Portal>
-      <Animated.View
-        entering={Platform.OS === 'ios' ? FadeIn : undefined}
-        exiting={Platform.OS === 'ios' ? FadeOut : undefined}
-        style={styles.container}
-      >
+      {visible ? (
         <Animated.View
-          style={{ flex: 1 }}
-          entering={Platform.OS === 'ios' ? SlideInUp.easing(Easing.ease) : undefined}
-          exiting={Platform.OS === 'ios' ? SlideOutDown.easing(Easing.ease) : undefined}
+          entering={Platform.OS === 'ios' ? FadeIn : undefined}
+          exiting={Platform.OS === 'ios' ? FadeOut : undefined}
+          style={styles.container}
         >
-          <View style={{ flex: 1 }} onTouchEnd={onClose} />
+          <Animated.View
+            style={{ flex: 1 }}
+            entering={Platform.OS === 'ios' ? SlideInUp.easing(Easing.ease) : undefined}
+            exiting={Platform.OS === 'ios' ? SlideOutDown.easing(Easing.ease) : undefined}
+          >
+            <View style={{ flex: 1 }} onTouchEnd={onClose} />
 
-          {Platform.select({
-            ios: (
-              <KeyboardAvoidingView behavior="padding" style={{}}>
-                {children}
-              </KeyboardAvoidingView>
-            ),
-            android: <View>{children}</View>,
-          })}
+            {Platform.select({
+              ios: (
+                <KeyboardAvoidingView behavior="padding" style={{}}>
+                  {children}
+                </KeyboardAvoidingView>
+              ),
+              android: <View>{children}</View>,
+            })}
+          </Animated.View>
         </Animated.View>
-      </Animated.View>
+      ) : null}
     </Portal>
-  ) : null;
+  );
 };

--- a/src/components/organisms/inputSupportModal/container/inputSupportModal.tsx
+++ b/src/components/organisms/inputSupportModal/container/inputSupportModal.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useRef, useState } from 'react';
-import Animated, { FadeIn, SlideInUp } from 'react-native-reanimated';
+import React from 'react';
+import Animated, { FadeIn, FadeOut, SlideInUp, SlideOutDown } from 'react-native-reanimated';
 import { Portal } from 'react-native-portalize';
 import { Easing, KeyboardAvoidingView, Platform, View } from 'react-native';
 import styles from '../children/inputSupportModal.styles';
@@ -11,49 +11,28 @@ export interface InputSupportModalProps {
 }
 
 export const InputSupportModal = ({ children, visible, onClose }: InputSupportModalProps) => {
-  // TODO: these refs attach to reanimated Animated.View, which has no
-  // slideOutDown/fadeOut - those are react-native-animatable methods left
-  // over from before the reanimated migration, so the close animation path
-  // needs a rework with exiting={} animations before it can be typed.
-  const container = useRef<any>(null);
-  const innerContainer = useRef<any>(null);
+  // Reanimated defers the unmount until the exiting animations below finish,
+  // so rendering can track `visible` directly with no delayed-hide state.
+  return visible ? (
+    <Portal>
+      <Animated.View entering={FadeIn} exiting={FadeOut} style={styles.container}>
+        <Animated.View
+          style={{ flex: 1 }}
+          entering={SlideInUp.easing(Easing.ease)}
+          exiting={SlideOutDown.easing(Easing.ease)}
+        >
+          <View style={{ flex: 1 }} onTouchEnd={onClose} />
 
-  const [showModal, setShowModal] = useState(visible);
-
-  useEffect(() => {
-    if (visible) {
-      setShowModal(true);
-    } else if (!visible && container.current && innerContainer.current) {
-      innerContainer.current.slideOutDown(1000);
-      setTimeout(async () => {
-        await container.current?.fadeOut(200);
-        setShowModal(false);
-      }, 300);
-    }
-  }, [visible]);
-
-  return (
-    showModal && (
-      <Portal>
-        <Animated.View ref={container} entering={FadeIn} style={styles.container}>
-          <Animated.View
-            ref={innerContainer}
-            style={{ flex: 1 }}
-            entering={SlideInUp.easing(Easing.ease)}
-          >
-            <View style={{ flex: 1 }} onTouchEnd={onClose} />
-
-            {Platform.select({
-              ios: (
-                <KeyboardAvoidingView behavior="padding" style={{}}>
-                  {children}
-                </KeyboardAvoidingView>
-              ),
-              android: <View>{children}</View>,
-            })}
-          </Animated.View>
+          {Platform.select({
+            ios: (
+              <KeyboardAvoidingView behavior="padding" style={{}}>
+                {children}
+              </KeyboardAvoidingView>
+            ),
+            android: <View>{children}</View>,
+          })}
         </Animated.View>
-      </Portal>
-    )
-  );
+      </Animated.View>
+    </Portal>
+  ) : null;
 };


### PR DESCRIPTION
Closes #3426

The close path called `innerContainer.current.slideOutDown(1000)` / `container.current.fadeOut(200)` on refs attached to reanimated `Animated.View`s. Those are react-native-animatable methods left over from before the reanimated migration; reanimated view instances do not have them, so flipping `visible` to false threw instead of playing the close animation.

Replace the refs, the mirrored `showModal` state and the `setTimeout` dance with declarative `exiting` animations symmetric to the existing `entering` ones. Reanimated defers the actual unmount until exit animations complete, so the component now renders directly from `visible`.

Per review: both `entering` and `exiting` are gated to iOS in the same style as 2d26cc4 - declarative animations on conditionally-mounted views race Fabric's transaction merging on Android ("Unable to find viewState for tag", ECENCY-MOBILE-7/78/7F). Android shows and hides instantly.

Also per review: `InputSupportModal` currently has no consumers - the only reference outside its folder is the `organisms/index.ts` barrel re-export - so this cannot be exercised from the app as-is. The fix keeps the component correct for revival or removal; deleting it entirely is a reasonable alternative if preferred.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Improved the support modal’s closing experience with smoother fade-out and slide-down animations on iOS.
  * Modal visibility now updates more responsively when opened or closed.
  * On Android, the modal now closes without unnecessary exit animations for a more consistent experience.
  * Improved platform-specific behavior for a smoother and more predictable modal experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->