### PR TITLE
chore: rename repository to vision-mobile

### DIFF
--- a/.claude/skills/add-mutation/SKILL.md
+++ b/.claude/skills/add-mutation/SKILL.md
@@ -105,7 +105,7 @@ export function use<Operation>(username?: string, auth?: AuthContextV2) {
 }
 ```
 
-Then rebuild SDK: `cd ../vision-next && pnpm --filter @ecency/sdk build`
+Then rebuild SDK: `cd ../vision-web && pnpm --filter @ecency/sdk build`
 
 ## Authority Levels
 

--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: code-review
-description: Review code changes for bugs, pattern violations, and common pitfalls in ecency-mobile
+description: Review code changes for bugs, pattern violations, and common pitfalls in vision-mobile
 argument-hint: [file-or-branch]
 disable-model-invocation: true
 ---
 
 # Code Review
 
-Review code for bugs, anti-patterns, and issues specific to the ecency-mobile codebase.
+Review code for bugs, anti-patterns, and issues specific to the vision-mobile codebase.
 
 ## How to Review
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Ecency Mobile
 
-[![iOS](https://github.com/ecency/ecency-mobile/actions/workflows/build-ios.yml/badge.svg)](https://github.com/ecency/ecency-mobile/actions/workflows/build-ios.yml)
-[![Android](https://github.com/ecency/ecency-mobile/actions/workflows/build-android.yml/badge.svg)](https://github.com/ecency/ecency-mobile/actions/workflows/build-android.yml)
+[![iOS](https://github.com/ecency/vision-mobile/actions/workflows/build-ios.yml/badge.svg)](https://github.com/ecency/vision-mobile/actions/workflows/build-ios.yml)
+[![Android](https://github.com/ecency/vision-mobile/actions/workflows/build-android.yml/badge.svg)](https://github.com/ecency/vision-mobile/actions/workflows/build-android.yml)
 
 Ecency is a React Native client for the [Hive](https://hive.io) blockchain available for iOS and Android devices.
 
@@ -27,8 +27,8 @@ Stable releases are distributed via the stores:
 ## Getting started
 
 ```bash
