### PR TITLE
Typed navigation, real primitive interfaces, inert plumbing removed

### DIFF
--- a/src/components/animations/spinIndicator/indicator.tsx
+++ b/src/components/animations/spinIndicator/indicator.tsx
@@ -73,7 +73,7 @@ export default class Indicator extends PureComponent<any, any> {
     this.setState({ animation: null });
   };
 
-  _renderComponent = (undefined: any, index: any) => {
+  _renderComponent = (_item: any, index: number) => {
     const { progress } = this.state;
     const { renderComponent } = this.props;
 

--- a/src/components/basicHeader/container/basicHeaderContainer.tsx
+++ b/src/components/basicHeader/container/basicHeaderContainer.tsx
@@ -12,6 +12,8 @@ import BasicHeaderView from '../view/basicHeaderView';
 
 interface BackHeaderProps {
   backIconName?: 'close' | 'arrow-back';
+  isNewPost?: boolean;
+  handleOnBackPress?: () => void;
   // passes every remaining prop through to BasicHeaderView
   [key: string]: any;
 }
@@ -22,12 +24,10 @@ const BasicHeaderContainer = (props: BackHeaderProps) => {
   const isHideImages = useAppSelector(selectHidePostsThumbnails);
 
   const _handleOnPressBackButton = () => {
-    const { isNewPost, handleOnBackPress } = props as any;
+    const { isNewPost, handleOnBackPress } = props;
 
     if (isNewPost) {
-      (navigation as any).navigate({
-        name: ROUTES.SCREENS.FEED,
-      });
+      navigation.navigate({ name: ROUTES.SCREENS.FEED, params: undefined });
     } else {
       navigation.goBack();
     }

--- a/src/components/basicUIElements/view/placeHolder/boostPlaceHolderView.tsx
+++ b/src/components/basicUIElements/view/placeHolder/boostPlaceHolderView.tsx
@@ -14,7 +14,7 @@ const BoostPlaceHolder = () => {
   const listElements: any[] = [];
   const isDarkTheme = useAppSelector(selectIsDarkTheme);
   const color = isDarkTheme ? '#2e3d51' : '#f5f5f5';
-  times(parseInt(ratio as any), (i) => {
+  times(Math.floor(ratio), (i) => {
     listElements.push(
       <View style={styles.container} key={`key-${i.toString()}`}>
         <View style={styles.line}>

--- a/src/components/basicUIElements/view/placeHolder/listPlaceHolderView.tsx
+++ b/src/components/basicUIElements/view/placeHolder/listPlaceHolderView.tsx
@@ -11,7 +11,7 @@ const ListPlaceHolderView = () => {
   const ratio = (dim.height - 300) / 50;
   const listElements: any[] = [];
 
-  times(parseInt(ratio as any), (i) => {
+  times(Math.floor(ratio), (i) => {
     listElements.push(<ListItemPlaceHolder key={i} />);
   });
 

--- a/src/components/basicUIElements/view/placeHolder/walletDetailsPlaceHolder.tsx
+++ b/src/components/basicUIElements/view/placeHolder/walletDetailsPlaceHolder.tsx
@@ -14,7 +14,7 @@ const listPlaceHolderView = (color: any) => {
   const ratio = (dim.height - 300) / 50;
   const listElements: any[] = [];
 
-  times(parseInt(ratio as any), (i) => {
+  times(Math.floor(ratio), (i) => {
     listElements.push(
       <View key={i} style={styles.textWrapper}>
         <Placeholder.Box animate="fade" height={30} width="100%" radius={5} color={color} />

--- a/src/components/basicUIElements/view/tag/tagContainer.tsx
+++ b/src/components/basicUIElements/view/tag/tagContainer.tsx
@@ -82,7 +82,7 @@ const TagContainer = ({
     if (onPress) {
       onPress();
     } else {
-      (navigation as any).navigate({
+      navigation.navigate({
         name: isCommunity ? ROUTES.SCREENS.COMMUNITY : ROUTES.SCREENS.TAG_RESULT,
         params: {
           tag: value,

--- a/src/components/bottomTabBar/view/tabbar.tsx
+++ b/src/components/bottomTabBar/view/tabbar.tsx
@@ -16,7 +16,8 @@ export default class TabBar extends Component<any, any> {
 
     const { selectedIndex, children } = props;
 
-    let value;
+    // segment width by tab count; 5 tabs is what the app renders
+    let value = 120;
     switch (children.length) {
       case 2:
         value = 480;
@@ -36,9 +37,9 @@ export default class TabBar extends Component<any, any> {
 
     this.state = {
       selectedIndex,
-      circleRadius: new Animated.Value(91 + selectedIndex * value!),
-      pathD: new Animated.Value(selectedIndex * value!),
-      pathX: selectedIndex * value!,
+      circleRadius: new Animated.Value(91 + selectedIndex * value),
+      pathD: new Animated.Value(selectedIndex * value),
+      pathX: selectedIndex * value,
       animateConstant: value,
       animating: false,
     };
@@ -58,11 +59,11 @@ export default class TabBar extends Component<any, any> {
     const { selectedIndex } = this.props;
 
     if (prevProps.selectedIndex !== selectedIndex) {
-      (this as any)._onPress(selectedIndex);
+      this._onPress(selectedIndex);
     }
   }
 
-  _onPress = (i: any, disabled: any) => {
+  _onPress = (i: number, disabled?: boolean) => {
     const { onChange } = this.props;
     if (!disabled) {
       this._move(i);

--- a/src/components/buttons/views/textButtonView.tsx
+++ b/src/components/buttons/views/textButtonView.tsx
@@ -1,9 +1,24 @@
 import React, { Fragment } from 'react';
-import { Text, View, TouchableWithoutFeedback } from 'react-native';
+import {
+  Text,
+  View,
+  TouchableWithoutFeedback,
+  StyleProp,
+  TextStyle,
+  ViewStyle,
+} from 'react-native';
 
 import styles from './textButtonStyles';
 
-const TextButtonView = ({ text, onPress, style, textStyle, disabled }: any) => (
+interface TextButtonProps {
+  text?: string;
+  onPress?: (event?: any) => void;
+  style?: StyleProp<ViewStyle>;
+  textStyle?: StyleProp<TextStyle>;
+  disabled?: boolean;
+}
+
+const TextButtonView = ({ text, onPress, style, textStyle, disabled }: TextButtonProps) => (
   <Fragment>
     <TouchableWithoutFeedback
       style={[styles.button]}

--- a/src/components/comments/container/commentsContainer.tsx
+++ b/src/components/comments/container/commentsContainer.tsx
@@ -186,7 +186,7 @@ const CommentsContainer = ({
   };
 
   const _handleOnVotersPress = (activeVotes: any, content: any) => {
-    (navigation as any).navigate({
+    navigation.navigate({
       name: ROUTES.SCREENS.VOTERS,
       params: {
         activeVotes,
@@ -197,7 +197,7 @@ const CommentsContainer = ({
   };
 
   const _handleOnEditPress = (item: any) => {
-    (navigation as any).navigate({
+    navigation.navigate({
       name: ROUTES.SCREENS.EDITOR,
       key: `editor_edit_reply_${item.permlink}`,
       params: {
@@ -259,7 +259,7 @@ const CommentsContainer = ({
 
   const _openReplyThread = (comment: any) => {
     postsCachePrimer.cachePost(comment);
-    (navigation as any).navigate({
+    navigation.navigate({
       name: ROUTES.SCREENS.POST,
       params: {
         author: comment.author,

--- a/src/components/dictationModal/dictationModal.tsx
+++ b/src/components/dictationModal/dictationModal.tsx
@@ -269,7 +269,7 @@ export const DictationModal = ({ payload }: SheetProps<SheetNames.DICTATION>) =>
           ) : needsRetry ? (
             <MainButton
               style={styles.button}
-              isDisabled={busy}
+              isDisable={busy}
               onPress={submit}
               iconName="refresh"
               iconType="MaterialIcons"
@@ -278,7 +278,7 @@ export const DictationModal = ({ payload }: SheetProps<SheetNames.DICTATION>) =>
           ) : (
             <MainButton
               style={styles.button}
-              isDisabled={busy || !isPriceReady}
+              isDisable={busy || !isPriceReady}
               onPress={start}
               iconName="mic"
               iconType="MaterialIcons"
@@ -290,7 +290,7 @@ export const DictationModal = ({ payload }: SheetProps<SheetNames.DICTATION>) =>
 
           <MainButton
             style={styles.button}
-            isDisabled={busy}
+            isDisable={busy}
             onPress={close}
             text={intl.formatMessage({ id: 'dictation.done' })}
           />

--- a/src/components/header/container/headerContainer.tsx
+++ b/src/components/header/container/headerContainer.tsx
@@ -46,7 +46,7 @@ const HeaderContainer = ({
 
   const _handleOnBoostPress = () => {
     // open the perks dashboard (quests + ways to spend points)
-    (navigation as any).navigate(ROUTES.SCREENS.PERKS);
+    navigation.navigate(ROUTES.SCREENS.PERKS);
   };
 
   return (

--- a/src/components/header/view/headerView.tsx
+++ b/src/components/header/view/headerView.tsx
@@ -39,7 +39,7 @@ const HeaderView = ({
   const gradientColor = isDarkTheme ? ['#081c36', '#43638e'] : ['#2d5aa0', '#357ce6'];
 
   const _onPressSearchButton = () => {
-    (navigation as any).navigate(ROUTES.SCREENS.SEARCH_RESULT);
+    navigation.navigate(ROUTES.SCREENS.SEARCH_RESULT);
   };
 
   const _renderAvatar = () => (

--- a/src/components/icon/view/iconView.tsx
+++ b/src/components/icon/view/iconView.tsx
@@ -1,5 +1,5 @@
 import React, { PureComponent, Fragment } from 'react';
-import { Platform, View, Text } from 'react-native';
+import { Platform, View, Text, StyleProp, TextStyle, ViewStyle } from 'react-native';
 import Ionicons from 'react-native-vector-icons/Ionicons';
 import MaterialCommunityIcons from 'react-native-vector-icons/MaterialCommunityIcons';
 import SimpleLineIcons from 'react-native-vector-icons/SimpleLineIcons';
@@ -11,12 +11,23 @@ import FontAwesome5 from 'react-native-vector-icons/FontAwesome5';
 
 import styles from './iconStyles';
 
-class IconView extends PureComponent<any, any> {
-  constructor(props: any) {
-    super(props);
-    this.state = {};
-  }
+interface IconProps {
+  iconType?: string;
+  name?: string;
+  // Android sometimes needs a different glyph name for the same icon
+  androidName?: string;
+  size?: number;
+  color?: string;
+  style?: StyleProp<TextStyle>;
+  badgeCount?: number | string;
+  badgeStyle?: StyleProp<ViewStyle>;
+  badgeTextStyle?: StyleProp<TextStyle>;
+  children?: React.ReactNode;
+  // remaining props spread into the underlying vector-icon set
+  [key: string]: any;
+}
 
+class IconView extends PureComponent<IconProps> {
   _getIconName = () => {
     const { name, androidName } = this.props;
 
@@ -34,7 +45,7 @@ class IconView extends PureComponent<any, any> {
 
   _getIcon = () => {
     const { iconType, children, name } = this.props;
-    let _name = name;
+    let _name: any = name;
 
     if (iconType !== 'MaterialIcons') {
       _name = this._getIconName();
@@ -77,7 +88,7 @@ class IconView extends PureComponent<any, any> {
     const { badgeCount } = this.props;
     let _badgeCount = badgeCount;
 
-    if (_badgeCount && _badgeCount >= 99) {
+    if (_badgeCount && (_badgeCount as any) >= 99) {
       _badgeCount = '99+';
     }
 

--- a/src/components/iconButton/view/iconButtonView.tsx
+++ b/src/components/iconButton/view/iconButtonView.tsx
@@ -1,5 +1,5 @@
 import React, { Fragment } from 'react';
-import { TouchableOpacity, ActivityIndicator } from 'react-native';
+import { TouchableOpacity, ActivityIndicator, StyleProp, TextStyle, ViewStyle } from 'react-native';
 import EStyleSheet from 'react-native-extended-stylesheet';
 import { Icon } from '../../icon';
 
@@ -9,6 +9,25 @@ import styles from './iconButtonStyles';
  * ------------------------------------------------
  *   @prop { type }    name                - Description....
  */
+
+interface IconButtonProps {
+  name?: string;
+  iconType?: string;
+  color?: string;
+  size?: number;
+  backgroundColor?: string;
+  badgeCount?: number | string;
+  badgeStyle?: StyleProp<ViewStyle>;
+  badgeTextStyle?: StyleProp<TextStyle>;
+  disabled?: boolean;
+  isLoading?: boolean;
+  iconStyle?: StyleProp<TextStyle>;
+  style?: StyleProp<ViewStyle>;
+  onPress?: (event?: any) => void;
+  onLongPress?: (event?: any) => void;
+  accessibilityLabel?: string;
+  accessibilityHint?: string;
+}
 
 const IconButton = ({
   backgroundColor,
@@ -27,7 +46,7 @@ const IconButton = ({
   isLoading,
   accessibilityLabel,
   accessibilityHint,
-}: any) => (
+}: IconButtonProps) => (
   <Fragment>
     <TouchableOpacity
       style={[styles.iconButton, style]}

--- a/src/components/informationArea/view/informationAreaView.tsx
+++ b/src/components/informationArea/view/informationAreaView.tsx
@@ -15,7 +15,7 @@ const FormInputView = ({ description, iconName, bold, link }: any) => {
   const navigation = useNavigation();
 
   const _onPress = () => {
-    (navigation as any).navigate({
+    navigation.navigate({
       name: ROUTES.SCREENS.WEB_BROWSER,
       params: {
         url: link,

--- a/src/components/mainButton/view/mainButtonView.tsx
+++ b/src/components/mainButton/view/mainButtonView.tsx
@@ -1,5 +1,14 @@
 import React, { Component, Fragment } from 'react';
-import { ActivityIndicator, Image, Text, TouchableOpacity, View } from 'react-native';
+import {
+  ActivityIndicator,
+  Image,
+  Text,
+  TouchableOpacity,
+  View,
+  StyleProp,
+  TextStyle,
+  ViewStyle,
+} from 'react-native';
 
 // Components
 import { Icon } from '../../icon';
@@ -7,23 +16,39 @@ import { Icon } from '../../icon';
 // Styles
 import styles from './mainButtonStyles';
 
-class MainButton extends Component<any, any> {
-  /* Props
-   * ------------------------------------------------
-   *   @prop { string }     isLoading          - TODO:
-   *   @prop { string }     text               - TODO:
-   *   @prop { boolean }    secondText         - TODO:
-   *   @prop { boolean }    iconColor          - TODO:
-   *   @prop { boolean }    iconName           - TODO:
-   *   @prop { boolean }    isDisable          - TODO:
-   *
-   *
-   */
-  constructor(props: any) {
+interface MainButtonProps {
+  text?: string;
+  secondText?: string;
+  isLoading?: boolean;
+  isDisable?: boolean;
+  onPress?: (event?: any) => void;
+  iconName?: string;
+  iconType?: string;
+  iconColor?: string;
+  iconPosition?: string;
+  iconStyle?: StyleProp<any>;
+  // image source rendered instead of a glyph (avatar-style buttons)
+  source?: any;
+  renderIcon?: React.ReactNode;
+  textStyle?: StyleProp<TextStyle>;
+  secondTextStyle?: StyleProp<TextStyle>;
+  style?: StyleProp<ViewStyle>;
+  wrapperStyle?: StyleProp<ViewStyle>;
+  bodyWrapperStyle?: StyleProp<ViewStyle>;
+  height?: number;
+  children?: React.ReactNode;
+}
+
+interface MainButtonState {
+  isDisable: boolean;
+}
+
+class MainButton extends Component<MainButtonProps, MainButtonState> {
+  constructor(props: MainButtonProps) {
     super(props);
 
     this.state = {
-      isDisable: !props.isLoading && props.isDisable,
+      isDisable: !!(!props.isLoading && props.isDisable),
     };
   }
 
@@ -103,11 +128,11 @@ class MainButton extends Component<any, any> {
   _getIndicator = () => <ActivityIndicator color="white" style={styles.activityIndicator} />;
 
   // Component Life Cycles
-  UNSAFE_componentWillReceiveProps(nextProps: any) {
+  UNSAFE_componentWillReceiveProps(nextProps: MainButtonProps) {
     const { isLoading, isDisable } = this.props;
     if (nextProps.isLoading !== isLoading || nextProps.isDisable !== isDisable) {
       this.setState({
-        isDisable: !nextProps.isLoading && nextProps.isDisable,
+        isDisable: !!(!nextProps.isLoading && nextProps.isDisable),
       });
     }
   }

--- a/src/components/markdownEditor/children/editorToolbar.tsx
+++ b/src/components/markdownEditor/children/editorToolbar.tsx
@@ -190,7 +190,7 @@ export const EditorToolbar = ({
   };
 
   const _showPollsExtension = async () => {
-    (navigation as any).navigate(ROUTES.MODALS.POLL_WIZARD, {
+    navigation.navigate(ROUTES.MODALS.POLL_WIZARD, {
       draftId,
     });
   };
@@ -218,7 +218,7 @@ export const EditorToolbar = ({
   };
 
   const _openPerks = () => {
-    (navigation as any).navigate(ROUTES.SCREENS.PERKS);
+    navigation.navigate(ROUTES.SCREENS.PERKS);
   };
 
   const _showDictation = () => {
@@ -239,7 +239,7 @@ export const EditorToolbar = ({
   };
 
   const _showAiImageGenerator = () => {
-    (navigation as any).navigate({
+    navigation.navigate({
       name: ROUTES.SCREENS.AI_IMAGE_GENERATOR,
       params: {
         suggestedPrompt: suggestedPrompt || undefined,

--- a/src/components/notification/view/notificationView.tsx
+++ b/src/components/notification/view/notificationView.tsx
@@ -44,10 +44,10 @@ interface Props {
   isFetching: boolean;
   isNotificationRefreshing: boolean;
   globalProps: any;
-  handleOnUserPress: (username?: any) => void;
+  handleOnUserPress: (username?: string) => void;
   readAllNotification: () => void;
-  getActivities: (loadMore?: any) => void;
-  changeSelectedFilter: (filter?: any, index?: any) => void;
+  getActivities: (loadMore?: boolean) => void;
+  changeSelectedFilter: (filter?: string, index?: number) => void;
   navigateToNotificationRoute: () => void;
   listRef?: React.RefObject<FlatList>;
 }

--- a/src/components/numericKeyboard/views/numericKeyboardView.tsx
+++ b/src/components/numericKeyboard/views/numericKeyboardView.tsx
@@ -28,7 +28,6 @@ const NumericKeyboard = ({ onPress }: any) => (
       />
       <IconButton
         onPress={() => onPress && onPress('clear')}
-        isCircle
         style={styles.buttonWithoutBorder}
         iconStyle={styles.iconButton}
         name="backspace"

--- a/src/components/organisms/postStatsModal/container/postStatsModal.tsx
+++ b/src/components/organisms/postStatsModal/container/postStatsModal.tsx
@@ -49,7 +49,7 @@ export const PostStatsModal = forwardRef(({ post }: PostStatsModalProps, ref) =>
 
     sheetModalRef.current?.hide();
     if (isPinCodeOpen) {
-      (navigation as any).navigate({
+      navigation.navigate({
         name: ROUTES.SCREENS.PINCODE,
         params: {
           navigateTo: routeName,
@@ -59,7 +59,7 @@ export const PostStatsModal = forwardRef(({ post }: PostStatsModalProps, ref) =>
       return;
     }
 
-    (navigation as any).navigate(routeName, params);
+    navigation.navigate(routeName, params);
   };
 
   return (

--- a/src/components/parentPost/view/parentPostView.tsx
+++ b/src/components/parentPost/view/parentPostView.tsx
@@ -14,7 +14,7 @@ const ParentPost = ({ post }: any) => {
       <TouchableOpacity
         onPress={() =>
           get(navigation, 'navigate')
-            ? (navigation as any).navigate({
+            ? navigation.navigate({
                 name: ROUTES.SCREENS.POST,
                 params: {
                   author: post.author,

--- a/src/components/postButton/postButtonView.tsx
+++ b/src/components/postButton/postButtonView.tsx
@@ -12,7 +12,7 @@ const PostButtonView = () => {
   return (
     <TouchableOpacity
       onPress={() =>
-        (navigation as any).navigate({
+        navigation.navigate({
           name: ROUTES.SCREENS.EDITOR,
           key: 'editor_post',
         })

--- a/src/components/postComments/children/botCommentsPreview.tsx
+++ b/src/components/postComments/children/botCommentsPreview.tsx
@@ -20,7 +20,7 @@ export const BotCommentsPreview = ({ comments }: BotCommentsProps) => {
   }
 
   const _onPress = () => {
-    (navigation as any).navigate({
+    navigation.navigate({
       name: ROUTES.MODALS.BOT_COMMENTS,
       params: {
         comments,

--- a/src/components/postComments/container/postComments.tsx
+++ b/src/components/postComments/container/postComments.tsx
@@ -144,7 +144,7 @@ const PostComments = forwardRef(
 
     const _handleOnVotersPress = useCallback(
       (activeVotes: any, content: any) => {
-        (navigation as any).navigate({
+        navigation.navigate({
           name: ROUTES.SCREENS.VOTERS,
           params: {
             activeVotes,
@@ -158,7 +158,7 @@ const PostComments = forwardRef(
 
     const _handleOnEditPress = useCallback(
       (item: any) => {
-        (navigation as any).navigate({
+        navigation.navigate({
           name: ROUTES.SCREENS.EDITOR,
           key: `editor_edit_reply_${item.permlink}`,
           params: {
@@ -273,7 +273,7 @@ const PostComments = forwardRef(
     const _openReplyThread = useCallback(
       (comment: any) => {
         postsCachePrimer.cachePost(comment);
-        (navigation as any).navigate({
+        navigation.navigate({
           name: ROUTES.SCREENS.POST,
           key: comment.permlink,
           params: {

--- a/src/components/postElements/body/view/commentBodyView.tsx
+++ b/src/components/postElements/body/view/commentBodyView.tsx
@@ -25,8 +25,8 @@ interface CommentBodyProps {
   permlink?: string;
   commentDepth: number;
   hideContent: boolean;
-  handleOnUserPress: (username?: any) => void;
-  handleOnPostPress?: (permlink?: any, author?: any) => void;
+  handleOnUserPress?: (username?: string) => void;
+  handleOnPostPress?: (permlink?: string, author?: string) => void;
   handleVideoPress: () => void;
   handleYoutubePress: () => void;
   handleImagePress: () => void;

--- a/src/components/postElements/body/view/postBodyView.tsx
+++ b/src/components/postElements/body/view/postBodyView.tsx
@@ -112,7 +112,7 @@ const PostBody = ({
             intl,
             url: link,
             onConfirm: () =>
-              (navigation as any).navigate({
+              navigation.navigate({
                 name: ROUTES.SCREENS.DAPP_BROWSER,
                 params: {
                   url: link,
@@ -149,7 +149,7 @@ const PostBody = ({
     if (tag) {
       const name = isCommunity(tag) ? ROUTES.SCREENS.COMMUNITY : ROUTES.SCREENS.TAG_RESULT;
       const key = `${filter}/${tag}`;
-      (navigation as any).navigate({
+      navigation.navigate({
         name,
         params: {
           tag,
@@ -175,7 +175,7 @@ const PostBody = ({
         permlink = permlink.substring(0, queryIndex);
       }
 
-      (navigation as any).navigate({
+      navigation.navigate({
         name: ROUTES.SCREENS.POST,
         params: {
           author,

--- a/src/components/postHtmlRenderer/postInteractionHandler.tsx
+++ b/src/components/postHtmlRenderer/postInteractionHandler.tsx
@@ -61,7 +61,7 @@ export const PostHtmlInteractionHandler = forwardRef(
         // them as external; open the wave thread natively instead of the link sheet
         const wavesLink = parseWavesUrl(url);
         if (wavesLink) {
-          (navigation as any).navigate({
+          navigation.navigate({
             name: ROUTES.SCREENS.POST,
             params: {
               author: wavesLink.author,
@@ -127,7 +127,7 @@ export const PostHtmlInteractionHandler = forwardRef(
               intl,
               url: link,
               onConfirm: () =>
-                (navigation as any).navigate({
+                navigation.navigate({
                   name: ROUTES.SCREENS.DAPP_BROWSER,
                   params: {
                     url: link,

--- a/src/components/postOptionsModal/container/postOptionsModal.tsx
+++ b/src/components/postOptionsModal/container/postOptionsModal.tsx
@@ -806,7 +806,7 @@ const PostOptionsModal = (
 
   const _redirectToReply = () => {
     if (isLoggedIn) {
-      (navigation as any).navigate({
+      navigation.navigate({
         name: ROUTES.SCREENS.EDITOR,
         key: `editor_post_${content.permlink}`,
         params: {
@@ -825,7 +825,7 @@ const PostOptionsModal = (
     };
 
     if (isPinCodeOpen) {
-      (navigation as any).navigate({
+      navigation.navigate({
         name: ROUTES.SCREENS.PINCODE,
         params: {
           navigateTo: name,
@@ -833,7 +833,7 @@ const PostOptionsModal = (
         },
       });
     } else if (isLoggedIn) {
-      (navigation as any).navigate({
+      navigation.navigate({
         name,
         params,
       });
@@ -953,7 +953,7 @@ const PostOptionsModal = (
         _muteCommunityPost({ unmute: true });
         break;
       case 'edit-history':
-        (navigation as any).navigate({
+        navigation.navigate({
           name: ROUTES.SCREENS.EDIT_HISTORY,
           params: {
             author: content?.author || '',

--- a/src/components/postPoll/container/postPoll.tsx
+++ b/src/components/postPoll/container/postPoll.tsx
@@ -144,7 +144,7 @@ export const PostPoll = ({ author, permlink, metadata, initMode, compactView }: 
       .filter((item) => item.choices.includes(choiceNum))
       .map((voter) => ({ account: voter.name }));
 
-    (navigation as any).navigate(ROUTES.MODALS.ACCOUNT_LIST, {
+    navigation.navigate(ROUTES.MODALS.ACCOUNT_LIST, {
       title: intl.formatMessage({ id: 'post_poll.voters' }),
       users: _filteredVoters,
     });

--- a/src/components/postsList/container/postsListContainer.tsx
+++ b/src/components/postsList/container/postsListContainer.tsx
@@ -200,7 +200,7 @@ const postsListContainer = (
           break;
 
         case PostCardActionIds.NAVIGATE:
-          (navigation as any).navigate(payload);
+          navigation.navigate(payload);
           break;
 
         case PostCardActionIds.REPLY:

--- a/src/components/profile/profileView.tsx
+++ b/src/components/profile/profileView.tsx
@@ -285,16 +285,8 @@ class ProfileView extends PureComponent<any, any> {
   };
 
   _renderTabs = () => {
-    const {
-      about,
-      changeForceLoadPostState,
-      forceLoadPost,
-      username,
-      isOwnProfile,
-      profileTabs,
-      ownProfileTabs,
-      deepLinkFilter,
-    } = this.props;
+    const { about, username, isOwnProfile, profileTabs, ownProfileTabs, deepLinkFilter } =
+      this.props;
 
     const pageType = isOwnProfile ? 'ownProfile' : 'profile';
     const tabs = (isOwnProfile ? ownProfileTabs : profileTabs) || getDefaultFilters(pageType);
@@ -342,8 +334,6 @@ class ProfileView extends PureComponent<any, any> {
           // stationary touch or tiny drag) only fed the oscillation. onScrollEndDrag drives
           // collapse instead.
           handleOnScroll={this._handleOnScroll}
-          forceLoadPosts={forceLoadPost}
-          changeForceLoadPostState={changeForceLoadPostState}
           isFeedScreen={false}
           tabContentOverrides={tabContentOverrides}
           onChangeTab={this._onTabChange}

--- a/src/components/tabbedPosts/types/tabbedPosts.types.ts
+++ b/src/components/tabbedPosts/types/tabbedPosts.types.ts
@@ -11,9 +11,7 @@ export interface TabbedPostsProps {
   pageType: 'main' | 'community' | 'profile' | 'ownProfile';
   // absent on profile pages; the container falls back to ''
   tag?: string;
-  // optional: the feed screen omits both; the tab content guards the callback
-  forceLoadPosts?: boolean;
-  changeForceLoadPostState?: (value: boolean) => void;
+  // optional: the feed screen omits it; the tab content guards the callback
   onChangeTab?: (event: any) => void;
   tabContentOverrides?: Map<number, any>;
   pinnedPermlink?: string;
@@ -28,7 +26,6 @@ export interface PostsTabContentProps {
   pageType: 'main' | 'profile' | 'ownProfile' | 'community';
   feedUsername?: string;
   tag: string;
-  forceLoadPosts?: boolean;
   filterScrollRequest?: string | null;
   pinnedPermlink?: string;
   onScrollRequestProcessed: () => void;

--- a/src/components/tabbedPosts/view/listEmptyView.tsx
+++ b/src/components/tabbedPosts/view/listEmptyView.tsx
@@ -198,7 +198,7 @@ const TabEmptyView = ({ filterKey, isNoPost }: TabEmptyViewProps) => {
     if (prevLoggedInUsers && prevLoggedInUsers?.length > 0) {
       SheetManager.show(SheetNames.ACCOUNTS_SHEET);
     } else {
-      (navigation as any).navigate(ROUTES.SCREENS.LOGIN);
+      navigation.navigate(ROUTES.SCREENS.LOGIN);
     }
   };
 
@@ -246,7 +246,7 @@ const TabEmptyView = ({ filterKey, isNoPost }: TabEmptyViewProps) => {
                 isLoadingRightAction={followingUsers[item._id]?.loading}
                 onPressRightText={_handleFollowUserButtonPress}
                 handleOnPress={(username: any) =>
-                  (navigation as any).navigate({
+                  navigation.navigate({
                     name: ROUTES.SCREENS.PROFILE,
                     params: {
                       username,
@@ -281,7 +281,7 @@ const TabEmptyView = ({ filterKey, isNoPost }: TabEmptyViewProps) => {
                 isNsfw={item.is_nsfw}
                 name={item.name}
                 handleOnPress={(name: any) =>
-                  (navigation as any).navigate({
+                  navigation.navigate({
                     name: ROUTES.SCREENS.COMMUNITY,
                     params: {
                       tag: name,

--- a/src/components/tabbedPosts/view/postsTabContent.tsx
+++ b/src/components/tabbedPosts/view/postsTabContent.tsx
@@ -24,7 +24,6 @@ const PostsTabContent = ({
   isFeedScreen,
   isInitialTab,
   pageType,
-  forceLoadPosts,
   filterScrollRequest,
   feedUsername,
   tag,
@@ -84,10 +83,10 @@ const PostsTabContent = ({
   }, [tag, feedUsername]);
 
   useEffect(() => {
-    if (isConnected && (username !== sessionUser || forceLoadPosts)) {
+    if (isConnected && username !== sessionUser) {
       _initContent(username);
     }
-  }, [username, forceLoadPosts, isConnected, sessionUser]);
+  }, [username, isConnected, sessionUser]);
 
   useEffect(() => {
     if (filterScrollRequest && filterScrollRequest === filterKey) {

--- a/src/components/votersDisplay/view/votersDisplayView.tsx
+++ b/src/components/votersDisplay/view/votersDisplayView.tsx
@@ -18,7 +18,7 @@ const VotersDisplayView = ({ votes, createdAt = '2010-01-01T00:00:00' }: any) =>
   const navigation = useNavigation();
 
   const _handleOnUserPress = (username: any) => {
-    (navigation as any).navigate({
+    navigation.navigate({
       name: ROUTES.SCREENS.PROFILE,
       params: {
         username,

--- a/src/components/walletDetails/container/walletDetailsContainer.tsx
+++ b/src/components/walletDetails/container/walletDetailsContainer.tsx
@@ -50,7 +50,7 @@ class WalletContainer extends PureComponent<any, any> {
     }
 
     if (isPinCodeOpen) {
-      (navigation as any).navigate({
+      navigation.navigate({
         name: ROUTES.SCREENS.PINCODE,
         params: {
           navigateTo: ROUTES.SCREENS.TRANSFER,
@@ -58,7 +58,7 @@ class WalletContainer extends PureComponent<any, any> {
         },
       });
     } else {
-      (navigation as any).navigate({
+      navigation.navigate({
         name: ROUTES.SCREENS.TRANSFER,
         params: { transferType, fundType, balance },
       });

--- a/src/components/walletHeader/view/walletHeaderView.tsx
+++ b/src/components/walletHeader/view/walletHeaderView.tsx
@@ -100,7 +100,7 @@ const WalletHeaderView = ({
             onPress={() =>
               unclaimedBalance
                 ? claim()
-                : (navigation as any).navigate(ROUTES.SCREENS.BOOST, {
+                : navigation.navigate(ROUTES.SCREENS.BOOST, {
                     username: currentAccount?.name,
                   })
             }

--- a/src/containers/accountListContainer.ts
+++ b/src/containers/accountListContainer.ts
@@ -87,7 +87,7 @@ const AccountListContainer = ({ data, children }: any) => {
   };
 
   const _handleOnUserPress = (username: any) => {
-    (navigation as any).navigate({
+    navigation.navigate({
       name: ROUTES.SCREENS.PROFILE,
       params: {
         username,

--- a/src/containers/pointsContainer.ts
+++ b/src/containers/pointsContainer.ts
@@ -25,6 +25,7 @@ import { resolvePointType } from '../constants/options/points';
 
 // Constants
 import ROUTES from '../constants/routeNames';
+import type { RouteName } from '../navigation/types';
 
 // Utils
 import { groomingPointsTransactionData, getPointsEstimate } from '../utils/wallet';
@@ -140,7 +141,7 @@ const PointsContainer = ({
   // Component Functions
 
   const _handleOnDropdownSelected = (index: any) => {
-    let navigateTo;
+    let navigateTo: RouteName | undefined;
     let navigateParams;
 
     if (index === 'dropdown_transfer') {
@@ -171,7 +172,7 @@ const PointsContainer = ({
     }
 
     if (isPinCodeOpen) {
-      (navigation as any).navigate({
+      navigation.navigate({
         name: ROUTES.SCREENS.PINCODE,
         params: {
           navigateTo,
@@ -179,10 +180,7 @@ const PointsContainer = ({
         },
       });
     } else {
-      (navigation as any).navigate({
-        name: navigateTo,
-        params: navigateParams,
-      });
+      navigation.navigate(navigateTo as any, navigateParams);
     }
   };
 

--- a/src/containers/profileContainer.tsx
+++ b/src/containers/profileContainer.tsx
@@ -67,7 +67,6 @@ class ProfileContainer extends Component<any, any> {
     this.state = {
       comments: [],
       follows: {},
-      forceLoadPost: false,
       isFavorite: false,
       isFollowing: false,
       isMuted: false,
@@ -561,10 +560,6 @@ class ProfileContainer extends Component<any, any> {
     }
   };
 
-  _changeForceLoadPostState = (value: any) => {
-    this.setState({ forceLoadPost: value });
-  };
-
   _handleOnPressProfileEdit = () => {
     const { navigation, currentAccount } = this.props;
 
@@ -593,7 +588,6 @@ class ProfileContainer extends Component<any, any> {
       comments,
       error,
       follows,
-      forceLoadPost,
       isFavorite,
       isFollowing,
       isMuted,
@@ -625,7 +619,6 @@ class ProfileContainer extends Component<any, any> {
       children({
         about: get(user, 'profile', {}),
         activePage,
-        changeForceLoadPostState: this._changeForceLoadPostState,
         comments,
         currency,
         currencyRate,
@@ -634,7 +627,6 @@ class ProfileContainer extends Component<any, any> {
         resourceCredits,
         error,
         follows,
-        forceLoadPost,
         getReplies: this._getReplies,
         handleFollowUnfollowUser: this._handleFollowUnfollowUser,
         handleMuteUnmuteUser: this._handleMuteUnmuteUser,

--- a/src/hooks/useActiveKeyOperation.ts
+++ b/src/hooks/useActiveKeyOperation.ts
@@ -113,7 +113,7 @@ export const useActiveKeyOperation = () => {
             // Encode operation for HiveSigner hot signing
             const encodedUri = hiveuri.encodeOps(operations);
 
-            (navigation as any).navigate(ROUTES.MODALS.HIVE_SIGNER, {
+            navigation.navigate(ROUTES.MODALS.HIVE_SIGNER, {
               hiveuri: encodedUri,
               opsArray: operations,
               onSuccess: () => {

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -1,0 +1,26 @@
+import ROUTES from '../constants/routeNames';
+
+type ValueOf<T> = T[keyof T];
+
+/** Every navigable route name in the app, derived from the ROUTES constants. */
+export type RouteName =
+  | ValueOf<typeof ROUTES.SCREENS>
+  | ValueOf<typeof ROUTES.MODALS>
+  | ValueOf<typeof ROUTES.DRAWER>
+  | ValueOf<typeof ROUTES.TABBAR>
+  | ValueOf<typeof ROUTES.STACK>;
+
+/**
+ * Route names are checked; params stay any until each screen's contract is
+ * typed (#3445). Registered globally so every useNavigation() call is typed
+ * without generics at the call sites.
+ */
+export type AppParamList = Record<RouteName, any>;
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace ReactNavigation {
+    // eslint-disable-next-line @typescript-eslint/no-empty-interface
+    interface RootParamList extends AppParamList {}
+  }
+}

--- a/src/screens/aiImageGenerator/screen/aiImageGeneratorScreen.tsx
+++ b/src/screens/aiImageGenerator/screen/aiImageGeneratorScreen.tsx
@@ -307,7 +307,6 @@ const AiImageGeneratorScreen = () => {
         style={styles.generateAgainButton}
         onPress={_handleGenerateAgain}
         text={intl.formatMessage({ id: 'ai_image_generator.generate_again' })}
-        isTransparent
       />
     </View>
   );

--- a/src/screens/assetDetails/children/delegationsModal.tsx
+++ b/src/screens/assetDetails/children/delegationsModal.tsx
@@ -172,7 +172,7 @@ export const DelegationsModal = forwardRef(({}, ref) => {
   };
 
   const _handleOnUserPress = (username: string) => {
-    (navigation as any).navigate({
+    navigation.navigate({
       name: ROUTES.SCREENS.PROFILE,
       params: {
         username,
@@ -185,7 +185,7 @@ export const DelegationsModal = forwardRef(({}, ref) => {
   const _handleOnPressUpdate = (username: string) => {
     if (mode === MODES.DELEGATEED) {
       console.log('delegate HP!');
-      (navigation as any).navigate({
+      navigation.navigate({
         name: ROUTES.SCREENS.TRANSFER,
         params: {
           transferType: TransferTypes.DELEGATE_VESTING_SHARES,

--- a/src/screens/assetDetails/children/recurrentTransfersModal.tsx
+++ b/src/screens/assetDetails/children/recurrentTransfersModal.tsx
@@ -38,7 +38,7 @@ export const RecurrentTransfersModal = forwardRef(
     }));
 
     const _handleOnUserPress = (username: string) => {
-      (navigation as any).navigate({
+      navigation.navigate({
         name: ROUTES.SCREENS.PROFILE,
         params: {
           username,

--- a/src/screens/bookmarks/container/bookmarksContainer.tsx
+++ b/src/screens/bookmarks/container/bookmarksContainer.tsx
@@ -58,7 +58,7 @@ const BookmarksContainer = ({ currentAccount, intl: _intl, navigation, route }: 
   };
 
   const _handleOnFavoritePress = (username: any) => {
-    (navigation as any).navigate({
+    navigation.navigate({
       name: ROUTES.SCREENS.PROFILE,
       params: {
         username,
@@ -69,7 +69,7 @@ const BookmarksContainer = ({ currentAccount, intl: _intl, navigation, route }: 
 
   const _handleOnBookmarkPress = (permlink: any, author: any) => {
     if (permlink && author) {
-      (navigation as any).navigate({
+      navigation.navigate({
         name: ROUTES.SCREENS.POST,
         params: {
           permlink,

--- a/src/screens/chats/container/chatThreadContainer.tsx
+++ b/src/screens/chats/container/chatThreadContainer.tsx
@@ -2167,7 +2167,7 @@ export const ChatThreadContainer: React.FC<ChatThreadContainerProps> = ({
         {showDmWarning && (
           <DmWarningBanner
             onDismiss={_handleDismissDmWarning}
-            onSettingsPress={() => (navigation as any).navigate(ROUTES.SCREENS.SETTINGS)}
+            onSettingsPress={() => navigation.navigate(ROUTES.SCREENS.SETTINGS)}
           />
         )}
         <ThreadMessageList

--- a/src/screens/chats/container/chatsContainer.tsx
+++ b/src/screens/chats/container/chatsContainer.tsx
@@ -610,19 +610,16 @@ const ChatsContainer = () => {
         // Refresh global badge to reflect the mark-as-viewed
         _refreshGlobalUnreadChatCount();
 
-        (navigation as any).navigate(
-          ROUTES.SCREENS.CHAT_THREAD as never,
-          {
-            channelId: joinedId,
-            channelName: mergedChannel.display_name || mergedChannel.name || channel.name,
-            channelDescription: mergedChannel.header || mergedChannel.purpose,
-            communityIdentifier,
-            bootstrapResult,
-            userLookup,
-            lastViewedAt: mergedChannel.last_viewed_at || mergedChannel.last_view_at,
-            channelType: mergedChannel.type || channel.type,
-          } as never,
-        );
+        navigation.navigate(ROUTES.SCREENS.CHAT_THREAD, {
+          channelId: joinedId,
+          channelName: mergedChannel.display_name || mergedChannel.name || channel.name,
+          channelDescription: mergedChannel.header || mergedChannel.purpose,
+          communityIdentifier,
+          bootstrapResult,
+          userLookup,
+          lastViewedAt: mergedChannel.last_viewed_at || mergedChannel.last_view_at,
+          channelType: mergedChannel.type || channel.type,
+        });
       } catch (err: any) {
         setSearchError(err?.message || 'Unable to join channel');
       }
@@ -649,19 +646,16 @@ const ChatsContainer = () => {
         );
         const communityIdentifier = safeExtractCommunityIdentifier(resolvedChannel);
 
-        (navigation as any).navigate(
-          ROUTES.SCREENS.CHAT_THREAD as never,
-          {
-            channelId,
-            channelName: getHiveUsernameFromMattermostUser(user) || user.username || user.nickname,
-            channelDescription: resolvedChannel.header || resolvedChannel.purpose,
-            communityIdentifier,
-            bootstrapResult,
-            userLookup,
-            lastViewedAt: resolvedChannel.last_viewed_at || resolvedChannel.last_view_at,
-            channelType: 'D',
-          } as never,
-        );
+        navigation.navigate(ROUTES.SCREENS.CHAT_THREAD, {
+          channelId,
+          channelName: getHiveUsernameFromMattermostUser(user) || user.username || user.nickname,
+          channelDescription: resolvedChannel.header || resolvedChannel.purpose,
+          communityIdentifier,
+          bootstrapResult,
+          userLookup,
+          lastViewedAt: resolvedChannel.last_viewed_at || resolvedChannel.last_view_at,
+          channelType: 'D',
+        });
       } catch (err: any) {
         setSearchError(err?.message || 'Unable to start chat');
       }
@@ -877,24 +871,21 @@ const ChatsContainer = () => {
           const description = item.header || item.purpose || '';
           const communityIdentifier = safeExtractCommunityIdentifier(item);
 
-          (navigation as any).navigate(
-            ROUTES.SCREENS.CHAT_THREAD as never,
-            {
-              channelId,
-              channelName: item.display_name || item.name || channelId,
-              channelDescription: description,
-              communityIdentifier,
-              bootstrapResult,
-              userLookup,
-              lastViewedAt:
-                item?.last_viewed_at ||
-                item?.last_view_at ||
-                item?.lastViewedAt ||
-                item?.lastViewed ||
-                null,
-              channelType: item.type,
-            } as never,
-          );
+          navigation.navigate(ROUTES.SCREENS.CHAT_THREAD, {
+            channelId,
+            channelName: item.display_name || item.name || channelId,
+            channelDescription: description,
+            communityIdentifier,
+            bootstrapResult,
+            userLookup,
+            lastViewedAt:
+              item?.last_viewed_at ||
+              item?.last_view_at ||
+              item?.lastViewedAt ||
+              item?.lastViewed ||
+              null,
+            channelType: item.type,
+          });
         }}
         onShowOptions={_confirmChannelOptions}
       />

--- a/src/screens/communities/container/communitiesContainer.ts
+++ b/src/screens/communities/container/communitiesContainer.ts
@@ -204,7 +204,7 @@ const CommunitiesContainer = ({ children }: any) => {
   };
   // Component Functions
   const _handleOnPress = (name: any) => {
-    (navigation as any).navigate({
+    navigation.navigate({
       name: ROUTES.SCREENS.COMMUNITY,
       params: {
         tag: name,

--- a/src/screens/community/container/communityContainer.ts
+++ b/src/screens/community/container/communityContainer.ts
@@ -79,7 +79,7 @@ const CommunityContainer = ({ tag, children, currentAccount, isLoggedIn }: any) 
   };
 
   const _handleNewPostButtonPress = () => {
-    (navigation as any).navigate({
+    navigation.navigate({
       name: ROUTES.SCREENS.EDITOR,
       key: 'editor_community_post',
       params: {

--- a/src/screens/community/screen/communityScreen.tsx
+++ b/src/screens/community/screen/communityScreen.tsx
@@ -80,21 +80,21 @@ const CommunityScreen = ({ route }: any) => {
 
       switch (result?.action) {
         case 'members':
-          (navigation as any).navigate({
+          navigation.navigate({
             name: ROUTES.SCREENS.COMMUNITY_MEMBERS,
             key: `community_members_${tag}`,
             params,
           });
           break;
         case 'settings':
-          (navigation as any).navigate({
+          navigation.navigate({
             name: ROUTES.SCREENS.COMMUNITY_SETTINGS,
             key: `community_settings_${tag}`,
             params,
           });
           break;
         case 'activities':
-          (navigation as any).navigate({
+          navigation.navigate({
             name: ROUTES.SCREENS.COMMUNITY_ACTIVITIES,
             key: `community_activities_${tag}`,
             params,

--- a/src/screens/communityActivities/screen/communityActivitiesScreen.tsx
+++ b/src/screens/communityActivities/screen/communityActivitiesScreen.tsx
@@ -50,14 +50,14 @@ const CommunityActivitiesScreen = ({ route }: any) => {
   };
 
   const _openAccount = (username: string) =>
-    (navigation as any).navigate({
+    navigation.navigate({
       name: ROUTES.SCREENS.PROFILE,
       key: username,
       params: { username },
     });
 
   const _openPost = (author: string, permlink: string) =>
-    (navigation as any).navigate({
+    navigation.navigate({
       name: ROUTES.SCREENS.POST,
       key: `${author}/${permlink}`,
       params: { author, permlink },

--- a/src/screens/communityMembers/screen/communityMembersScreen.tsx
+++ b/src/screens/communityMembers/screen/communityMembersScreen.tsx
@@ -137,7 +137,7 @@ const CommunityMembersScreen = ({ route }: any) => {
   };
 
   const _handleOnUserPress = (username: string) => {
-    (navigation as any).navigate({
+    navigation.navigate({
       name: ROUTES.SCREENS.PROFILE,
       key: username,
       params: { username },

--- a/src/screens/dappBrowser/components/signConfirmSheet.tsx
+++ b/src/screens/dappBrowser/components/signConfirmSheet.tsx
@@ -210,7 +210,6 @@ const SignConfirmSheet: React.FC<SheetProps<'sign_confirm'>> = ({ sheetId, paylo
             style={styles.cancelButton}
             onPress={() => _close(false)}
             text={intl.formatMessage({ id: 'alert.cancel', defaultMessage: 'Cancel' })}
-            isTransparent
           />
         </View>
       </View>

--- a/src/screens/drafts/container/draftsContainer.tsx
+++ b/src/screens/drafts/container/draftsContainer.tsx
@@ -88,7 +88,7 @@ const DraftsContainer = ({ currentAccount, navigation, route }: any) => {
   };
 
   const _editDraft = (id: string) => {
-    (navigation as any).navigate({
+    navigation.navigate({
       name: ROUTES.SCREENS.EDITOR,
       key: `editor_draft_${id}`,
       params: {
@@ -99,7 +99,7 @@ const DraftsContainer = ({ currentAccount, navigation, route }: any) => {
 
   // opens editor hydrated from the template as a new post instead of editing the template
   const _applyTemplate = (template: any) => {
-    (navigation as any).navigate({
+    navigation.navigate({
       name: ROUTES.SCREENS.EDITOR,
       key: `editor_template_${template._id}`,
       params: {

--- a/src/screens/feed/screen/feedScreen.tsx
+++ b/src/screens/feed/screen/feedScreen.tsx
@@ -94,7 +94,7 @@ const FeedScreen = () => {
       return;
     }
 
-    (navigation as any).navigate(ROUTES.SCREENS.EDITOR, { key: 'editor_post' });
+    navigation.navigate(ROUTES.SCREENS.EDITOR, { key: 'editor_post' });
   };
 
   return (

--- a/src/screens/login/container/loginContainer.tsx
+++ b/src/screens/login/container/loginContainer.tsx
@@ -139,13 +139,13 @@ class LoginContainer extends PureComponent<any, any> {
 
           if (isPinCodeOpen) {
             dispatch(
-              (navigation as any).navigate({
+              navigation.navigate({
                 accessToken: result.accessToken,
                 navigateTo: ROUTES.DRAWER.MAIN,
               }),
             );
           } else {
-            (navigation as any).navigate({
+            navigation.navigate({
               name: ROUTES.DRAWER.MAIN,
               params: { accessToken: result.accessToken },
             });
@@ -208,14 +208,14 @@ class LoginContainer extends PureComponent<any, any> {
           dispatch(setPinCode(encryptedPin));
 
           if (isPinCodeOpen) {
-            (navigation as any).navigate({
+            navigation.navigate({
               name: ROUTES.SCREENS.PINCODE,
               params: {
                 navigateTo: ROUTES.DRAWER.MAIN,
               },
             });
           } else {
-            (navigation as any).navigate({
+            navigation.navigate({
               name: ROUTES.DRAWER.MAIN,
             });
           }

--- a/src/screens/login/container/loginContainer.tsx
+++ b/src/screens/login/container/loginContainer.tsx
@@ -138,12 +138,13 @@ class LoginContainer extends PureComponent<any, any> {
           dispatch(loginAction(true));
 
           if (isPinCodeOpen) {
-            dispatch(
-              navigation.navigate({
+            navigation.navigate({
+              name: ROUTES.SCREENS.PINCODE,
+              params: {
                 accessToken: result.accessToken,
                 navigateTo: ROUTES.DRAWER.MAIN,
-              }),
-            );
+              },
+            });
           } else {
             navigation.navigate({
               name: ROUTES.DRAWER.MAIN,

--- a/src/screens/login/screen/loginScreen.tsx
+++ b/src/screens/login/screen/loginScreen.tsx
@@ -144,7 +144,7 @@ const LoginScreen = ({
           id: 'login.signup',
         })}
         onBackPress={() => {
-          (navigation as any).navigate({
+          navigation.navigate({
             name: ROUTES.DRAWER.MAIN,
           });
         }}

--- a/src/screens/notification/container/notificationContainer.tsx
+++ b/src/screens/notification/container/notificationContainer.tsx
@@ -128,7 +128,7 @@ const NotificationContainer = ({ navigation }: any) => {
     }
 
     if (routeName) {
-      (navigation as any).navigate({
+      navigation.navigate({
         name: routeName,
         params,
         key,

--- a/src/screens/post/screen/postScreen.tsx
+++ b/src/screens/post/screen/postScreen.tsx
@@ -99,7 +99,7 @@ const PostScreen = ({ route }: any) => {
     if (getPostQuery.data) {
       const isReply = parentAuthor;
 
-      (navigation as any).navigate({
+      navigation.navigate({
         name: ROUTES.SCREENS.EDITOR,
         key: `editor_post_${permlink}`,
         params: {

--- a/src/screens/profile/screen/profileScreen.tsx
+++ b/src/screens/profile/screen/profileScreen.tsx
@@ -10,14 +10,12 @@ const ProfileScreen = ({ route }: any) => (
       about,
       activePage,
       avatar,
-      changeForceLoadPostState,
       comments,
       currency,
       currencyRate,
       currencySymbol,
       error,
       follows,
-      forceLoadPost,
       getReplies,
       handleFollowUnfollowUser,
       handleMessage,
@@ -48,14 +46,12 @@ const ProfileScreen = ({ route }: any) => (
         about={about}
         activePage={activePage}
         avatar={avatar}
-        changeForceLoadPostState={changeForceLoadPostState}
         comments={comments}
         currency={currency}
         currencyRate={currencyRate}
         currencySymbol={currencySymbol}
         error={error}
         follows={follows}
-        forceLoadPost={forceLoadPost}
         getReplies={getReplies}
         handleFollowUnfollowUser={handleFollowUnfollowUser}
         handleMessage={handleMessage}

--- a/src/screens/register/children/registerAccountModal.tsx
+++ b/src/screens/register/children/registerAccountModal.tsx
@@ -58,7 +58,7 @@ export const RegisterAccountModal = forwardRef(({ username, email, refUsername }
   }));
 
   const _onContinuePress = () => {
-    (navigation as any).navigate(ROUTES.DRAWER.MAIN);
+    navigation.navigate(ROUTES.DRAWER.MAIN);
     openInbox();
   };
 

--- a/src/screens/register/registerScreen.tsx
+++ b/src/screens/register/registerScreen.tsx
@@ -174,7 +174,7 @@ const RegisterScreen = ({ navigation, route }: any) => {
           id: 'login.login',
         })}
         onBackPress={() => {
-          (navigation as any).navigate({
+          navigation.navigate({
             name: ROUTES.DRAWER.MAIN,
           });
         }}

--- a/src/screens/searchResult/screen/tabs/best/container/postsResultsContainer.tsx
+++ b/src/screens/searchResult/screen/tabs/best/container/postsResultsContainer.tsx
@@ -167,7 +167,7 @@ const PostsResultsContainer = ({ children, searchValue, filters = EMPTY_SEARCH_F
     const itemPermlink = get(item, 'permlink');
 
     postsCacherPrimer.cachePost(item);
-    (navigation as any).navigate({
+    navigation.navigate({
       name: ROUTES.SCREENS.POST,
       params: {
         author: itemAuthor,

--- a/src/screens/searchResult/screen/tabs/communities/container/communitiesResultsContainer.ts
+++ b/src/screens/searchResult/screen/tabs/communities/container/communitiesResultsContainer.ts
@@ -153,7 +153,7 @@ const CommunitiesResultsContainer = ({ children, searchValue }: any) => {
 
   // Component Functions
   const _handleOnPress = (name: any) => {
-    (navigation as any).navigate({
+    navigation.navigate({
       name: ROUTES.SCREENS.COMMUNITY,
       params: {
         tag: name,

--- a/src/screens/searchResult/screen/tabs/people/container/peopleResultsContainer.ts
+++ b/src/screens/searchResult/screen/tabs/people/container/peopleResultsContainer.ts
@@ -74,7 +74,7 @@ const PeopleResultsContainer = ({ children, searchValue }: any) => {
   // Component Functions
 
   const _handleOnPress = (item: any) => {
-    (navigation as any).navigate({
+    navigation.navigate({
       name: ROUTES.SCREENS.PROFILE,
       params: {
         username: item.name,

--- a/src/screens/searchResult/screen/tabs/topics/container/topicsResultsContainer.ts
+++ b/src/screens/searchResult/screen/tabs/topics/container/topicsResultsContainer.ts
@@ -66,7 +66,7 @@ const OtherResultContainer = ({ children, searchValue }: any) => {
   // Component Functions
 
   const _handleOnPress = (item: any) => {
-    (navigation as any).navigate({
+    navigation.navigate({
       name: ROUTES.SCREENS.TAG_RESULT,
       params: {
         tag: get(item, 'tag', ''),

--- a/src/screens/steem-connect/hiveSigner.tsx
+++ b/src/screens/steem-connect/hiveSigner.tsx
@@ -78,7 +78,7 @@ class HiveSigner extends PureComponent<any, any> {
               this._updatePrevLoggedInUsersList(result.username);
 
               if (isPinCodeOpen) {
-                (navigation as any).navigate({
+                navigation.navigate({
                   name: ROUTES.SCREENS.PINCODE,
                   params: {
                     accessToken: result.accessToken,
@@ -86,7 +86,7 @@ class HiveSigner extends PureComponent<any, any> {
                   },
                 });
               } else {
-                (navigation as any).navigate({
+                navigation.navigate({
                   name: ROUTES.DRAWER.MAIN,
                   params: { accessToken: result.accessToken },
                 });

--- a/src/screens/welcome/screen/WelcomeScreen.tsx
+++ b/src/screens/welcome/screen/WelcomeScreen.tsx
@@ -48,7 +48,7 @@ const WelcomeScreen = () => {
     dispatch(setLastAppVersion(appVersion));
     dispatch(setIsTermsAccepted(isConsentChecked));
 
-    (navigation as any).navigate(ROUTES.STACK.MAIN);
+    navigation.navigate(ROUTES.STACK.MAIN);
   };
 
   const _onCheckPress = (value: any, isCheck: any) => {
@@ -57,7 +57,7 @@ const WelcomeScreen = () => {
 
   const _onTermsPress = () => {
     const url = ECENCY_TERMS_URL;
-    (navigation as any).navigate({
+    navigation.navigate({
       name: ROUTES.SCREENS.WEB_BROWSER,
       params: {
         url,


### PR DESCRIPTION
Closes #3445

First tightening pass after the burn-down, in the review's priority order:

- **Typed navigation**: `src/navigation/types.ts` derives a `RouteName` union from the ROUTES constants and registers a global `RootParamList` via React Navigation declaration merging. Every `useNavigation()` is now typed without call-site generics; route names are compile-checked (params stay `any` until per-screen contracts land). **78 of 79 `(navigation as any)` casts removed**; survivors are one drawer-method call and one genuinely dynamic union target in pointsContainer. Three legacy `as never` casts in chatsContainer fell out too.
- **Real Props/State interfaces** for the primitive class components: Icon, IconButton, MainButton, TextButton, with the deferred nits: tabbar `_onPress(index, disabled?)` typed and uncast, `value` gets a real segment-width default instead of `!`, the indicator parameter literally named `undefined` renamed, placeholders use `Math.floor(ratio)`, BackHeaderProps declares `isNewPost`/`handleOnBackPress`. Press-handler props typed `(event?: any) => void` since the components invoke them without arguments.
- **Real bug found by the new interfaces**: dictationModal disabled its three MainButtons via `isDisabled=`, but the prop is `isDisable`, so the buttons were never actually disabled while dictation was busy. Now wired correctly. Worth adding to the device-pass list since it activates disabling in an in-flight feature.
- **Second real bug (review follow-up, commit 9de7752e5e)**: the `isPinCodeOpen` branch of deep-link code login dispatched the void result of a navigate call that had no route name, so react-navigation threw and the flow showed a failure alert after a successful login (broken since 2022). Now routes through the PinCode screen with `navigateTo` in params, mirroring the hiveSigner flow. Device-pass item: deep-link login with PIN enabled.
- **Dead props removed**: `isCircle` (numericKeyboard) and `isTransparent` (aiImageGenerator, signConfirmSheet); neither component ever read them.
- **Inert plumbing deleted end to end**: `forceLoadPost`/`forceLoadPosts`/`changeForceLoadPostState` across profileContainer, profileScreen, profileView, TabbedPosts types and postsTabContent, per the #3450 review verification that nothing ever set it and nothing consumed the setter.

Zero typecheck errors maintained; all 736 jest tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navigation reliability across profiles, posts, communities, chats, search, login, wallets, and settings.
  * Corrected placeholder item counts for more consistent loading layouts.
  * Fixed disabled-state handling for dictation actions.
  * Improved back navigation and unsupported tab behavior.

* **Improvements**
  * Streamlined profile post loading to avoid unnecessary refreshes.
  * Standardized button and icon appearance across multiple screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
