### PR TITLE
Localize alert error fallbacks instead of error.toString()

### DIFF
--- a/src/components/organisms/quickProfileModal/children/quickProfileContent.tsx
+++ b/src/components/organisms/quickProfileModal/children/quickProfileContent.tsx
@@ -12,6 +12,7 @@ import {
   checkFavoriteQueryOptions,
 } from '@ecency/sdk';
 import { useQueryClient } from '@tanstack/react-query';
+import { captureException } from '../../../../utils/sentryUtils';
 import { MainButton, StatsPanel } from '../../..';
 import {
   useAddFavouriteMutation,
@@ -160,6 +161,7 @@ export const QuickProfileContent = ({ username, onClose }: QuickProfileContentPr
       }
     } catch (error) {
       console.warn('Failed to fetch complete profile data', error);
+      captureException(error, (scope) => scope.setTag('context', 'quick-profile-fetch'));
       Alert.alert(
         intl.formatMessage({
           id: 'alert.fail',
@@ -210,6 +212,7 @@ export const QuickProfileContent = ({ username, onClose }: QuickProfileContentPr
       onError: (error: any) => {
         // Error toast is already dispatched by the mutation hook
         console.warn('Failed to perform favorite action', error);
+        captureException(error, (scope) => scope.setTag('context', 'quick-profile-favorite'));
         setIsLoading(false);
         Alert.alert(
           intl.formatMessage({

--- a/src/components/organisms/quickProfileModal/children/quickProfileContent.tsx
+++ b/src/components/organisms/quickProfileModal/children/quickProfileContent.tsx
@@ -164,7 +164,7 @@ export const QuickProfileContent = ({ username, onClose }: QuickProfileContentPr
         intl.formatMessage({
           id: 'alert.fail',
         }),
-        (error as any).message || (error as any).toString(),
+        (error as any).message || intl.formatMessage({ id: 'alert.unknow_error' }),
       );
     }
   };
@@ -215,7 +215,7 @@ export const QuickProfileContent = ({ username, onClose }: QuickProfileContentPr
           intl.formatMessage({
             id: 'alert.fail',
           }),
-          error.message || error.toString(),
+          error.message || intl.formatMessage({ id: 'alert.unknow_error' }),
         );
       },
     });

--- a/src/components/postOptionsModal/container/postOptionsModal.tsx
+++ b/src/components/postOptionsModal/container/postOptionsModal.tsx
@@ -384,7 +384,7 @@ const PostOptionsModal = (
           intl.formatMessage({
             id: 'alert.fail',
           }),
-          error.message || error.toString(),
+          error.message || intl.formatMessage({ id: 'alert.unknow_error' }),
         );
       }
     }

--- a/src/components/postOptionsModal/container/postOptionsModal.tsx
+++ b/src/components/postOptionsModal/container/postOptionsModal.tsx
@@ -17,6 +17,7 @@ import {
   useDeleteComment,
 } from '@ecency/sdk';
 import { postBodySummary } from '@ecency/render-helper';
+import { captureException } from '../../../utils/sentryUtils';
 import { useAuthContext } from '../../../providers/sdk';
 import {
   useReblogMutation,
@@ -380,6 +381,7 @@ const PostOptionsModal = (
         // when RC is not enough, offer boosting account
         dispatch(setRcOffer(true));
       } else {
+        captureException(error, (scope) => scope.setTag('context', 'post-options-action'));
         Alert.alert(
           intl.formatMessage({
             id: 'alert.fail',

--- a/src/components/uploadsGalleryModal/container/uploadsGalleryModal.tsx
+++ b/src/components/uploadsGalleryModal/container/uploadsGalleryModal.tsx
@@ -429,7 +429,7 @@ export const UploadsGalleryModal = forwardRef(
                 }),
               );
             } else {
-              errorMessages.add(error.message || error.toString());
+              errorMessages.add(error.message || intl.formatMessage({ id: 'alert.unknow_error' }));
             }
           });
 

--- a/src/components/uploadsGalleryModal/container/uploadsGalleryModal.tsx
+++ b/src/components/uploadsGalleryModal/container/uploadsGalleryModal.tsx
@@ -7,6 +7,7 @@ import { ImageManipulator, SaveFormat } from 'expo-image-manipulator';
 import { openSettings } from 'react-native-permissions';
 import { SheetManager } from 'react-native-actions-sheet';
 import * as Sentry from '@sentry/react-native';
+import { captureException } from '../../../utils/sentryUtils';
 import UploadsGalleryContent from '../children/uploadsGalleryContent';
 
 import { useAppSelector } from '../../../hooks';
@@ -429,6 +430,7 @@ export const UploadsGalleryModal = forwardRef(
                 }),
               );
             } else {
+              captureException(error, (scope) => scope.setTag('context', 'media-upload-batch'));
               errorMessages.add(error.message || intl.formatMessage({ id: 'alert.unknow_error' }));
             }
           });

