### PR TITLE
Type src/utils: 324 baseline errors to zero

### DIFF
--- a/src/constants/repeatableTransfers.ts
+++ b/src/constants/repeatableTransfers.ts
@@ -1,11 +1,11 @@
 // This document lets us mark which wallet operations can be repeatable
 // directly from transaction/activities list
 
-export const RepeatableTransfers = {
+export const RepeatableTransfers: Partial<Record<string, boolean>> = {
   // Hive transfers
   transfer: true,
   // Ecency transfer
   outgoing_transfer_title: true,
   // Engine transfers
   tokens_transfer: true,
-} as const;
+};

--- a/src/containers/walletContainer.ts
+++ b/src/containers/walletContainer.ts
@@ -17,7 +17,12 @@ import { useClaimRewardsMutation as useSdkClaimRewardsMutation } from '../provid
 import { getQueryClient } from '../providers/queries';
 
 // Utils
-import { groomingWalletTabData, groomingTransactionData, transferTypes } from '../utils/wallet';
+import {
+  WalletTabData,
+  groomingWalletTabData,
+  groomingTransactionData,
+  transferTypes,
+} from '../utils/wallet';
 import parseToken from '../utils/parseToken';
 import { vestsToHp } from '../utils/conversions';
 import RootNavigation from '../navigation/rootNavigation';
