### PR TITLE
Reveal profile summary on upward scroll anywhere in the feed

### DIFF
--- a/src/components/profile/profileView.tsx
+++ b/src/components/profile/profileView.tsx
@@ -38,11 +38,25 @@ import { Icon } from '..';
 const SUMMARY_COLLAPSE_THRESHOLD = 80;
 const SUMMARY_EXPAND_THRESHOLD = 8;
 const SUMMARY_TOGGLE_COOLDOWN_MS = 550;
+// The header also reveals mid-list once the user has dragged upward this many px in one
+// continuous run (#1915). Because the header can now be open while scrolled deep into the
+// list, collapse must be direction-aware as well or the next cooldown recheck past the
+// threshold would immediately undo a mid-list reveal: both legs read one signed run that
+// accumulates same-direction deltas and resets when direction flips. Per-event deltas at
+// or above the jump size are layout blips (the post-toggle reflow, tab switches), not
+// user scrolling: they zero the run, because a stale blip-inflated run would otherwise
+// mistoggle when the cooldown recheck fires.
+const SUMMARY_REVEAL_SCROLL_UP_PX = 60;
+const SUMMARY_COLLAPSE_RUN_PX = 20;
+const SUMMARY_LAYOUT_JUMP_PX = 250;
 
 class ProfileView extends PureComponent<any, any> {
   _lastSummaryToggleAt = 0;
 
   _lastOffsetY = 0;
+
+  // signed: positive = downward scrolling, negative = upward
+  _scrollRun = 0;
 
   _summaryRecheckTimer: any = null;
 
@@ -69,8 +83,13 @@ class ProfileView extends PureComponent<any, any> {
   _evaluateSummary = () => {
     const { isSummaryOpen } = this.state;
     const offsetY = this._lastOffsetY;
-    const wantCollapse = isSummaryOpen && offsetY > SUMMARY_COLLAPSE_THRESHOLD;
-    const wantExpand = !isSummaryOpen && offsetY <= SUMMARY_EXPAND_THRESHOLD;
+    const wantCollapse =
+      isSummaryOpen &&
+      offsetY > SUMMARY_COLLAPSE_THRESHOLD &&
+      this._scrollRun >= SUMMARY_COLLAPSE_RUN_PX;
+    const wantExpand =
+      !isSummaryOpen &&
+      (offsetY <= SUMMARY_EXPAND_THRESHOLD || this._scrollRun <= -SUMMARY_REVEAL_SCROLL_UP_PX);
     if (!wantCollapse && !wantExpand) {
       return;
     }
@@ -89,6 +108,7 @@ class ProfileView extends PureComponent<any, any> {
     }
 
     this._lastSummaryToggleAt = now;
+    this._scrollRun = 0;
     this.setState({ isSummaryOpen: wantExpand });
   };
 
@@ -96,6 +116,13 @@ class ProfileView extends PureComponent<any, any> {
     const offsetY = event?.nativeEvent?.contentOffset?.y;
     if (offsetY === undefined) {
       return;
+    }
+    const delta = offsetY - this._lastOffsetY;
+    if (Math.abs(delta) >= SUMMARY_LAYOUT_JUMP_PX) {
+      this._scrollRun = 0;
+    } else if (delta !== 0) {
+      const sameDirection = delta > 0 === this._scrollRun > 0 || this._scrollRun === 0;
+      this._scrollRun = sameDirection ? this._scrollRun + delta : delta;
     }
     this._lastOffsetY = offsetY;
     this._evaluateSummary();


### PR DESCRIPTION
Closes #1915

Most of what this 2021 issue asked for already landed in the recent profile design pass: the collapse is animated (500ms CollapsibleCard height), automated (dead zone plus cooldown against oscillation) and revertable at the top. The remaining gap was the reveal: the header only re-expanded within 8px of the top, so scrolling back up mid-list never brought it back.

Both toggle legs now read one signed scroll run: same-direction deltas accumulate, a direction flip resets the run to the new delta and per-event deltas of 250px or more are treated as layout blips (post-toggle reflow, tab switches) that zero it. 60px of continuous upward drag reveals the header anywhere in the list; collapse now requires 20px of downward run on top of the existing 80px threshold, which keeps a cooldown recheck from undoing a mid-list reveal (the old code could assume open means near-top; this change breaks that invariant so collapse had to become direction-aware too).

Out of scope, noted for the record: a fully interactive proportional collapse (header tracking the finger, head-tab-view style) would need the header restructured into an overlay with a shared animated value across every tab's list. The issue itself recorded that attempt as not worth the trouble; this delivers the missing behavior with the existing machinery.

Device pass: profile feed scroll down (collapses past 80px), drag up mid-list (header reveals after ~60px), flick between tabs at different offsets (no spurious toggles), settle at top (stays expanded).