--- a/src/containers/profileContainer.tsx
+++ b/src/containers/profileContainer.tsx
@@ -297,7 +297,7 @@ class ProfileContainer extends Component<any, any> {
               intl.formatMessage({
                 id: 'alert.fail',
               }),
-              (error as any).message || (error as any).toString(),
+              (error as any).message || intl.formatMessage({ id: 'alert.unknow_error' }),
             ),
         );
       }
@@ -388,7 +388,7 @@ class ProfileContainer extends Component<any, any> {
         intl.formatMessage({
           id: 'alert.fail',
         }),
-        (error as any).message || (error as any).toString(),
+        (error as any).message || intl.formatMessage({ id: 'alert.unknow_error' }),
       );
     }
   };
@@ -485,7 +485,7 @@ class ProfileContainer extends Component<any, any> {
           intl.formatMessage({
             id: 'alert.fail',
           }),
-          (error as any).message || (error as any).toString(),
+          (error as any).message || intl.formatMessage({ id: 'alert.unknow_error' }),
         );
       });
   };

--- a/src/containers/profileContainer.tsx
+++ b/src/containers/profileContainer.tsx
@@ -15,6 +15,7 @@ import {
   getAccountRcQueryOptions,
   checkFavoriteQueryOptions,
 } from '@ecency/sdk';