@@ -59,7 +64,7 @@ const WalletContainer = ({
   const [isClaiming, setIsClaiming] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
-  const [walletData, setWalletData] = useState(null);
+  const [walletData, setWalletData] = useState<WalletTabData | null>(null);
   const [userActivities, setUserActivities] = useState([]);
   const [hbdBalance, setHbdBalance] = useState(0);
   const [tokenBalance, setTokenBalance] = useState(0);

--- a/src/providers/hive-engine/hiveEngine.types.ts
+++ b/src/providers/hive-engine/hiveEngine.types.ts
@@ -150,6 +150,7 @@ export interface MarketData {
 
 export interface HistoryItem {
   _id: string;
+  id?: string;
   blockNumber: number;
   transactionId: string;
   timestamp: number;

--- a/src/providers/hive/hive.types.ts
+++ b/src/providers/hive/hive.types.ts
@@ -48,18 +48,26 @@ export interface AiToolsMeta {
   writing_edit?: boolean; // AI grammar/formatting/editing assistance
 }
 
+// All fields optional: extractMetadata builds this progressively and app/format
+// etc. are merged in later by makeJsonMetadata.
 export interface PostMetadata extends Partial<PollMetadata> {
   // GENERAL
-  tags: string[];
-  token: string;
-  description: string;
-  format: string;
-  version: number;
-  app: string;
+  tags?: string[];
+  token?: string;
+  description?: string;
+  format?: string;
+  version?: number;
+  app?: string;
+  // separates waves/comments from top-level posts (PostTypes value)
+  type?: string;
+
+  // LINKS
+  links?: string[];
+  links_meta?: Record<string, { title?: string; summary?: string; image?: string[] } | null>;
 
   // IMAGE
-  image: string[];
-  image_ratios: number[];
+  image?: string[];
+  image_ratios?: number[];
 
   // AI-usage disclosure (interoperable across Hive frontends; omitted when nothing disclosed)
   ai_tools?: AiToolsMeta;

--- a/src/providers/hive/hive.types.ts
+++ b/src/providers/hive/hive.types.ts
@@ -63,7 +63,7 @@ export interface PostMetadata extends Partial<PollMetadata> {
 
   // LINKS
   links?: string[];
-  links_meta?: Record<string, { title?: string; summary?: string; image?: string[] } | null>;
+  links_meta?: Record<string, { title?: string; summary?: string; image?: string | null } | null>;
 
   // IMAGE
   image?: string[];

--- a/src/providers/queries/walletQueries/walletQueries.ts
+++ b/src/providers/queries/walletQueries/walletQueries.ts
@@ -425,7 +425,9 @@ export const useActivitiesQuery = (symbol: string, layer: PortfolioLayer) => {
     if (isEngine) {
       const pages = engineQuery.data?.pages || [];
       const merged = unionBy(...pages, 'engineTrxId');
-      return merged.sort((a, b) => new Date(b.created).getTime() - new Date(a.created).getTime());
+      return merged.sort(
+        (a, b) => new Date(b.created ?? 0).getTime() - new Date(a.created ?? 0).getTime(),
+      );
     }
 
     // SDK pages have shape { entries: Transaction[], currentPage }; flatten the

--- a/src/redux/reducers/walletReducer.ts
+++ b/src/redux/reducers/walletReducer.ts
@@ -67,17 +67,17 @@ export interface CoinActivity {
   trxIndex: number;
   engineTrxId?: string;
   iconType: string;
-  textKey: string;
-  created: string;
-  expires: string;
-  icon: string;
-  value: string;
-  details: string | null;
-  memo: string;
-  cancelable: boolean;
-  recurrence: string;
-  executions: string;
-  repeatable: boolean;
+  textKey?: string;
+  created?: string;
+  expires?: string;
+  icon?: string;
+  value?: string;
+  details?: string | null;
+  memo?: string;
+  cancelable?: boolean;
+  recurrence?: string;
+  executions?: string;
+  repeatable?: boolean;
   sender?: string;
   receiver?: string;
 }

--- a/src/screens/assetDetails/screen/assetDetailsScreen.tsx
+++ b/src/screens/assetDetails/screen/assetDetailsScreen.tsx
@@ -202,7 +202,9 @@ const AssetDetailsScreen = ({ navigation, route }: AssetDetailsScreenProps) => {
         ...navigateParams,
         referredUsername:
           baseActivity.receiver !== username ? baseActivity.receiver : baseActivity.sender,
-        initialAmount: `${Math.abs(parseAsset((baseActivity.value ?? '').trim()).amount)}`,
+        initialAmount: baseActivity.value
+          ? `${Math.abs(parseAsset(baseActivity.value.trim()).amount)}`
+          : '0',
         initialMemo: baseActivity.memo,
       };
     }

--- a/src/screens/assetDetails/screen/assetDetailsScreen.tsx
+++ b/src/screens/assetDetails/screen/assetDetailsScreen.tsx
@@ -202,7 +202,7 @@ const AssetDetailsScreen = ({ navigation, route }: AssetDetailsScreenProps) => {
         ...navigateParams,
         referredUsername:
           baseActivity.receiver !== username ? baseActivity.receiver : baseActivity.sender,
-        initialAmount: `${Math.abs(parseAsset(baseActivity.value.trim()).amount)}`,
+        initialAmount: `${Math.abs(parseAsset((baseActivity.value ?? '').trim()).amount)}`,
         initialMemo: baseActivity.memo,
       };
     }

--- a/src/utils/I18nUtils.ts
+++ b/src/utils/I18nUtils.ts
@@ -4,7 +4,7 @@ import rtlDetect from 'rtl-detect';
 
 export const isRTL = () => I18nManager.isRTL;
 
-export const languageRestart = (prevLang, lang, intl) => {
+export const languageRestart = (prevLang: string, lang: string, intl: any) => {
   if (prevLang != lang) {
     // if selected lang is RTL, switch the layout
     if (rtlDetect.isRtlLang(lang)) {

--- a/src/utils/b64.ts
+++ b/src/utils/b64.ts
@@ -7,7 +7,7 @@ const b64uLookup = {
   '.': '=',
 };
 
-export const b64uEnc = (str) =>
+export const b64uEnc = (str: string) =>
   Buffer.from(str)
     .toString('base64')
-    .replace(/(\+|\/|=)/g, (m) => b64uLookup[m]);
+    .replace(/(\+|\/|=)/g, (m) => b64uLookup[m as keyof typeof b64uLookup]);

--- a/src/utils/conversions.ts
+++ b/src/utils/conversions.ts
@@ -1,16 +1,22 @@
-export const vestsToHp = (vests, hivePerMVests) => {
+export const vestsToHp = (
+  vests: string | number | null | undefined,
+  hivePerMVests: number | null | undefined,
+) => {
   if (!vests || !hivePerMVests) {
     return 0;
   }
 
-  return (parseFloat(vests) / 1e6) * hivePerMVests;
+  return (parseFloat(String(vests)) / 1e6) * hivePerMVests;
 };
 
-export const hpToVests = (hp, hivePerMVests) => {
+export const hpToVests = (
+  hp: string | number | null | undefined,
+  hivePerMVests: number | null | undefined,
+) => {
   if (!hp || !hivePerMVests) {
     return 0;
   }
-  return (parseFloat(hp) * 1e6) / hivePerMVests;
+  return (parseFloat(String(hp)) * 1e6) / hivePerMVests;
 };
 
 export const vestsToRshares = (vests: number, votingPower: number, weight: number) => {

--- a/src/utils/deepLinkParser.test.ts
+++ b/src/utils/deepLinkParser.test.ts
@@ -10,6 +10,12 @@ jest.mock('@ecency/sdk', () => ({
 }));
 
 describe('deepLinkParser', () => {
+  // Non-null variant for tests that assert on the parsed route.
+  const parse = async (url: string) => {
+    const parsed = await deepLinkParser(url);
+    expect(parsed).toBeDefined();
+    return parsed!;
+  };
   it('returns undefined for null/empty url', async () => {
     expect(await deepLinkParser(null)).toBeUndefined();
     expect(await deepLinkParser('')).toBeUndefined();
@@ -21,14 +27,14 @@ describe('deepLinkParser', () => {
 
   describe('post URLs', () => {
     it('parses author/permlink post url', async () => {
-      const result = await deepLinkParser('https://ecency.com/hive/@alice/my-first-post');
+      const result = await parse('https://ecency.com/hive/@alice/my-first-post');
       expect(result.name).toBe(ROUTES.SCREENS.POST);
       expect(result.params).toEqual({ author: 'alice', permlink: 'my-first-post' });
       expect(result.key).toBe('alice/my-first-post');
     });
 
     it('parses ecency:// deep link for posts', async () => {
-      const result = await deepLinkParser('ecency://@alice/my-post');
+      const result = await parse('ecency://@alice/my-post');
       expect(result.name).toBe(ROUTES.SCREENS.POST);
       expect(result.params.author).toBe('alice');
       expect(result.params.permlink).toBe('my-post');
@@ -37,33 +43,33 @@ describe('deepLinkParser', () => {
 
   describe('waves URLs', () => {
     it('routes waves permalink (no @author) to post screen', async () => {
-      const result = await deepLinkParser('https://ecency.com/waves/jza/wave-202677t12348900z');
+      const result = await parse('https://ecency.com/waves/jza/wave-202677t12348900z');
       expect(result.name).toBe(ROUTES.SCREENS.POST);
       expect(result.params).toEqual({ author: 'jza', permlink: 'wave-202677t12348900z' });
       expect(result.key).toBe('jza/wave-202677t12348900z');
     });
 
     it('routes waves permalink with @author to post screen', async () => {
-      const result = await deepLinkParser('https://ecency.com/waves/@jza/wave-202677t12348900z');
+      const result = await parse('https://ecency.com/waves/@jza/wave-202677t12348900z');
       expect(result.name).toBe(ROUTES.SCREENS.POST);
       expect(result.params).toEqual({ author: 'jza', permlink: 'wave-202677t12348900z' });
     });
 
     it('parses ecency:// deep link for waves', async () => {
-      const result = await deepLinkParser('ecency://waves/jza/wave-202677t12348900z');
+      const result = await parse('ecency://waves/jza/wave-202677t12348900z');
       expect(result.name).toBe(ROUTES.SCREENS.POST);
       expect(result.params.author).toBe('jza');
       expect(result.params.permlink).toBe('wave-202677t12348900z');
     });
 
     it('routes bare waves url to waves tab', async () => {
-      const result = await deepLinkParser('https://ecency.com/waves');
+      const result = await parse('https://ecency.com/waves');
       expect(result.name).toBe(ROUTES.TABBAR.WAVES);
       expect(result.key).toBe('waves');
     });
 
     it('routes waves permalink named like a profile filter to post screen', async () => {
-      const result = await deepLinkParser('https://ecency.com/waves/alice/wallet');
+      const result = await parse('https://ecency.com/waves/alice/wallet');
       expect(result.name).toBe(ROUTES.SCREENS.POST);
       expect(result.params).toEqual({ author: 'alice', permlink: 'wallet' });
     });
@@ -71,75 +77,75 @@ describe('deepLinkParser', () => {
 
   describe('profile URLs', () => {
     it('routes to profile when author only (no permlink)', async () => {
-      const result = await deepLinkParser('https://ecency.com/@alice');
+      const result = await parse('https://ecency.com/@alice');
       expect(result.name).toBe(ROUTES.SCREENS.PROFILE);
       expect(result.params.username).toBe('mockuser');
     });
 
     it('routes to profile with wallet filter', async () => {
-      const result = await deepLinkParser('https://ecency.com/hive/@alice/wallet');
+      const result = await parse('https://ecency.com/hive/@alice/wallet');
       expect(result.name).toBe(ROUTES.SCREENS.PROFILE);
       expect(result.params.deepLinkFilter).toBe('wallet');
     });
 
     it('maps points filter to wallet', async () => {
-      const result = await deepLinkParser('https://ecency.com/hive/@alice/points');
+      const result = await parse('https://ecency.com/hive/@alice/points');
       expect(result.name).toBe(ROUTES.SCREENS.PROFILE);
       expect(result.params.deepLinkFilter).toBe('wallet');
     });
 
     it('routes to profile with comments filter', async () => {
-      const result = await deepLinkParser('https://ecency.com/hive/@alice/comments');
+      const result = await parse('https://ecency.com/hive/@alice/comments');
       expect(result.name).toBe(ROUTES.SCREENS.PROFILE);
       expect(result.params.deepLinkFilter).toBe('comments');
     });
 
     it('routes to profile with replies filter', async () => {
-      const result = await deepLinkParser('https://ecency.com/hive/@alice/replies');
+      const result = await parse('https://ecency.com/hive/@alice/replies');
       expect(result.name).toBe(ROUTES.SCREENS.PROFILE);
       expect(result.params.deepLinkFilter).toBe('replies');
     });
 
     it('routes to profile with posts filter', async () => {
-      const result = await deepLinkParser('https://ecency.com/hive/@alice/posts');
+      const result = await parse('https://ecency.com/hive/@alice/posts');
       expect(result.name).toBe(ROUTES.SCREENS.PROFILE);
       expect(result.params.deepLinkFilter).toBe('posts');
     });
 
     it('routes communities permlink to web browser', async () => {
-      const result = await deepLinkParser('https://ecency.com/hive/@alice/communities');
+      const result = await parse('https://ecency.com/hive/@alice/communities');
       expect(result.name).toBe(ROUTES.SCREENS.WEB_BROWSER);
     });
   });
 
   describe('feed URLs', () => {
     it('routes trending feed', async () => {
-      const result = await deepLinkParser('https://ecency.com/trending/hive');
+      const result = await parse('https://ecency.com/trending/hive');
       expect(result.name).toBe(ROUTES.SCREENS.TAG_RESULT);
       expect(result.params.filter).toBe('trending');
       expect(result.params.tag).toBe('hive');
     });
 
     it('routes hot feed', async () => {
-      const result = await deepLinkParser('https://ecency.com/hot/photography');
+      const result = await parse('https://ecency.com/hot/photography');
       expect(result.name).toBe(ROUTES.SCREENS.TAG_RESULT);
       expect(result.params.filter).toBe('hot');
     });
 
     it('routes created feed', async () => {
-      const result = await deepLinkParser('https://ecency.com/created/art');
+      const result = await parse('https://ecency.com/created/art');
       expect(result.name).toBe(ROUTES.SCREENS.TAG_RESULT);
       expect(result.params.filter).toBe('created');
     });
 
     it('routes community tag to COMMUNITY screen', async () => {
-      const result = await deepLinkParser('https://ecency.com/trending/hive-174301');
+      const result = await parse('https://ecency.com/trending/hive-174301');
       expect(result.name).toBe(ROUTES.SCREENS.COMMUNITY);
       expect(result.params.tag).toBe('hive-174301');
     });
 
     it('routes feed without tag', async () => {
-      const result = await deepLinkParser('https://ecency.com/trending');
+      const result = await parse('https://ecency.com/trending');
       expect(result.name).toBe(ROUTES.SCREENS.TAG_RESULT);
       expect(result.params.filter).toBe('trending');
     });
@@ -147,54 +153,54 @@ describe('deepLinkParser', () => {
 
   describe('native web-standard routes', () => {
     it('routes /communities to the communities directory', async () => {
-      const result = await deepLinkParser('https://ecency.com/communities');
+      const result = await parse('https://ecency.com/communities');
       expect(result.name).toBe(ROUTES.SCREENS.COMMUNITIES);
     });
 
     it('routes /search to the search screen', async () => {
-      const result = await deepLinkParser('https://ecency.com/search');
+      const result = await parse('https://ecency.com/search');
       expect(result.name).toBe(ROUTES.SCREENS.SEARCH_RESULT);
     });
 
     it('routes /bookmarks to the bookmarks screen', async () => {
-      const result = await deepLinkParser('https://ecency.com/bookmarks');
+      const result = await parse('https://ecency.com/bookmarks');
       expect(result.name).toBe(ROUTES.SCREENS.BOOKMARKS);
     });
 
     it('routes /wallet to the wallet tab', async () => {
-      const result = await deepLinkParser('https://ecency.com/wallet');
+      const result = await parse('https://ecency.com/wallet');
       expect(result.name).toBe(ROUTES.TABBAR.WALLET);
     });
 
     it('routes /@user/followers to the follows screen (followers)', async () => {
-      const result = await deepLinkParser('https://ecency.com/@alice/followers');
+      const result = await parse('https://ecency.com/@alice/followers');
       expect(result.name).toBe(ROUTES.SCREENS.FOLLOWS);
       expect(result.params.username).toBe('alice');
       expect(result.params.isFollowingPress).toBe(false);
     });
 
     it('routes /@user/following to the follows screen (following)', async () => {
-      const result = await deepLinkParser('https://ecency.com/@alice/following');
+      const result = await parse('https://ecency.com/@alice/following');
       expect(result.name).toBe(ROUTES.SCREENS.FOLLOWS);
       expect(result.params.username).toBe('alice');
       expect(result.params.isFollowingPress).toBe(true);
     });
 
     it('does not native-route web paths on non-Ecency hosts', async () => {
-      const result = await deepLinkParser('https://example.com/wallet');
+      const result = await parse('https://example.com/wallet');
       expect(result.name).toBeUndefined();
     });
   });
 
   describe('auth URLs', () => {
     it('parses signup URL', async () => {
-      const result = await deepLinkParser('https://ecency.com/signup?referral=alice');
+      const result = await parse('https://ecency.com/signup?referral=alice');
       expect(result.name).toBe(ROUTES.SCREENS.REGISTER);
       expect(result.params.referredUser).toBe('alice');
     });
 
     it('parses auth URL', async () => {
-      const result = await deepLinkParser('https://ecency.com/auth?username=alice&code=abc123');
+      const result = await parse('https://ecency.com/auth?username=alice&code=abc123');
       expect(result.name).toBe(ROUTES.SCREENS.LOGIN);
       expect(result.params.username).toBe('alice');
       expect(result.params.code).toBe('abc123');
@@ -203,13 +209,13 @@ describe('deepLinkParser', () => {
 
   describe('purchase URLs', () => {
     it('parses boost purchase', async () => {
-      const result = await deepLinkParser('https://ecency.com/purchase?type=boost&username=alice');
+      const result = await parse('https://ecency.com/purchase?type=boost&username=alice');
       expect(result.name).toBe(ROUTES.SCREENS.ACCOUNT_BOOST);
       expect(result.params.username).toBe('alice');
     });
 
     it('parses points purchase', async () => {
-      const result = await deepLinkParser(
+      const result = await parse(
         'https://ecency.com/purchase?type=points&username=alice&product_id=999points',
       );
       expect(result.name).toBe(ROUTES.SCREENS.BOOST);
@@ -218,7 +224,7 @@ describe('deepLinkParser', () => {
     });
 
     it('parses account purchase', async () => {
-      const result = await deepLinkParser(
+      const result = await parse(
         'https://ecency.com/purchase?type=account&username=newuser&email=a@b.com&referral=alice',
       );
       expect(result.name).toBe(ROUTES.SCREENS.REGISTER);

--- a/src/utils/deepLinkParser.ts
+++ b/src/utils/deepLinkParser.ts
@@ -5,13 +5,23 @@ import parseAuthUrl, { AUTH_MODES } from './parseAuthUrl';
 import ROUTES from '../constants/routeNames';
 import parsePurchaseUrl from './parsePurchaseUrl';
 
-export const deepLinkParser = async (url) => {
+// name can be undefined on fall-through: useLinkProcessor only navigates
+// natively when name, params and key are all set.
+export interface DeepLinkRoute {
+  name?: string;
+  params?: any;
+  key?: string;
+}
+
+export const deepLinkParser = async (
+  url: string | null | undefined,
+): Promise<DeepLinkRoute | undefined> => {
   if (!url || url.indexOf('ShareMedia://') >= 0) return;
 
-  let routeName;
-  let params;
+  let routeName: string | undefined;
+  let params: any;
   let profile;
-  let keey;
+  let keey: string | undefined;
 
   // waves permalinks always open the thread view; route them before the
   // generic author/permlink flow so reserved permlink names like 'wallet'

--- a/src/utils/editor.ts
+++ b/src/utils/editor.ts
@@ -16,12 +16,12 @@ import { PollDraft } from '../providers/ecency/ecency.types';
 import { ContentType, PollMetadata, PostMetadata } from '../providers/hive/hive.types';
 import postUrlParser from './postUrlParser';
 
-export const getWordsCount = (text) =>
+export const getWordsCount = (text: any) =>
   text && typeof text === 'string' ? text.replace(/^\s+|\s+$/g, '').split(/\s+/).length : 0;
 
 export const generateRndStr = () => (Math.random() + 1).toString(16).substring(2);
 
-export const generatePermlink = (title, random = false) => {
+export const generatePermlink = (title: string, random = false) => {
   if (!title) {
     return '';
   }
@@ -92,7 +92,7 @@ export const extractWordAtIndex = (text: string, index: number) => {
   return word;
 };
 
-export const generateUniquePermlink = (prefix) => {
+export const generateUniquePermlink = (prefix: string) => {
   if (!prefix) {
     return '';
   }
@@ -131,7 +131,7 @@ export const generateContentBasedPermlink = (prefix: string, contentKey: string)
   return `${prefix}-${hash}`;
 };
 
-export const makeOptions = (postObj) => {
+export const makeOptions = (postObj: any) => {
   if (!postObj.author || !postObj.permlink) {
     return {};
   }
@@ -164,20 +164,20 @@ export const makeOptions = (postObj) => {
   }
 
   if (postObj.beneficiaries && postObj.beneficiaries.length > 0) {
-    postObj.beneficiaries.sort((a, b) => a.account.localeCompare(b.account));
+    postObj.beneficiaries.sort((a: any, b: any) => a.account.localeCompare(b.account));
     a.extensions = [[0, { beneficiaries: unionBy(postObj.beneficiaries, 'account') }]];
   }
 
   return a;
 };
 
-export const makeJsonMetadataReply = (tags) => ({
+export const makeJsonMetadataReply = (tags: string[]) => ({
   tags,
   app: `ecency/${VersionNumber.appVersion}-mobile`,
   format: 'markdown+html',
 });
 
-export const makeJsonMetadata = (meta, tags) =>
+export const makeJsonMetadata = (meta: any, tags: string[]) =>
   Object.assign({}, meta, {
     tags,
     app: `ecency/${VersionNumber.appVersion}-mobile`,
@@ -187,7 +187,7 @@ export const makeJsonMetadata = (meta, tags) =>
 // Optional AI-usage disclosure (`ai_tools`, interoperable with other Hive frontends). Keeps
 // only the truthy flags and returns undefined when nothing is disclosed, so a normal post's
 // metadata is untouched.
-export const cleanAiTools = (aiTools) => {
+export const cleanAiTools = (aiTools: any) => {
   if (!aiTools) {
     return undefined;
   }
@@ -201,7 +201,7 @@ export const cleanAiTools = (aiTools) => {
   return Object.keys(out).length > 0 ? out : undefined;
 };
 
-export const makeJsonMetadataForUpdate = (oldJson, meta, tags) => {
+export const makeJsonMetadataForUpdate = (oldJson: any, meta: any, tags: string[]) => {
   const { meta: oldMeta } = oldJson;
   const mergedMeta = Object.assign({}, oldMeta, meta);
 
@@ -217,8 +217,8 @@ export const extractUrls = (body: string) => {
 export const extractImageUrls = ({ body, urls }: { body?: string; urls?: string[] }) => {
   const imgReg = /(https?:\/\/.*\.(?:png|jpg|jpeg|gif|heic|webp))/gim;
 
-  const imgUrls = [];
-  const mUrls = urls || extractUrls(body);
+  const imgUrls: string[] = [];
+  const mUrls = urls || extractUrls(body || '');
 
   mUrls.forEach((url) => {
     const isImage = url.match(imgReg);
@@ -230,7 +230,7 @@ export const extractImageUrls = ({ body, urls }: { body?: string; urls?: string[
   return imgUrls;
 };
 
-export const extract3SpeakIds = ({ body }) => {
+export const extract3SpeakIds = ({ body }: { body?: string }) => {
   if (!body) {
     return [];
   }
@@ -264,7 +264,7 @@ export const extractFilenameFromPath = ({
   } catch (err) {
     let _ext = 'jpg';
     if (mimeType) {
-      _ext = MimeTypes.extension(mimeType);
+      _ext = MimeTypes.extension(mimeType) || 'jpg';
     }
     return `${generateRndStr()}.${_ext}`;
   }
@@ -378,7 +378,7 @@ export const extractMetadata = async ({
   filteredUrls.forEach((url) => {
     try {
       // Check if url is a post url
-      const { author, permlink } = postUrlParser(url);
+      const { author, permlink } = postUrlParser(url) || ({} as any);
 
       if (author && permlink) {
         // Store URL info alongside the promise
@@ -431,7 +431,7 @@ export const extractMetadata = async ({
       out.image
         .slice(0, 5)
         .map((url) => {
-          return new Promise((resolve) => {
+          return new Promise<number>((resolve) => {
             Image.getSize(
               url,
               (width, height) => {
@@ -468,7 +468,7 @@ export const extractMetadata = async ({
   return out;
 };
 
-export const createPatch = (text1, text2) => {
+export const createPatch = (text1: any, text2: any) => {
   if (!text1 && text1 === '') {
     return undefined;
   }
@@ -480,7 +480,7 @@ export const createPatch = (text1, text2) => {
   return patch;
 };
 
-export const delay = (ms) => new Promise((res) => setTimeout(res, ms));
+export const delay = (ms: number) => new Promise((res) => setTimeout(res, ms));
 
 export const convertToPollMeta = (pollDraft: PollDraft) => {
   if (!pollDraft) {

--- a/src/utils/getCurrentHpApr.ts
+++ b/src/utils/getCurrentHpApr.ts
@@ -1,4 +1,4 @@
-export const getCurrentHpApr = (gprops) => {
+export const getCurrentHpApr = (gprops: any) => {
   // The inflation was set to 9.5% at block 7m
   const initialInflationRate = 9.5;
   const initialBlock = 7000000;

--- a/src/utils/getLocale.ts
+++ b/src/utils/getLocale.ts
@@ -8,7 +8,7 @@ const getLocale = (): string => {
       NativeModules.SettingsManager.getConstants().settings.AppleLocale ||
       NativeModules.SettingsManager.getConstants().settings.AppleLanguages[0];
   } else {
-    locale = I18nManager.localeIdentifier;
+    locale = (I18nManager as any).localeIdentifier;
   }
 
   return locale;

--- a/src/utils/hive-uri.ts
+++ b/src/utils/hive-uri.ts
@@ -34,7 +34,7 @@ const _checkOpsArray = (ops: any) => {
   return ops && isArray(ops) && ops.length === 1 && isArray(ops[0]) && ops[0].length === 2;
 };
 
-const findParentKey = (obj, value, parentKey = null) => {
+const findParentKey = (obj: any, value: any, parentKey: string | null = null): string | null => {
   // eslint-disable-next-line no-restricted-syntax
   for (const key in obj) {
     if (obj[key] === value) {
@@ -51,7 +51,7 @@ const findParentKey = (obj, value, parentKey = null) => {
 
 // get operation name and signer field from operation object
 const getOperationProps = (opName: string) => {
-  const op = get(operationsData, opName, null);
+  const op: any = get(operationsData, opName, null);
   if (op) {
     const signerField = findParentKey(op, '__signer');
     return {
@@ -130,10 +130,10 @@ export const getFormattedTx = (tx: any, authoritiesMap: Map<string, boolean>) =>
       return Promise.reject(errorObj);
     }
   }
-  const opSignerValue = get(op[1], opProps.signerField, '');
+  const opSignerValue = get(op[1], opProps.signerField as string, '');
   // if signer field contains empty value, fill it with __signer
   if (!opSignerValue) {
-    operationObj[opProps.signerField] = '__signer';
+    operationObj[opProps.signerField as string] = '__signer';
   }
 
   const { opName } = opProps;

--- a/src/utils/image.ts
+++ b/src/utils/image.ts
@@ -26,7 +26,7 @@ export const shouldPrefetchImages = () => {
   }
 };
 
-export const generateSignature = (media, privateKey) => {
+export const generateSignature = (media: any, privateKey: string) => {
   const STRING = 'ImageSigningChallenge';
   const prefix = Buffer.from(STRING);
 
@@ -34,7 +34,8 @@ export const generateSignature = (media, privateKey) => {
   const dataBs64 = media.data.substring(commaIdx + 1);
   const data = Buffer.from(dataBs64, 'base64');
 
-  const hash = CryptoJS.SHA256(prefix, data);
+  // CryptoJS coerces the Buffers; the produced signature is what imagehoster accepts
+  const hash = CryptoJS.SHA256(prefix as any, data as any);
   const buffer = Buffer.from(hash.toString(CryptoJS.enc.Hex), 'hex');
   const array = new Uint8Array(buffer);
   const key = PrivateKey.fromString(privateKey);
@@ -42,7 +43,7 @@ export const generateSignature = (media, privateKey) => {
   return key.sign(Buffer.from(array)).toString();
 };
 
-export const catchEntryImage = (entry, width = 0, height = 0, format = 'match') => {
+export const catchEntryImage = (entry: any, width = 0, height = 0, format = 'match') => {
   // return from json metadata if exists
   let meta;
 
@@ -82,7 +83,7 @@ export const catchEntryImage = (entry, width = 0, height = 0, format = 'match') 
   return null;
 };
 
-export const catchDraftImage = (body, format = 'match', thumbnail = false) => {
+export const catchDraftImage = (body: any, format = 'match', thumbnail = false) => {
   const imgRegex = /(https?:\/\/.*\.(?:png|jpg|jpeg|gif|heic|webp))/gim;
 
   if (body && imgRegex.test(body)) {
@@ -96,7 +97,7 @@ export const catchDraftImage = (body, format = 'match', thumbnail = false) => {
 };
 
 // get the image from meta data
-export const catchImageFromMetadata = (meta, format = 'match', thumbnail = false) => {
+export const catchImageFromMetadata = (meta: any, format = 'match', thumbnail = false) => {
   if (meta && meta.image) {
     const images = meta.image;
     // console.log('images : ',images);
@@ -109,7 +110,7 @@ export const catchImageFromMetadata = (meta, format = 'match', thumbnail = false
   return null;
 };
 
-export const getResizedImage = (url, size = 600, format = 'match') => {
+export const getResizedImage = (url: any, size = 600, format = 'match') => {
   // TODO: implement fallback onError, for imagehoster is down case
   if (!url) {
     return '';
@@ -117,7 +118,7 @@ export const getResizedImage = (url, size = 600, format = 'match') => {
   return proxifyImageSrc(url, size, 0, format);
 };
 
-export const getResizedAvatar = (author, sizeString = 'small') => {
+export const getResizedAvatar = (author: any, sizeString = 'small') => {
   if (!author) {
     return '';
   }

--- a/src/utils/migrationHelpers.test.ts
+++ b/src/utils/migrationHelpers.test.ts
@@ -92,8 +92,8 @@ describe('migrateSelectedTokens', () => {
       ];
       const result = migrateSelectedTokens(tokens);
       expect(result).toHaveLength(2);
-      expect(result[0].meta).toEqual({ show: true });
-      expect(result[1].meta).toEqual({ show: true });
+      expect(result![0].meta).toEqual({ show: true });
+      expect(result![1].meta).toEqual({ show: true });
     });
 
     it('deduplicates by symbol+type, preferring entry with meta', () => {
@@ -103,7 +103,7 @@ describe('migrateSelectedTokens', () => {
       ];
       const result = migrateSelectedTokens(tokens);
       expect(result).toHaveLength(1);
-      expect(result[0].meta).toEqual({ show: true });
+      expect(result![0].meta).toEqual({ show: true });
     });
   });
 
@@ -342,7 +342,7 @@ describe('reduxMigrations', () => {
     it('no-ops when the application slice is absent', () => {
       const state = { account: { keep: 'me' } } as any;
       const result = reduxMigrations[17](state);
-      expect(result.account.keep).toBe('me');
+      expect(result!.account.keep).toBe('me');
       expect(result.application).toBeUndefined();
     });
   });
@@ -392,7 +392,7 @@ describe('reduxMigrations', () => {
     it('is a no-op when the wallet slice is absent', () => {
       const state = { account: { keep: 'me' } } as any;
       const result = reduxMigrations[19](state);
-      expect(result.account.keep).toBe('me');
+      expect(result!.account.keep).toBe('me');
       expect(result.wallet).toBeUndefined();
     });
   });
@@ -419,8 +419,8 @@ describe('reduxMigrations', () => {
     it('is a no-op when notificationDetails is absent', () => {
       const state = { application: {}, account: { keep: 'me' } } as any;
       const result = reduxMigrations[20](state);
-      expect(result.application.notificationDetails).toBeUndefined();
-      expect(result.account.keep).toBe('me');
+      expect(result!.application.notificationDetails).toBeUndefined();
+      expect(result!.account.keep).toBe('me');
     });
   });
 
@@ -449,8 +449,8 @@ describe('reduxMigrations', () => {
     it('is a no-op when notificationDetails is absent', () => {
       const state = { application: {}, account: { keep: 'me' } } as any;
       const result = reduxMigrations[21](state);
-      expect(result.application.notificationDetails).toBeUndefined();
-      expect(result.account.keep).toBe('me');
+      expect(result!.application.notificationDetails).toBeUndefined();
+      expect(result!.account.keep).toBe('me');
     });
   });
 
@@ -465,9 +465,9 @@ describe('reduxMigrations', () => {
         result = reduxMigrations[1](state);
       }).not.toThrow();
       // unrelated persisted state survives
-      expect(result.account.keep).toBe('me');
+      expect(result!.account.keep).toBe('me');
       // the failed migration's partial change is not applied
-      expect(result.application.notificationDetails).toBeUndefined();
+      expect(result!.application.notificationDetails).toBeUndefined();
     });
 
     it('returns a clean snapshot (not a partially-mutated object) on a mid-migration throw', () => {
@@ -479,7 +479,7 @@ describe('reduxMigrations', () => {
         account: { keep: 'me' },
       } as any;
       const result = reduxMigrations[13](state);
-      expect(result.account.keep).toBe('me');
+      expect(result!.account.keep).toBe('me');
       // selectedCoins was NOT deleted (rolled back), selectedAssets was NOT added
       expect(result.wallet.selectedCoins).toBeDefined();
       expect(result.wallet.selectedAssets).toBeUndefined();

--- a/src/utils/migrationHelpers.ts
+++ b/src/utils/migrationHelpers.ts
@@ -100,14 +100,19 @@ export const migrateSettings = async (dispatch: any, settingsMigratedV2: boolean
 };
 
 // migrates local user data to use default pin encruption instead of user pin encryption
-export const migrateUserEncryption = async (dispatch, currentAccount, encUserPin, onFailure) => {
-  const oldPinCode = decryptKey(encUserPin, Config.PIN_KEY);
+export const migrateUserEncryption = async (
+  dispatch: any,
+  currentAccount: any,
+  encUserPin: string,
+  onFailure: (error: unknown) => void,
+) => {
+  const oldPinCode = decryptKey(encUserPin, Config.PIN_KEY!);
 
   if (oldPinCode === undefined || oldPinCode === Config.DEFAULT_PIN) {
     return true;
   }
 
-  let migratedLocal;
+  let migratedLocal: any;
   try {
     const pinData = {
       pinCode: Config.DEFAULT_PIN,
@@ -135,7 +140,7 @@ export const migrateUserEncryption = async (dispatch, currentAccount, encUserPin
       }),
     );
 
-    const encryptedPin = encryptKey(Config.DEFAULT_PIN, Config.PIN_KEY);
+    const encryptedPin = encryptKey(Config.DEFAULT_PIN!, Config.PIN_KEY!);
     dispatch(setPinCode(encryptedPin));
   } catch (err) {
     // Re-encryption to DEFAULT_PIN failed. Do NOT mark the migration complete
@@ -158,7 +163,7 @@ export const migrateUserEncryption = async (dispatch, currentAccount, encUserPin
   _currentAccount.local = migratedLocal;
 
   try {
-    const pinHash = encryptKey(Config.DEFAULT_PIN, Config.PIN_KEY);
+    const pinHash = encryptKey(Config.DEFAULT_PIN!, Config.PIN_KEY!);
     // migration script for previously mast key based logged in user not having access token
     if (migratedLocal.authType !== AUTH_TYPE.STEEM_CONNECT && migratedLocal.accessToken === '') {
       _currentAccount = await migrateToMasterKeyWithAccessToken(
@@ -180,7 +185,7 @@ export const migrateUserEncryption = async (dispatch, currentAccount, encUserPin
     const queryClient = getQueryClient();
     const accessToken =
       (_currentAccount?.local?.accessToken
-        ? decryptKey(_currentAccount.local.accessToken, Config.DEFAULT_PIN)
+        ? decryptKey(_currentAccount.local.accessToken, Config.DEFAULT_PIN!)
         : '') ?? '';
     _currentAccount.unread_activity_count = await queryClient.fetchQuery(
       getNotificationsUnreadCountQueryOptions(_currentAccount.name, accessToken),
@@ -200,7 +205,13 @@ export const migrateUserEncryption = async (dispatch, currentAccount, encUserPin
   return true;
 };
 
-export const repairUserAccountData = async (username, dispatch, intl, accounts, pinHash) => {
+export const repairUserAccountData = async (
+  username: string,
+  dispatch: any,
+  intl: any,
+  accounts: any[],
+  pinHash: string,
+) => {
   let authData: any[] = [];
   try {
     // clean realm data just in case, to avoid already logged error
@@ -231,7 +242,7 @@ export const repairUserAccountData = async (username, dispatch, intl, accounts, 
       // if already expired, prompt for relogin
     } else {
       const _encryptedKey = _userAccount.local[_authType];
-      const _key = decryptKey(_encryptedKey, getDigitPinCode(pinHash));
+      const _key = decryptKey(_encryptedKey, getDigitPinCode(pinHash)!);
       if (!_key) {
         throw new Error('Pin decryption failed');
       }
@@ -276,12 +287,12 @@ export const repairUserAccountData = async (username, dispatch, intl, accounts, 
   return authData;
 };
 
-export const repairOtherAccountsData = (accounts, realmAuthData, dispatch) => {
+export const repairOtherAccountsData = (accounts: any[], realmAuthData: any, dispatch: any) => {
   accounts.forEach((account) => {
     // otherAccounts entries are keyed by username; account.name can be undefined on some
     // (e.g. HiveSigner) entries, so match realm data on either field.
     const accRealmData = realmAuthData.find(
-      (data) => data.username === (account.username || account.name),
+      (data: any) => data.username === (account.username || account.name),
     );
     if (!account.local?.accessToken && accRealmData) {
       account.local = accRealmData;
@@ -340,24 +351,24 @@ export const migrateSelectedTokens = (tokens: any) => {
 };
 
 const reduxMigrations = {
-  0: (state) => {
+  0: (state: any) => {
     const { upvotePercent } = state.application;
     state.application.postUpvotePercent = upvotePercent;
     state.application.commentUpvotePercent = upvotePercent;
     state.application.upvotePercent = undefined;
     return state;
   },
-  1: (state) => {
+  1: (state: any) => {
     state.application.notificationDetails.favoriteNotification = true;
     return state;
   },
-  2: (state) => {
+  2: (state: any) => {
     state.application.notificationDetails.bookmarkNotification = true;
     return state;
   },
-  3: (state) => {
+  3: (state: any) => {
     const { drafts } = state.cache;
-    const _draftsCollection = {};
+    const _draftsCollection: Record<string, any> = {};
     if (drafts instanceof Array) {
       drafts.forEach(([key, data]) => {
         if (key && data.body && data.author && data.updated) {
@@ -369,9 +380,9 @@ const reduxMigrations = {
     delete state.cache.drafts;
     return state;
   },
-  4: (state) => {
+  4: (state: any) => {
     const { comments } = state.cache;
-    const _collection = {};
+    const _collection: Record<string, any> = {};
     if (comments instanceof Array) {
       comments.forEach(([key, data]) => {
         if (key && data.body && data.parent_author && data.parent_permlink) {
@@ -383,39 +394,39 @@ const reduxMigrations = {
     delete state.cache.comments;
     return state;
   },
-  5: (state) => {
+  5: (state: any) => {
     state.cache.votesCollection = {};
     return state;
   },
-  6: (state) => {
+  6: (state: any) => {
     state.application.waveUpvotePercent = state.application.commentUpvotePercent;
     return state;
   },
-  7: (state) => {
+  7: (state: any) => {
     state.cache.announcementsMeta = {};
     return state;
   },
-  8: (state) => {
+  8: (state: any) => {
     state.cache.pollVotesCollection = {};
     return state;
   },
-  9: (state) => {
+  9: (state: any) => {
     state.editor.pollDraftsMap = {};
     return state;
   },
-  10: (state) => {
+  10: (state: any) => {
     state.customTabs.mainTabs = DEFAULT_FEED_FILTERS;
     return state;
   },
-  11: (state) => {
+  11: (state: any) => {
     state.cache.proposalsVoteMeta = {};
     return state;
   },
-  12: (state) => {
-    state.application.pin = encryptKey(Config.DEFAULT_PIN, Config.PIN_KEY);
+  12: (state: any) => {
+    state.application.pin = encryptKey(Config.DEFAULT_PIN!, Config.PIN_KEY!);
     return state;
   },
-  13: (state) => {
+  13: (state: any) => {
     state.wallet.selectedAssets = state.wallet.selectedCoins || DEFAULT_ASSETS;
     // Fix first asset symbol if it's not POINTS (migration from old data)
     if (state.wallet.selectedAssets[0] && state.wallet.selectedAssets[0].symbol !== 'POINTS') {
@@ -429,13 +440,13 @@ const reduxMigrations = {
 
     return state;
   },
-  14: (state) => {
+  14: (state: any) => {
     // Migrate reply and wave drafts from draftsCollection to replyCache
     state.cache.replyCache = {};
 
     if (state.cache.draftsCollection) {
-      const _replyCache = {};
-      const _draftsToKeep = {};
+      const _replyCache: Record<string, any> = {};
+      const _draftsToKeep: Record<string, any> = {};
 
       Object.keys(state.cache.draftsCollection).forEach((key) => {
         const draft = state.cache.draftsCollection[key];
@@ -461,9 +472,9 @@ const reduxMigrations = {
 
     return state;
   },
-  15: (state) => {
+  15: (state: any) => {
     // Add 'waves' tab to profile and own-profile custom tabs for existing users
-    const _insertWaves = (tabs, defaults) => {
+    const _insertWaves = (tabs: any, defaults: any) => {
       if (!tabs || tabs.indexOf('waves') !== -1) {
         return tabs;
       }
@@ -484,7 +495,7 @@ const reduxMigrations = {
     );
     return state;
   },
-  16: (state) => {
+  16: (state: any) => {
     // Backfill account.globalProps fields added later (votePowerReserveRate,
     // authorRewardCurve, contentConstant, currentHardforkVersion, lastHardfork).
     // Without these, vote estimation can throw on first launch after upgrade
@@ -502,7 +513,7 @@ const reduxMigrations = {
     }
     return state;
   },
-  17: (state) => {
+  17: (state: any) => {
     // Backfill appRating for users upgrading from a build before the in-app
     // review prompt. autoMergeLevel1 replaces the whole persisted `application`
     // slice on rehydration, so a missing appRating key is NOT defaulted from
@@ -518,7 +529,7 @@ const reduxMigrations = {
     }
     return state;
   },
-  18: (state) => {
+  18: (state: any) => {
     // Backfill editor.caretMap for users upgrading from a build before per-draft
     // caret persistence existed. autoMergeLevel1 keeps the persisted `editor`
     // slice as-is on rehydration, so the new key is not defaulted from
@@ -529,7 +540,7 @@ const reduxMigrations = {
     }
     return state;
   },
-  19: (state) => {
+  19: (state: any) => {
     // SPK Network support removed: purge persisted SPK/LARYNX/LP entries from
     // wallet.selectedAssets so stale selections don't linger in the wallet list.
     // The symbol check catches legacy entries persisted before the isSpk flag;
@@ -537,13 +548,13 @@ const reduxMigrations = {
     // symbols is never purged.
     if (state.wallet) {
       state.wallet.selectedAssets = (state.wallet.selectedAssets || []).filter(
-        (asset) =>
+        (asset: any) =>
           !asset?.isSpk && (asset?.isEngine || !['SPK', 'LARYNX', 'LP'].includes(asset?.symbol)),
       );
     }
     return state;
   },
-  20: (state) => {
+  20: (state: any) => {
     // Default the scheduled-post-published notification setting ON for existing
     // installs; autoMergeLevel1 keeps the persisted notificationDetails as-is on
     // rehydration, so the new key is never defaulted from initialState (see 17).
@@ -556,7 +567,7 @@ const reduxMigrations = {
     }
     return state;
   },
-  21: (state) => {
+  21: (state: any) => {
     // Default the notification types that previously had no push toggle ON for
     // existing installs, matching every other type (and 20 above): autoMergeLevel1
     // keeps persisted notificationDetails as-is, so a new key is never picked up

--- a/src/utils/points.ts
+++ b/src/utils/points.ts
@@ -166,7 +166,7 @@ export const PROMOTED_POST_STATUS_DISABLED = 3;
  */
 export const resolvePointType = (item: any) => {
   const type = item?.type;
-  const entry = POINTS[type] || POINTS.default;
+  const entry = (POINTS as any)[type] || POINTS.default;
   if (type === BURN_TYPE && parseFloat(String(item?.amount ?? 0)) > 0) {
     return BURN_REFUND;
   }

--- a/src/utils/postParser.tsx
+++ b/src/utils/postParser.tsx
@@ -24,7 +24,7 @@ const DOWNVOTED_MIN_VOTES = 3;
  * First matching reason wins, most authoritative first: an explicit moderator action
  * outranks the heuristics. Returns null when the content is not muted.
  */
-export const getMutedReason = (content): MutedReason | null => {
+export const getMutedReason = (content: any): MutedReason | null => {
   if (content?.stats?.gray || content?.stats?.hide) {
     return MutedReason.MODERATED;
   }
@@ -41,9 +41,9 @@ export const getMutedReason = (content): MutedReason | null => {
 };
 
 export const parsePost = (
-  post,
-  currentUserName,
-  isPromoted,
+  post: any,
+  currentUserName: string | null | undefined,
+  isPromoted: boolean,
   isList = false,
   discardBody = false,
   currentTime?: number, // Optional timestamp to avoid creating new Date for each post
@@ -123,7 +123,7 @@ export const parsePost = (
       [post.thumbRatio] = post.json_metadata.image_ratios;
     } else if (imgRatios.length && imgRatios[0]?.height && imgRatios[0]?.width) {
       // convert to image ratio if old meta data found
-      post.json_metadata.image_ratios = imgRatios.map((item) => {
+      post.json_metadata.image_ratios = imgRatios.map((item: any) => {
         const ratio = item.width / item.height;
         return item.width && item.height ? parseFloat(ratio.toFixed(4)) : item;
       });
@@ -138,7 +138,7 @@ export const parsePost = (
     post.body = renderPostBody({ ...post, last_update: post.updated }, true, false);
   }
   // Use description from json_metadata if available, otherwise generate summary from body
-  post.summary = post.json_metadata?.description || postBodySummary(post, 150, Platform.OS);
+  post.summary = post.json_metadata?.description || postBodySummary(post, 150, Platform.OS as any);
   post.max_payout = parseAsset(post.max_accepted_payout).amount || 0;
   post.is_declined_payout = !!post.max_accepted_payout && post.max_payout === 0;
 
@@ -169,7 +169,7 @@ export const parsePost = (
   post.isMuted = !!post.mutedReason;
 
   // determine vote status
-  const vote = (post.active_votes || []).find((element) => element.voter === currentUserName);
+  const vote = (post.active_votes || []).find((element: any) => element.voter === currentUserName);
   post.isUpVoted = !!vote && vote.rshares > 0;
   post.isDownVoted = !!vote && vote.rshares < 0;
 
@@ -219,7 +219,7 @@ export const parseCommentThreads = async (
   currentUsername?: string,
 ) => {
   const MAX_THREAD_LEVEL = 3;
-  const comments = [];
+  const comments: any[] = [];
 
   if (!commentsMap) {
     return null;
@@ -262,7 +262,7 @@ export const mapDiscussionToThreads = async (
   permlink: string,
   maxLevel = 3,
 ) => {
-  const comments = [];
+  const comments: any[] = [];
 
   if (!commentsMap) {
     return null;
@@ -358,7 +358,9 @@ export const parseComment = (comment: any, currentUsername?: string, currentTime
   comment.isMuted = !!comment.mutedReason;
 
   // set user vote status on comment
-  const vote = (comment.active_votes || []).find((element) => element.voter === currentUsername);
+  const vote = (comment.active_votes || []).find(
+    (element: any) => element.voter === currentUsername,
+  );
   comment.isUpVoted = !!vote && vote.rshares > 0;
   comment.isDownVoted = !!vote && vote.rshares < 0;
 
@@ -370,7 +372,7 @@ export const parseComment = (comment: any, currentUsername?: string, currentTime
   return comment;
 };
 
-export const isVoted = (activeVotes, currentUserName) => {
+export const isVoted = (activeVotes: any[], currentUserName: string | null | undefined) => {
   if (!currentUserName) {
     return false;
   }
@@ -383,7 +385,7 @@ export const isVoted = (activeVotes, currentUserName) => {
   return false;
 };
 
-export const isDownVoted = (activeVotes, currentUserName) => {
+export const isDownVoted = (activeVotes: any[], currentUserName: string | null | undefined) => {
   if (!currentUserName) {
     return false;
   }
@@ -396,7 +398,7 @@ export const isDownVoted = (activeVotes, currentUserName) => {
   return false;
 };
 
-export const parseActiveVotes = (post) => {
+export const parseActiveVotes = (post: any) => {
   const votes = Array.isArray(post.active_votes) ? post.active_votes : [];
   const _totalRShares = votes.reduce(
     (accumulator: number, item: any) => accumulator + parseFloat(item.rshares),
@@ -404,7 +406,7 @@ export const parseActiveVotes = (post) => {
   );
 
   if (votes.length) {
-    post.active_votes = votes.map((vote) => parseVote(vote, post, _totalRShares));
+    post.active_votes = votes.map((vote: any) => parseVote(vote, post, _totalRShares));
   } else {
     post.active_votes = votes;
   }
@@ -437,13 +439,13 @@ const parseTags = (post: any) => {
   return post;
 };
 
-const parseLinksMeta = (jsonMeta) => {
+const parseLinksMeta = (jsonMeta: any) => {
   // If jsonMeta is null, undefined, or doesn't have links_meta, return the original object
   if (!jsonMeta || !jsonMeta.links_meta) {
     return jsonMeta;
   }
 
-  const validatedLinksMeta = {};
+  const validatedLinksMeta: Record<string, any> = {};
   let hasValidLinks = false;
 
   // Iterate through each key in links_meta
@@ -452,9 +454,9 @@ const parseLinksMeta = (jsonMeta) => {
     if (
       linkData &&
       typeof linkData === 'object' &&
-      typeof linkData.title === 'string' &&
-      typeof linkData.summary === 'string' &&
-      typeof linkData.image === 'string'
+      typeof (linkData as any).title === 'string' &&
+      typeof (linkData as any).summary === 'string' &&
+      typeof (linkData as any).image === 'string'
     ) {
       // This link is well-formed, add it to validated links
       validatedLinksMeta[key] = linkData;

--- a/src/utils/transactionOpsBuilder.test.ts
+++ b/src/utils/transactionOpsBuilder.test.ts
@@ -23,7 +23,7 @@ describe('buildTransferOpsArray', () => {
   describe('decimal normalization', () => {
     it('pads amount to 3 decimal places when fewer', () => {
       const ops = buildTransferOpsArray(TransferTypes.TRANSFER, { ...baseData, amount: '10' });
-      expect(ops[0][1].amount).toBe('10.000 HIVE');
+      expect((ops[0][1] as any).amount).toBe('10.000 HIVE');
     });
 
     it('normalizes an over-precise amount down to the asset precision (3 dp for HIVE)', () => {
@@ -31,7 +31,7 @@ describe('buildTransferOpsArray', () => {
         ...baseData,
         amount: '10.12345',
       });
-      expect(ops[0][1].amount).toBe('10.123 HIVE');
+      expect((ops[0][1] as any).amount).toBe('10.123 HIVE');
     });
 
     it('uses 6 dp for VESTS amounts', () => {
@@ -40,7 +40,7 @@ describe('buildTransferOpsArray', () => {
         amount: '10',
         fundType: 'VESTS',
       });
-      expect(ops[0][1].vesting_shares).toBe('10.000000 VESTS');
+      expect((ops[0][1] as any).vesting_shares).toBe('10.000000 VESTS');
     });
 
     it('does not force engine-token quantities to 3 dp (mock shape: [op, action, from, to, amount, symbol, memo])', () => {
@@ -111,8 +111,8 @@ describe('buildTransferOpsArray', () => {
         to: 'bob, charlie',
       });
       expect(ops).toHaveLength(2);
-      expect(ops[0][1].to).toBe('bob');
-      expect(ops[1][1].to).toBe('charlie');
+      expect((ops[0][1] as any).to).toBe('bob');
+      expect((ops[1][1] as any).to).toBe('charlie');
     });
 
     it('splits multi-recipient by space', () => {
@@ -135,7 +135,7 @@ describe('buildTransferOpsArray', () => {
 
     it('includes memo when provided', () => {
       const ops = buildTransferOpsArray(TransferTypes.TRANSFER, { ...baseData, memo: 'thanks' });
-      expect(ops[0][1].memo).toBe('thanks');
+      expect((ops[0][1] as any).memo).toBe('thanks');
     });
   });
 
@@ -143,9 +143,9 @@ describe('buildTransferOpsArray', () => {
     it('builds convert op with requestid', () => {
       const ops = buildTransferOpsArray(TransferTypes.CONVERT, baseData);
       expect(ops[0][0]).toBe('convert');
-      expect(ops[0][1].owner).toBe('alice');
-      expect(ops[0][1].amount).toBe('10.000 HIVE');
-      expect(typeof ops[0][1].requestid).toBe('number');
+      expect((ops[0][1] as any).owner).toBe('alice');
+      expect((ops[0][1] as any).amount).toBe('10.000 HIVE');
+      expect(typeof (ops[0][1] as any).requestid).toBe('number');
     });
   });
 
@@ -153,9 +153,9 @@ describe('buildTransferOpsArray', () => {
     it('builds delegation op', () => {
       const ops = buildTransferOpsArray(TransferTypes.DELEGATE_VESTING_SHARES, baseData);
       expect(ops[0][0]).toBe('delegate_vesting_shares');
-      expect(ops[0][1].delegator).toBe('alice');
-      expect(ops[0][1].delegatee).toBe('bob');
-      expect(ops[0][1].vesting_shares).toBe('10.000 HIVE');
+      expect((ops[0][1] as any).delegator).toBe('alice');
+      expect((ops[0][1] as any).delegatee).toBe('bob');
+      expect((ops[0][1] as any).vesting_shares).toBe('10.000 HIVE');
     });
   });
 
@@ -163,8 +163,8 @@ describe('buildTransferOpsArray', () => {
     it('builds savings transfer op', () => {
       const ops = buildTransferOpsArray(TransferTypes.TRANSFER_TO_SAVINGS, baseData);
       expect(ops[0][0]).toBe('transfer_to_savings');
-      expect(ops[0][1].from).toBe('alice');
-      expect(ops[0][1].to).toBe('bob');
+      expect((ops[0][1] as any).from).toBe('alice');
+      expect((ops[0][1] as any).to).toBe('bob');
     });
   });
 
@@ -175,7 +175,7 @@ describe('buildTransferOpsArray', () => {
         memo: 'ignored',
       });
       expect(ops[0][0]).toBe('transfer_to_vesting');
-      expect(ops[0][1].memo).toBeUndefined();
+      expect((ops[0][1] as any).memo).toBeUndefined();
     });
   });
 
@@ -183,7 +183,7 @@ describe('buildTransferOpsArray', () => {
     it('builds savings withdrawal with request_id', () => {
       const ops = buildTransferOpsArray(TransferTypes.TRANSFER_FROM_SAVINGS, baseData);
       expect(ops[0][0]).toBe('transfer_from_savings');
-      expect(typeof ops[0][1].request_id).toBe('number');
+      expect(typeof (ops[0][1] as any).request_id).toBe('number');
     });
   });
 
@@ -191,8 +191,8 @@ describe('buildTransferOpsArray', () => {
     it('builds power down op', () => {
       const ops = buildTransferOpsArray(TransferTypes.WITHDRAW_VESTING, baseData);
       expect(ops[0][0]).toBe('withdraw_vesting');
-      expect(ops[0][1].account).toBe('alice');
-      expect(ops[0][1].vesting_shares).toBe('10.000 HIVE');
+      expect((ops[0][1] as any).account).toBe('alice');
+      expect((ops[0][1] as any).vesting_shares).toBe('10.000 HIVE');
     });
   });
 
@@ -204,9 +204,9 @@ describe('buildTransferOpsArray', () => {
         executions: 7,
       });
       expect(ops[0][0]).toBe('recurrent_transfer');
-      expect(ops[0][1].recurrence).toBe(24);
-      expect(ops[0][1].executions).toBe(7);
-      expect(ops[0][1].extensions).toEqual([]);
+      expect((ops[0][1] as any).recurrence).toBe(24);
+      expect((ops[0][1] as any).executions).toBe(7);
+      expect((ops[0][1] as any).extensions).toEqual([]);
     });
   });
 

--- a/src/utils/transferBalance.ts
+++ b/src/utils/transferBalance.ts
@@ -6,7 +6,7 @@ import TransferTypes from '../constants/transferTypes';
  * Shared by the wallet navigation path and the transfer container so both agree on
  * a single mapping instead of re-deriving it inline.
  */
-export const normalizeTransferType = (transferType) => {
+export const normalizeTransferType = (transferType: string) => {
   switch (transferType) {
     case 'transfer_token':
       return TransferTypes.TRANSFER;
@@ -18,7 +18,7 @@ export const normalizeTransferType = (transferType) => {
   }
 };
 
-export const parseAccountAssetBalance = (value, fundType) => {
+export const parseAccountAssetBalance = (value: any, fundType: string) => {
   if (value === undefined || value === null || value === '') {
     return undefined;
   }
@@ -30,7 +30,7 @@ export const parseAccountAssetBalance = (value, fundType) => {
   return Number.isFinite(parsed) ? parsed : undefined;
 };
 
-export const getNativeAccountBalance = (account, transferType, fundType) => {
+export const getNativeAccountBalance = (account: any, transferType: string, fundType: string) => {
   if (!account) {
     return undefined;
   }

--- a/src/utils/useDebounceHook.ts
+++ b/src/utils/useDebounceHook.ts
@@ -18,8 +18,12 @@ export const useDebounce = () => {
    * @param {this function would be called always} alwaysCall
    * @param {debounce delay in ms} ms
    */
-  const debounce = (callback, alwaysCall, ms) => {
-    return (...args) => {
+  const debounce = (
+    callback: (...args: any[]) => void,
+    alwaysCall: (...args: any[]) => void,
+    ms: number,
+  ) => {
+    return (...args: any[]) => {
       alwaysCall(...args);
       clearTimeout(timeoutToClear?.current as any);
       timeoutToClear.current = setTimeout(() => {

--- a/src/utils/user.ts
+++ b/src/utils/user.ts
@@ -35,7 +35,7 @@ export const parseReputation = (input: string | number): number => {
   return Math.floor(reputationLevel);
 };
 
-export const getName = (about) => {
+export const getName = (about: any) => {
   // Guard against null/undefined
   if (!about) {
     return null;
@@ -50,7 +50,7 @@ export const getName = (about) => {
   return null;
 };
 
-export const getAvatar = (about) => {
+export const getAvatar = (about: any) => {
   // Guard against null/undefined
   if (!about) {
     return null;
@@ -65,7 +65,7 @@ export const getAvatar = (about) => {
   return null;
 };
 
-export const validateUsername = (username) => {
+export const validateUsername = (username: string) => {
   const usernameRegex = /^[a-zA-Z0-9]+$/g;
 
   return usernameRegex.test(username);

--- a/src/utils/vote.ts
+++ b/src/utils/vote.ts
@@ -1,7 +1,7 @@
 import { votingPower, votingRshares, votingValue } from '@ecency/sdk';
 import { GlobalProps } from '../redux/reducers/accountReducer';
 
-export const getEstimatedAmount = (account, globalProps: GlobalProps, sliderValue = 1) => {
+export const getEstimatedAmount = (account: any, globalProps: GlobalProps, sliderValue = 1) => {
   const weight = sliderValue * 10000;
   const sign = weight < 0 ? -1 : 1;
   const estimatedAmount =

--- a/src/utils/wallet.ts
+++ b/src/utils/wallet.ts
@@ -40,7 +40,10 @@ export const transferTypes = [
   'fill_vesting_withdraw',
 ];
 
-export const groomingTransactionData = (transaction, hivePerMVests): CoinActivity | null => {
+export const groomingTransactionData = (
+  transaction: any,
+  hivePerMVests: number | null,
+): CoinActivity | null => {
   if (!transaction) {
     return null;
   }
@@ -63,7 +66,7 @@ export const groomingTransactionData = (transaction, hivePerMVests): CoinActivit
   result.icon = 'local-activity';
 
   // Format other wallet related operations
-  result.repeatable = RepeatableTransfers[result.textKey] || false;
+  result.repeatable = RepeatableTransfers[result.textKey ?? ''] || false;
 
   switch (result.textKey) {
     case 'curation_reward':
@@ -297,14 +300,43 @@ export const groomingEngineHistory = (transaction: HistoryItem): CoinActivity | 
   return result;
 };
 
+export interface WalletTabData {
+  rewardHiveBalance?: number;
+  rewardHbdBalance?: number;
+  rewardVestingHive?: number;
+  hasUnclaimedRewards?: boolean;
+  balance?: number;
+  vestingShares?: number;
+  vestingSharesDelegated?: number;
+  vestingSharesReceived?: number;
+  vestingSharesTotal?: number;
+  hbdBalance?: number;
+  savingBalance?: number;
+  savingBalanceHbd?: number;
+  hivePerMVests?: number;
+  estimatedValue?: number;
+  estimatedHiveValue?: number;
+  estimatedHbdValue?: number;
+  estimatedHpValue?: number;
+  hasQuotes?: boolean;
+  showPowerDown?: boolean;
+  nextVestingWithdrawal?: number;
+}
+
 export const groomingWalletTabData = async ({
   user,
   globalProps,
   quotes,
   userCurrency: _userCurrency,
   isRefresh,
+}: {
+  user: any;
+  globalProps: any;
+  quotes: any;
+  userCurrency?: string;
+  isRefresh?: boolean;
 }) => {
-  const walletData = {};
+  const walletData: WalletTabData = {};
 
   if (!user) {
     return walletData;
@@ -387,7 +419,7 @@ export const groomingWalletTabData = async ({
   walletData.hasQuotes = hasQuotes;
 
   walletData.showPowerDown = userdata.next_vesting_withdrawal !== '1969-12-31T23:59:59';
-  const timeDiff = Math.abs(parseDate(userdata.next_vesting_withdrawal) - new Date());
+  const timeDiff = Math.abs(parseDate(userdata.next_vesting_withdrawal).getTime() - Date.now());
   walletData.nextVestingWithdrawal = Math.round(timeDiff / (1000 * 3600));
 
   return walletData;
@@ -453,7 +485,8 @@ export const fetchPendingRequests = async (
   const pendingRequests = [...openOrderRequests, ...withdrawRequests, ...conversionRequests];
 
   pendingRequests.sort((a, b) =>
-    new Date(a.expires || a.created).getTime() > new Date(b.expires || b.created).getTime()
+    new Date(a.expires || a.created || 0).getTime() >
+    new Date(b.expires || b.created || 0).getTime()
       ? 1
       : -1,
   );
@@ -469,7 +502,7 @@ export const fetchPendingRequests = async (
  * @returns {Promise<CoinActivity[]>}
  */
 
-export const groomingPointsTransactionData = (transaction) => {
+export const groomingPointsTransactionData = (transaction: any) => {
   if (!transaction) {
     return null;
   }
@@ -490,7 +523,7 @@ export const groomingPointsTransactionData = (transaction) => {
   return result;
 };
 
-export const getPointsEstimate = async (amount, userCurrency) => {
+export const getPointsEstimate = async (amount: number, userCurrency: string) => {
   if (!amount) {
     return 0;
   }
@@ -499,7 +532,7 @@ export const getPointsEstimate = async (amount, userCurrency) => {
   return ppEstm * amount;
 };
 
-export const getBtcEstimate = async (amount, userCurrency) => {
+export const getBtcEstimate = async (amount: number, userCurrency: string) => {
   if (!amount) {
     return 0;
   }

--- a/tsc-baseline.json
+++ b/tsc-baseline.json
@@ -1,5 +1,5 @@
 {
-  "total": 4891,
+  "total": 4563,
   "files": {
     "App.tsx": 1,
     "jest.setup.ts": 1,
@@ -118,7 +118,7 @@
     "src/components/markdownEditor/children/formats/utils.ts": 4,
     "src/components/markdownEditor/children/textFormatModal.tsx": 2,
     "src/components/markdownEditor/children/usernameAutofillBar.tsx": 4,
-    "src/components/markdownEditor/view/markdownEditorView.tsx": 43,
+    "src/components/markdownEditor/view/markdownEditorView.tsx": 42,
     "src/components/modNotesSheet/modNotesSheet.tsx": 2,
     "src/components/modal/view/modalView.tsx": 16,
     "src/components/modalHeader/container/modalHeader.tsx": 1,
@@ -161,7 +161,7 @@
     "src/components/postOptionsModal/container/postOptionsModal.tsx": 16,
     "src/components/postPoll/children/pollChoices.tsx": 3,
     "src/components/postPoll/children/pollHeader.tsx": 3,
-    "src/components/postPoll/container/postPoll.tsx": 13,
+    "src/components/postPoll/container/postPoll.tsx": 10,
     "src/components/postView/children/postReadingMetadata.tsx": 3,
     "src/components/postView/children/postTranslateInline.tsx": 2,
     "src/components/postView/container/postDisplayContainer.tsx": 11,
@@ -405,26 +405,6 @@
     "src/screens/waves/children/wavesReelVideo.tsx": 2,
     "src/screens/waves/screen/wavesScreen.tsx": 7,
     "src/screens/webBrowser/screen/webBrowser.tsx": 1,
-    "src/screens/welcome/screen/WelcomeScreen.tsx": 10,
-    "src/utils/I18nUtils.ts": 3,
-    "src/utils/b64.ts": 2,
-    "src/utils/conversions.ts": 4,
-    "src/utils/deepLinkParser.test.ts": 94,
-    "src/utils/deepLinkParser.ts": 1,
-    "src/utils/editor.ts": 29,
-    "src/utils/getCurrentHpApr.ts": 1,
-    "src/utils/getLocale.ts": 1,
-    "src/utils/hive-uri.ts": 7,
-    "src/utils/image.ts": 8,
-    "src/utils/migrationHelpers.test.ts": 5,
-    "src/utils/migrationHelpers.ts": 52,
-    "src/utils/points.ts": 1,
-    "src/utils/postParser.tsx": 25,
-    "src/utils/transactionOpsBuilder.test.ts": 21,
-    "src/utils/transferBalance.ts": 6,
-    "src/utils/useDebounceHook.ts": 4,
-    "src/utils/user.ts": 3,
-    "src/utils/vote.ts": 1,
-    "src/utils/wallet.ts": 56
+    "src/screens/welcome/screen/WelcomeScreen.tsx": 10
   }
 }


### PR DESCRIPTION
Closes #3428

Takes `src/utils` from 324 baselined errors to zero, in five commits by area. Net baseline: **4891 -> 4563 (-328)** including collateral fixes outside utils.

- **deepLinkParser**: explicit `DeepLinkRoute | undefined` return (`name` is legitimately optional on fall-through; `useLinkProcessor` gates on it). The test asserts through a non-null `parse()` helper instead of dereferencing a possibly-undefined result 94 times.
- **wallet**: `CoinActivity`'s per-operation fields become optional - both grooming constructors only set `trxIndex`/`iconType` unconditionally, so the required contract was fiction. New `WalletTabData` shape for the wallet-tab accumulator; `RepeatableTransfers` becomes a string record; `Date` arithmetic via `getTime()`; the three call sites that dereferenced now-optional fields are guarded (walletQueries sort, assetDetailsScreen `parseAsset`, pendingRequests sort); `walletContainer` state gets the real type.
- **migrationHelpers**: the 22 redux-persist migrations take explicit `any` state (old persisted shapes are genuinely unknown); repair/migrate functions get real signatures; mandatory `Config` pin env values non-null asserted at crypto call sites.
- **editor/postParser + PostMetadata**: `PostMetadata` fields become optional (built progressively, merged later) and the `links`/`links_meta`/`type` fields it actually writes are now declared; parameter types throughout; typed image-ratio promise.
- **tail** (b64, conversions, hive-uri, image, points, transferBalance, useDebounceHook, user, vote, I18nUtils, getLocale, getCurrentHpApr, transactionOpsBuilder test): parameter annotations; conversions accepts the string/null inputs its guards and tests already exercise.

No runtime behavior changes intended; the only expression-level edits are type-preserving (`String()` wrap inside existing `parseFloat`, `getTime()` on both sides of date subtraction, `|| 'jpg'` fallback that matches the declared default, guards on optional fields). All 477 jest tests in the utils suites pass.