### PR TITLE
Pass the editor's live isEditing to the toolbar

### DIFF
--- a/src/components/markdownEditor/children/editorToolbar.tsx
+++ b/src/components/markdownEditor/children/editorToolbar.tsx
@@ -53,7 +53,7 @@ type Props = {
   draftId?: string;
   postBody: string;
   paramFiles: any[];
-  isEditing?: boolean;
+  isEditing: boolean;
   isPreviewActive: boolean;
   isEditMode: boolean;
   isReply?: boolean;
@@ -374,7 +374,7 @@ export const EditorToolbar = ({
               postBody={postBody}
               isPreviewActive={isPreviewActive}
               paramFiles={paramFiles}
-              isEditing={!!isEditing}
+              isEditing={isEditing}
               hideToolbarExtension={_hideExtension}
               handleMediaInsert={handleMediaInsert}
               onVideoThumb={handleVideoThumb}

--- a/src/components/markdownEditor/view/markdownEditorView.tsx
+++ b/src/components/markdownEditor/view/markdownEditorView.tsx
@@ -591,6 +591,7 @@ const MarkdownEditorView = ({
         <EditorToolbar
           draftId={draftId}
           postBody={bodyTextRef.current}
+          isEditing={isEditing}
           isPreviewActive={isPreviewActive}
           paramFiles={paramFiles}
           isEditMode={isEdit}

--- a/src/components/uploadsGalleryModal/container/uploadsGalleryModal.tsx
+++ b/src/components/uploadsGalleryModal/container/uploadsGalleryModal.tsx
@@ -87,6 +87,8 @@ export const UploadsGalleryModal = forwardRef(
     const mediaUploadMutation = editorQueries.useMediaUploadMutation();
 
     const pendingInserts = useRef<MediaInsertData[]>([]);
+    const isEditingRef = useRef(isEditing);
+    isEditingRef.current = isEditing;
     const speakUploaderRef = useRef<any>(null);
 
     const [showModal, setShowModal] = useState(false);
@@ -553,7 +555,7 @@ export const UploadsGalleryModal = forwardRef(
     };
 
     const _handleMediaInsertion = (data: MediaInsertData[]) => {
-      if (isEditing) {
+      if (isEditingRef.current) {
         pendingInserts.current.push(...data);
       } else if (handleMediaInsert) {
         handleMediaInsert(data);


### PR DESCRIPTION
Closes #3448

CodeRabbit follow-up on merged #3446; the defect is pre-existing. UploadsGalleryModal has a pending-inserts queue precisely so uploads finishing during the typing debounce window cannot interleave with the body update (queue while editing, flush on pause). The editor view, the only toolbar call site, never passed its live isEditing state, so the modal always saw false and the queue has been dead since introduction.

Commit 1 wires isEditing through from MarkdownEditorView, restores the prop as required in the toolbar contract and forwards it directly.

Commit 2 (review finding): _handleMediaInsertion runs in async upload continuations that captured isEditing at upload start. A completion mid-typing could still insert directly and a completion after typing ended could queue with no flush transition left to drain it, silently dropping the media if the user published right away. A render-synced ref now gives the handler the current value in both cases.

Known remaining edge for the device pass: if the editor unmounts with items still queued (upload completing inside the 500ms window right before close), the modal's flush effect cannot run during teardown and queued inserts drop. Worth covering in the pending editor device pass (draft-load button, image insert) before release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency between the editor’s current state and upload gallery behavior.
  * Ensured the toolbar always receives the editor’s editing status.
  * Fixed media insertion to respect the latest editing state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->