+import { captureException } from '../utils/sentryUtils';
 import {
   selectCurrentAccount,
   selectIsLoggedIn,
@@ -288,6 +289,7 @@ class ProfileContainer extends Component<any, any> {
         dispatch(setRcOffer(true));
       } else {
         // when other errors
+        captureException(error, (scope) => scope.setTag('context', 'profile-action'));
         this.setState(
           {
             error,
@@ -383,6 +385,7 @@ class ProfileContainer extends Component<any, any> {
       }
     } catch (error) {
       console.warn('Failed to fetch complete profile data', error);
+      captureException(error, (scope) => scope.setTag('context', 'profile-fetch'));
       this.setState({ isProfileLoading: false, isReady: true });
       Alert.alert(
         intl.formatMessage({
@@ -480,6 +483,7 @@ class ProfileContainer extends Component<any, any> {
       })
       .catch((error: any) => {
         console.warn('Failed to perform favorite action');
+        captureException(error, (scope) => scope.setTag('context', 'profile-favorite'));
         this.setState({ isProfileLoading: false });
         Alert.alert(
           intl.formatMessage({

--- a/src/containers/profileEditContainer.tsx
+++ b/src/containers/profileEditContainer.tsx
@@ -121,7 +121,7 @@ class ProfileEditContainer extends Component<any, any> {
             intl.formatMessage({
               id: 'alert.fail',
             }),
-            error.message || error.toString(),
+            error.message || intl.formatMessage({ id: 'alert.unknow_error' }),
           );
         }
         this.setState({ isUploading: false });

--- a/src/containers/profileEditContainer.tsx
+++ b/src/containers/profileEditContainer.tsx
@@ -6,6 +6,7 @@ import ImagePicker from 'react-native-image-crop-picker';
 import get from 'lodash/get';
 
 import { useNavigation } from '@react-navigation/native';
+import { captureException } from '../utils/sentryUtils';
 import { selectCurrentAccount, selectIsDarkTheme, selectPin } from '../redux/selectors';
 import { uploadImage } from '../providers/ecency/ecency';
 
@@ -117,6 +118,7 @@ class ProfileEditContainer extends Component<any, any> {
       })
       .catch((error) => {
         if (error) {
+          captureException(error, (scope) => scope.setTag('context', 'profile-edit-image-upload'));
           Alert.alert(
             intl.formatMessage({
               id: 'alert.fail',

--- a/src/containers/spinGameContainer.ts
+++ b/src/containers/spinGameContainer.ts
@@ -1,11 +1,13 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { Alert } from 'react-native';
+import { useIntl } from 'react-intl';
 import get from 'lodash/get';
 import { useQueryClient } from '@tanstack/react-query';
 import { getGameStatusCheckQueryOptions, useGameClaim } from '@ecency/sdk';
 import { useAuth } from '../hooks';
 
 const RedeemContainer = ({ children }: any) => {
+  const intl = useIntl();
   const queryClient = useQueryClient();
   const { username, code } = useAuth();
 
@@ -34,7 +36,7 @@ const RedeemContainer = ({ children }: any) => {
       return res;
     } catch (err) {
       if (err) {
-        Alert.alert(get(err, 'message') || err.toString());
+        Alert.alert(get(err, 'message') || intl.formatMessage({ id: 'alert.unknow_error' }));
       }
       setIsLoading(false);
       return null;
@@ -53,7 +55,7 @@ const RedeemContainer = ({ children }: any) => {
       );
     } catch (err) {
       if (err) {
-        Alert.alert(get(err, 'message') || err.toString());
+        Alert.alert(get(err, 'message') || intl.formatMessage({ id: 'alert.unknow_error' }));
       }
       return;
     }
@@ -89,7 +91,7 @@ const RedeemContainer = ({ children }: any) => {
       } catch (err) {
         pendingGameStatusRef.current = null;
         if (err) {
-          Alert.alert(get(err, 'message') || err.toString());
+          Alert.alert(get(err, 'message') || intl.formatMessage({ id: 'alert.unknow_error' }));
         }
       }
     };

--- a/src/containers/spinGameContainer.ts
+++ b/src/containers/spinGameContainer.ts
@@ -4,6 +4,7 @@ import { useIntl } from 'react-intl';
 import get from 'lodash/get';
 import { useQueryClient } from '@tanstack/react-query';
 import { getGameStatusCheckQueryOptions, useGameClaim } from '@ecency/sdk';
+import { captureException } from '../utils/sentryUtils';
 import { useAuth } from '../hooks';
 
 const RedeemContainer = ({ children }: any) => {
@@ -36,6 +37,7 @@ const RedeemContainer = ({ children }: any) => {
       return res;
     } catch (err) {
       if (err) {
+        captureException(err, (scope) => scope.setTag('context', 'spin-game-status'));
         Alert.alert(get(err, 'message') || intl.formatMessage({ id: 'alert.unknow_error' }));
       }
       setIsLoading(false);
@@ -55,6 +57,7 @@ const RedeemContainer = ({ children }: any) => {
       );
     } catch (err) {
       if (err) {
+        captureException(err, (scope) => scope.setTag('context', 'spin-game-start'));
         Alert.alert(get(err, 'message') || intl.formatMessage({ id: 'alert.unknow_error' }));
       }
       return;
@@ -91,6 +94,7 @@ const RedeemContainer = ({ children }: any) => {
       } catch (err) {
         pendingGameStatusRef.current = null;
         if (err) {
+          captureException(err, (scope) => scope.setTag('context', 'spin-game-claim'));
           Alert.alert(get(err, 'message') || intl.formatMessage({ id: 'alert.unknow_error' }));
         }
       }

--- a/src/containers/transferContainer.ts
+++ b/src/containers/transferContainer.ts
@@ -84,7 +84,9 @@ class TransferContainer extends Component<any, any> {
       })
       .catch((err) => {
         if (err) {
-          Alert.alert(get(err, 'message') || err.toString());
+          Alert.alert(
+            get(err, 'message') || this.props.intl.formatMessage({ id: 'alert.unknow_error' }),
+          );
         }
       });
   };

--- a/src/containers/transferContainer.ts
+++ b/src/containers/transferContainer.ts
@@ -12,6 +12,7 @@ import {
   getAccountsQueryOptions,
   getRecurrentTransfersQueryOptions,
 } from '@ecency/sdk';
+import { captureException } from '../utils/sentryUtils';
 import { selectCurrentAccount, selectGlobalProps, selectOtherAccounts } from '../redux/selectors';
 import { useTransferMutations } from '../hooks';
 import { getQueryClient } from '../providers/queries';
@@ -84,6 +85,7 @@ class TransferContainer extends Component<any, any> {
       })
       .catch((err) => {
         if (err) {
+          captureException(err, (scope) => scope.setTag('context', 'transfer-points-balance'));
           Alert.alert(
             get(err, 'message') || this.props.intl.formatMessage({ id: 'alert.unknow_error' }),
           );

--- a/src/screens/communityMembers/screen/communityMembersScreen.tsx
+++ b/src/screens/communityMembers/screen/communityMembersScreen.tsx
@@ -20,6 +20,7 @@ import {
   ROLES,
   roleMap,
 } from '@ecency/sdk';
+import { captureException } from '../../../utils/sentryUtils';
 
 import { BasicHeader, UserListItem } from '../../../components';
 import ROUTES from '../../../constants/routeNames';
@@ -160,6 +161,7 @@ const CommunityMembersScreen = ({ route }: any) => {
         applyRoleToSubscribersCache(cached as any, targetAccount, role),
       );
     } catch (err) {
+      captureException(err, (scope) => scope.setTag('context', 'community-role-update'));
       Alert.alert(
         intl.formatMessage({ id: 'alert.fail' }),
         (err as Error)?.message || intl.formatMessage({ id: 'alert.unknow_error' }),

--- a/src/screens/communityMembers/screen/communityMembersScreen.tsx
+++ b/src/screens/communityMembers/screen/communityMembersScreen.tsx
@@ -160,7 +160,10 @@ const CommunityMembersScreen = ({ route }: any) => {
         applyRoleToSubscribersCache(cached as any, targetAccount, role),
       );
     } catch (err) {
-      Alert.alert(intl.formatMessage({ id: 'alert.fail' }), (err as Error)?.message || String(err));
+      Alert.alert(
+        intl.formatMessage({ id: 'alert.fail' }),
+        (err as Error)?.message || intl.formatMessage({ id: 'alert.unknow_error' }),
+      );
     }
   };
 

--- a/src/screens/communitySettings/screen/communitySettingsScreen.tsx
+++ b/src/screens/communitySettings/screen/communitySettingsScreen.tsx
@@ -123,7 +123,10 @@ const CommunitySettingsScreen = ({ route }: any) => {
       dispatch(toastNotification(intl.formatMessage({ id: 'alert.successful' })));
       navigation.goBack();
     } catch (err) {
-      Alert.alert(intl.formatMessage({ id: 'alert.fail' }), (err as Error)?.message || String(err));
+      Alert.alert(
+        intl.formatMessage({ id: 'alert.fail' }),
+        (err as Error)?.message || intl.formatMessage({ id: 'alert.unknow_error' }),
+      );
     } finally {
       setIsSaving(false);
     }

--- a/src/screens/communitySettings/screen/communitySettingsScreen.tsx
+++ b/src/screens/communitySettings/screen/communitySettingsScreen.tsx
@@ -8,6 +8,7 @@ import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view
 import { SafeAreaView } from 'react-native-safe-area-context';
 import EStyleSheet from 'react-native-extended-stylesheet';
 import { getCommunityQueryOptions, ROLES } from '@ecency/sdk';
+import { captureException } from '../../../utils/sentryUtils';
 
 import { BasicHeader, FormInput, MainButton, ToggleSwitch } from '../../../components';
 import { useAppDispatch, useAppSelector } from '../../../hooks';
@@ -123,6 +124,7 @@ const CommunitySettingsScreen = ({ route }: any) => {
       dispatch(toastNotification(intl.formatMessage({ id: 'alert.successful' })));
       navigation.goBack();
     } catch (err) {
+      captureException(err, (scope) => scope.setTag('context', 'community-settings-save'));
       Alert.alert(
         intl.formatMessage({ id: 'alert.fail' }),
         (err as Error)?.message || intl.formatMessage({ id: 'alert.unknow_error' }),

--- a/src/screens/transfer/screen/delegateScreen.tsx
+++ b/src/screens/transfer/screen/delegateScreen.tsx
@@ -315,7 +315,7 @@ const DelegateScreen = ({
         setIsTransfering(false);
         Alert.alert(
           intl.formatMessage({ id: 'alert.error' }),
-          (error as any).message || (error as any).toString(),
+          (error as any).message || intl.formatMessage({ id: 'alert.unknow_error' }),
         );
       }
     },

--- a/src/screens/transfer/screen/delegateScreen.tsx
+++ b/src/screens/transfer/screen/delegateScreen.tsx
@@ -10,6 +10,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { SheetManager } from 'react-native-actions-sheet';
 import { getVestingDelegationsQueryOptions } from '@ecency/sdk';
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
+import { captureException } from '../../../utils/sentryUtils';
 
 import { BasicHeader, TextInput, MainButton, UserAvatar, Icon, Modal } from '../../../components';
 
@@ -313,6 +314,7 @@ const DelegateScreen = ({
         handleOnModalClose?.();
       } catch (error) {
         setIsTransfering(false);
+        captureException(error, (scope) => scope.setTag('context', 'delegate-broadcast'));
         Alert.alert(
           intl.formatMessage({ id: 'alert.error' }),
           (error as any).message || intl.formatMessage({ id: 'alert.unknow_error' }),

--- a/src/screens/transfer/screen/powerDownScreen.tsx
+++ b/src/screens/transfer/screen/powerDownScreen.tsx
@@ -7,6 +7,7 @@ import Animated, { BounceInRight } from 'react-native-reanimated';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { getWithdrawRoutesQueryOptions } from '@ecency/sdk';
 import { useQueryClient } from '@tanstack/react-query';
+import { captureException } from '../../../utils/sentryUtils';
 
 import {
   BasicHeader,
@@ -69,6 +70,7 @@ const PowerDownScreen = ({
         setDestinationAccounts(accounts);
         return res;
       } catch (e) {
+        captureException(e, (scope) => scope.setTag('context', 'withdraw-routes-fetch'));
         Alert.alert(
           intl.formatMessage({ id: 'alert.error' }),
           (e as any).message || intl.formatMessage({ id: 'alert.unknow_error' }),
@@ -94,6 +96,7 @@ const PowerDownScreen = ({
         }
       } catch (error) {
         setIsTransfering(false);
+        captureException(error, (scope) => scope.setTag('context', 'power-down-broadcast'));
         Alert.alert(
           intl.formatMessage({ id: 'alert.error' }),
           (error as any).message || intl.formatMessage({ id: 'alert.unknow_error' }),

--- a/src/screens/transfer/screen/powerDownScreen.tsx
+++ b/src/screens/transfer/screen/powerDownScreen.tsx
@@ -71,7 +71,7 @@ const PowerDownScreen = ({
       } catch (e) {
         Alert.alert(
           intl.formatMessage({ id: 'alert.error' }),
-          (e as any).message || (e as any).toString(),
+          (e as any).message || intl.formatMessage({ id: 'alert.unknow_error' }),
         );
       }
     },
@@ -96,7 +96,7 @@ const PowerDownScreen = ({
         setIsTransfering(false);
         Alert.alert(
           intl.formatMessage({ id: 'alert.error' }),
-          (error as any).message || (error as any).toString(),
+          (error as any).message || intl.formatMessage({ id: 'alert.unknow_error' }),
         );
       }
     },


### PR DESCRIPTION
Closes #2684

Sixteen user-facing alerts across eleven files fell back to `error.toString()` or `String(err)` for the message body, which shows raw stringified output when a throw carries no `message` (worst case `[object Object]`). All of them now fall back to the existing `alert.unknow_error` locale string ("An error occurred"), keeping the real `error.message` when present.

- spinGameContainer had no intl access and gains `useIntl` for its three alert sites; transferContainer's class site uses its injected intl.
- The `toString()` uses that only sniff status codes (409/413 matching in editorQueries and uploadsGalleryModal) are matching logic, not user-facing text, and are untouched. mediaPickerError's internal normalizer is also out of scope since it feeds its own message-mapping table.

Zero typecheck errors; behavior change is limited to what the fallback string says.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error alerts across profile, upload, transfer, community, and game actions.
  * Displays clearer localized fallback messaging when specific error details are unavailable.
  * Preserves available error messages while avoiding unclear technical error text.
  * Improved consistency of save-failure alerts.
  * Improved error reporting to help diagnose failures across key actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

**Second commit (937eaee8c4), addressing review feedback:** the generic fallback also hides diagnostics from screenshots, so every one of the sixteen catch sites now reports the error to Sentry via the typed helper with a `context` tag naming the flow (`spin-game-status`, `transfer-points-balance`, `profile-fetch`, `profile-favorite`, `delegate-broadcast`, `power-down-broadcast`, `withdraw-routes-fetch`, `community-role-update`, `media-upload-batch` and so on) before alerting. Thirteen of the sixteen previously reported nothing anywhere, including the delegation and power-down broadcast failures. If user-cancelled broadcasts turn out to flood any of these tags, filtering by tag in Sentry is now a one-liner.