### PR TITLE
Fix collapsible card clamped to zero height on first layout

### DIFF
--- a/src/components/collapsibleCard/view/collapsibleCardView.tsx
+++ b/src/components/collapsibleCard/view/collapsibleCardView.tsx
@@ -29,13 +29,18 @@ const CollapsibleCardView = (props: any) => {
   } = props;
 
   const [contentHeight, setContentHeight] = useState(0);
-  const animation = useSharedValue({ height: contentHeight });
+  // The height must stay unset until onLayout measures the natural content
+  // size: an initial 0 clamps the view, so measurement would always read 0
+  // and the card could never expand.
+  const animation = useSharedValue<{ height: number | undefined }>({ height: undefined });
   const animationStyle = useAnimatedStyle(() => {
-    return {
-      height: withTiming(animation.value.height, {
-        duration: 500,
-      }),
-    };
+    return animation.value.height === undefined
+      ? {}
+      : {
+          height: withTiming(animation.value.height, {
+            duration: 500,
+          }),
+        };
   });
 
   const [collapsed, setCollapsed] = useState(expanded || isExpanded || false);


### PR DESCRIPTION
Closes #3458

Regression from the typing pass (8027853cad): reordering the `contentHeight` declaration above `useSharedValue({ height: contentHeight })` changed the animated height's initial value from `undefined` (accidental, via loose-mode hoisting, but load-bearing) to `0`. The animated style clamped the card to zero height on first render, `onLayout` measured the clamped view as 0 and the card deadlocked collapsed. On the profile screen that hid the entire summary area (RC, VP, about) with no way to expand.

Fix: the shared value now starts with an explicit `undefined` height and the animated style applies no height until the first measurement, so the card lays out naturally once, captures its real height and the expand plus collapse-on-scroll cycle works against real values.

Affects every CollapsibleCard consumer (profile summary, settings cards, editor sections). Device pass: profile summary visible on load, collapses on scroll, re-expands; settings cards toggle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved collapsible card animations by preventing premature height transitions before the content size is measured.
  * Ensured the card height animates smoothly once content dimensions are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->