-git clone https://github.com/ecency/ecency-mobile.git
-cd ecency-mobile
+git clone https://github.com/ecency/vision-mobile.git
+cd vision-mobile
 yarn
 ```
 
@@ -123,7 +123,7 @@ During confirmation Ecency replaces the placeholder `__signer` values with the a
 
 We welcome community contributions! To get started:
 
-1. Browse [open issues](https://github.com/ecency/ecency-mobile/issues) and assign one to yourself.
+1. Browse [open issues](https://github.com/ecency/vision-mobile/issues) and assign one to yourself.
 2. Create a feature or bugfix branch (e.g. `feature/my-change` or `bugfix/my-fix`).
 3. Commit your work and open a pull request. Include relevant issue numbers in commit/PR messages.
 4. Request a review from [@feruzm](https://github.com/feruzm) or [@noumantahir](https://github.com/noumantahir).

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ import './src/utils/abortSignalPolyfill';
 import EcencyApp from './App';
 
 // TODO Remove ignoreLogs when referenced issue is fixed properly
-// ref: https://github.com/ecency/ecency-mobile/issues/2466
+// ref: https://github.com/ecency/vision-mobile/issues/2466
 // ignore warnings
 LogBox.ignoreLogs(['Require cycle:', 'Remote debugger']);
 

--- a/src/components/balanceAnalyticsSheet/balanceAnalyticsSheet.tsx
+++ b/src/components/balanceAnalyticsSheet/balanceAnalyticsSheet.tsx
@@ -209,7 +209,7 @@ const BalanceAnalyticsSheet = ({ payload }: SheetProps<SheetNames.BALANCE_ANALYT
   };
 
   // Pixel width per data point — keeps the chart denser than the viewport so
-  // the user can pan back through history. Mirrors how vision-next's
+  // the user can pan back through history. Mirrors how vision-web's
   // lightweight-charts setup spaces points.
   const POINT_WIDTH = 12;
   const _viewportWidth = dim.width - 32 + CHART_NEGATIVE_MARGIN;

--- a/src/components/hiveAuthModal/hooks/useHiveAuth.ts
+++ b/src/components/hiveAuthModal/hooks/useHiveAuth.ts
@@ -131,7 +131,7 @@ const getHiveAuthUri = async (path: string, preferredScheme?: HiveAuthScheme | n
 
 /**
  * Infers the required key type (posting or active) based on operation types
- * Matches the logic from vision-next website for consistency
+ * Matches the logic from vision-web website for consistency
  * @param opsArray Array of operations to analyze
  * @returns 'posting' or 'active' key type
  */

--- a/src/components/postHtmlRenderer/speakAudioPlayer.utils.ts
+++ b/src/components/postHtmlRenderer/speakAudioPlayer.utils.ts
@@ -2,7 +2,7 @@
 // component so the URL building and waveform/time math are unit-testable.
 
 // The web endpoint that transcodes Liketu's Opus/WebM voice clips to AAC/m4a so
-// iOS AVPlayer (react-native-video) can play them. See vision-next
+// iOS AVPlayer (react-native-video) can play them. See vision-web
 // /api/speak-audio. It takes the wave's author+permlink (NOT the raw audio URL):
 // the server looks the wave up on chain and derives audio_url itself, so the
 // fetch target is never user-supplied. The audio is immutable -> edge-cached.

--- a/src/components/upvotePopover/children/percentKeypad.tsx
+++ b/src/components/upvotePopover/children/percentKeypad.tsx
@@ -16,7 +16,7 @@ const KeyIcon = Icon as unknown as React.ComponentType<any>;
 
 /*
  * Keyboard-free numeric keypad shown inside the vote popover when the user taps
- * the NN% label, giving exact value entry like the vision-next web input —
+ * the NN% label, giving exact value entry like the vision-web web input —
  * without ever raising the OS keyboard (which would be occluded by this
  * Modal-hosted popover). Vote weight is whole-percent on chain, so an integer
  * keypad has full precision parity with typing.

--- a/src/components/upvotePopover/children/voteSlider.tsx
+++ b/src/components/upvotePopover/children/voteSlider.tsx
@@ -4,7 +4,7 @@ import { View, PanResponder, GestureResponderEvent, PanResponderGestureState } f
 import styles from './upvoteStyles';
 
 /*
- * Custom voting slider inspired by the vision-next web "input-vote" control.
+ * Custom voting slider inspired by the vision-web web "input-vote" control.
  *
  * Replaces the thin native @react-native-community/slider (a ~16px thumb on a
  * 2px track, which many users struggled to grab precisely) with a fat

--- a/src/components/upvotePopover/container/upvotePopover.tsx
+++ b/src/components/upvotePopover/container/upvotePopover.tsx
@@ -205,7 +205,7 @@ const UpvotePopover = forwardRef(({}, ref) => {
   const [sliderValue, setSliderValue] = useState(1);
   const [amount, setAmount] = useState('0.00000');
 
-  // Use SDK's votingValue (same formula as vision-next web) for vote estimation
+  // Use SDK's votingValue (same formula as vision-web web) for vote estimation
   const _estimateVoteValue = (account: any, props: any, sliderVal: number) => {
     const vPower = sdkVotingPower(account) * 100;
     const weight = Math.abs(sliderVal) * 10000;

--- a/src/config/githubApi.ts
+++ b/src/config/githubApi.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 const githubApi = axios.create({
-  baseURL: 'https://api.github.com/repos/ecency/ecency-mobile/',
+  baseURL: 'https://api.github.com/repos/ecency/vision-mobile/',
 });
 
 export default githubApi;

--- a/src/constants/exchangeAccounts.ts
+++ b/src/constants/exchangeAccounts.ts
@@ -8,7 +8,7 @@
 //      operations, which exchange deposit systems do not monitor, so recurring
 //      sends to an exchange may never be credited.
 //
-// Mirrors vision-next's apps/web/src/consts/exchange-accounts.ts — keep in sync when
+// Mirrors vision-web's apps/web/src/consts/exchange-accounts.ts — keep in sync when
 // the web list changes.
 export const EXCHANGE_ACCOUNTS = [
   'deepcrypto8',
@@ -88,7 +88,7 @@ const levenshtein = (a: string, b: string): number => {
  *      brand is distinct from the full name, the brand core ('upbitcoin');
  *   3. a single-character typo of the full account name ('bittrx').
  *
- * Mirrors vision-next's isExchangeLikeUsername — keep the two in sync.
+ * Mirrors vision-web's isExchangeLikeUsername — keep the two in sync.
  */
 export const isExchangeLikeUsername = (username?: string | null): boolean => {
   if (!username) {

--- a/src/constants/options/imageServer.ts
+++ b/src/constants/options/imageServer.ts
@@ -1,6 +1,6 @@
 // i.ecency.com is the same imagehoster backend as images.ecency.com, on an
 // SNI-resilient hostname (some ISPs, e.g. Virgin Media UK, SNI-filter the
-// images.ecency.com hostname). See vision-next PR #791.
+// images.ecency.com hostname). See vision-web PR #791.
 export const DEFAULT_IMAGE_SERVER = 'https://i.ecency.com';
 
 export const IMAGE_SERVERS = [

--- a/src/providers/queries/postQueries/repostQueries.ts
+++ b/src/providers/queries/postQueries/repostQueries.ts
@@ -167,7 +167,7 @@ export function useCrossPostMutation() {
 export const makeCrossPostMessage = (post: any, poster: string, message: string) => {
   const { author, permlink } = post;
   // Use ecency.com's canonical post path `/@author/permlink` (no category
-  // segment). The web parser regex (`crossPostRegex` in vision-next's
+  // segment). The web parser regex (`crossPostRegex` in vision-web's
   // `cross-post.ts`) matches both legacy and canonical forms, so existing
   // cross-posts keep rendering correctly and new ones skip the redirect.
   const postLink = `[@${author}/${permlink}](/@${author}/${permlink})`;

--- a/src/providers/sdk/mutations/index.ts
+++ b/src/providers/sdk/mutations/index.ts
@@ -3,7 +3,7 @@
  *
  * Each wrapper injects the mobile auth context (platform adapter + current user)
  * into the corresponding SDK mutation hook.  This mirrors the pattern used in
- * vision-next/apps/web/src/api/sdk-mutations/.
+ * vision-web/apps/web/src/api/sdk-mutations/.
  */
 
 // Social

--- a/src/screens/application/container/applicationContainer.tsx
+++ b/src/screens/application/container/applicationContainer.tsx
@@ -281,7 +281,7 @@ class ApplicationContainer extends Component {
           setLastUpdateCheck(new Date().getTime());
         } else if (action === 'update') {
           DeviceInfo.getInstallerPackageName().then((installerPackageName) => {
-            let _url = 'https://github.com/ecency/ecency-mobile/releases';
+            let _url = 'https://github.com/ecency/vision-mobile/releases';
             switch (installerPackageName) {
               case 'com.android.vending':
                 _url = 'market://details?id=app.esteem.mobile.android';

--- a/src/screens/waves/children/wavesOnboardingChecklist.tsx
+++ b/src/screens/waves/children/wavesOnboardingChecklist.tsx
@@ -66,7 +66,7 @@ const DISMISS_HIT_SLOP = { top: 8, bottom: 8, left: 8, right: 8 };
  * Wave as the entry action. Completion is derived from the daily quests API and
  * latched per-user in AsyncStorage so items never un-check when the daily quest
  * window resets at 00:00 UTC. Once every item is done it celebrates once, then
- * hides for good. Mirrors the web (vision-next) WavesOnboardingChecklist.
+ * hides for good. Mirrors the web (vision-web) WavesOnboardingChecklist.
  */
 const WavesOnboardingChecklist = () => {
   const intl = useIntl();

--- a/src/utils/wavesOnboarding.ts
+++ b/src/utils/wavesOnboarding.ts
@@ -49,7 +49,7 @@ export const isNewAccount = (
  * caller passes completions it already latched to storage: a checklist item must
  * never un-check itself the next day. Returns null until both inputs arrive so
  * callers can distinguish "loading" from "nothing to show". Mirrors the web
- * implementation (vision-next deriveWavesOnboardingState) so both apps behave
+ * implementation (vision-web deriveWavesOnboardingState) so both apps behave
  * the same.
  */
 export const deriveWavesOnboardingState = (


### PR DESCRIPTION
Repository was renamed from `ecency-mobile` to `vision-mobile` (the web repo is now `vision-web`). This updates all self-references:

- `src/config/githubApi.ts` base URL and the releases link in `applicationContainer` (shipped app versions keep working via GitHub's rename redirect)
- README badges/clone instructions and skill docs
- Comment references to the web repo (`vision-next` -> `vision-web`)

Intentionally unchanged: Sentry project name `ecency-mobile` (app.json, sentry.properties, build workflows) and on-chain client-id strings in comments — renaming the Sentry project is a separate decision.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project references, setup instructions, badges, issue links, and implementation links to use the current project names.
  * Refreshed developer guidance and comments across the app for consistency.

* **Bug Fixes**
  * Updated GitHub integrations and release links to point to the current repository, ensuring issue reporting and update checks use the correct destination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->