### PR TITLE
fix(dictation): stop calling into the recorder after expo-audio released it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,7 +172,13 @@ Uses `react-native-actions-sheet` for globally-registered bottom sheets:
 - Registry: `src/navigation/sheets.tsx` — all sheets registered with `SheetNames` enum
 - Show from anywhere: `SheetManager.show(SheetNames.MY_SHEET, { payload: {...} })`
 - Returns value: `const result = await SheetManager.show(...)` — resolves when sheet closes
-- Sheets stay mounted — reset state in `useEffect(() => { ... }, [payload])`
+- Sheets are registered globally but MOUNT on show and UNMOUNT on hide (`SheetProvider`
+  renders `!visible ? null : <Sheet/>`), so mount-time state resets are enough and any
+  unmount cleanup runs on every close, not rarely
+- Sheets render as siblings of `<Application/>` (`src/index.tsx`), so they sit OUTSIDE the
+  app's `ErrorBoundary`: a throw from a sheet's render or effect cleanup is uncaught and
+  fatal. Be careful with native/Expo shared objects in cleanups. Expo hooks such as
+  `useAudioRecorder` release their native object before any cleanup you declare after them
 
 ### Styling
 

--- a/src/components/dictationModal/dictationModal.tsx
+++ b/src/components/dictationModal/dictationModal.tsx
@@ -81,10 +81,9 @@ export const DictationModal = ({ payload }: SheetProps<SheetNames.DICTATION>) =>
     SheetManager.hide(SheetNames.DICTATION);
   }, [reset]);
 
-  // Sheets in this app STAY MOUNTED, so the unmount cleanup below effectively never
-  // fires and state would otherwise persist into the next open -- stale segment
-  // counts, or a failed recording offered for retry against a different draft.
-  // Reset per open, which is the documented convention for sheets here.
+  // Reset per open: stale segment counts, or a failed recording offered for retry
+  // against a different draft, must never survive into the next presentation.
+  // The sheet unmounts on hide, so this runs on mount for every presentation.
   useEffect(() => {
     closedRef.current = false;
     reset();

--- a/src/hooks/useDictationRecorder.test.tsx
+++ b/src/hooks/useDictationRecorder.test.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+
+// Mirrors expo-audio for real: useAudioRecorder delegates to useReleasingSharedObject,
+// which registers its release() cleanup FIRST, so it runs before any cleanup declared
+// later in useDictationRecorder. After release the JS object is detached from its
+// native counterpart and every native member access throws.
+const mockState = { released: false };
+const mockSetAudioModeAsync = jest.fn(async () => undefined);
+
+function mockThrowIfReleased(member: string) {
+  if (mockState.released) {
+    throw new Error(
+      `Unable to find the native shared object associated with given JavaScript object (${member})`,
+    );
+  }
+}
+
+jest.mock('expo-audio', () => ({
+  RecordingPresets: { HIGH_QUALITY: {} },
+  requestRecordingPermissionsAsync: jest.fn(async () => ({ granted: true })),
+  setAudioModeAsync: (...args: any[]) => (mockSetAudioModeAsync as any)(...args),
+  useAudioRecorder: () => {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { useEffect } = require('react');
+    useEffect(
+      () => () => {
+        mockState.released = true;
+      },
+      [],
+    );
+    return {
+      get isRecording() {
+        mockThrowIfReleased('isRecording');
+        return false;
+      },
+      get uri() {
+        mockThrowIfReleased('uri');
+        return null;
+      },
+      record: jest.fn(() => mockThrowIfReleased('record')),
+      stop: jest.fn(async () => mockThrowIfReleased('stop')),
+      prepareToRecordAsync: jest.fn(async () => mockThrowIfReleased('prepareToRecordAsync')),
+    };
+  },
+}));
+
+// eslint-disable-next-line import/first
+import { useDictationRecorder } from './useDictationRecorder';
+
+function Probe() {
+  useDictationRecorder({ maxSeconds: 300 });
+  return null;
+}
+
+describe('useDictationRecorder unmount', () => {
+  beforeEach(() => {
+    mockState.released = false;
+    mockSetAudioModeAsync.mockClear();
+  });
+
+  // Registered sheets unmount on hide, so this is what happens every time the user
+  // closes the dictation sheet. Touching the recorder here used to throw an uncaught
+  // fatal, because expo-audio had already released it.
+  it('does not touch the recorder after expo-audio released it', () => {
+    let renderer: any;
+    act(() => {
+      renderer = TestRenderer.create(<Probe />);
+    });
+
+    expect(() => act(() => renderer.unmount())).not.toThrow();
+  });
+
+  it('still deactivates the recording session on unmount', () => {
+    let renderer: any;
+    act(() => {
+      renderer = TestRenderer.create(<Probe />);
+    });
+    act(() => renderer.unmount());
+
+    expect(mockSetAudioModeAsync).toHaveBeenCalledWith({ allowsRecording: false });
+  });
+});

--- a/src/hooks/useDictationRecorder.ts
+++ b/src/hooks/useDictationRecorder.ts
@@ -32,11 +32,10 @@ interface Options {
  * is deliberate on two counts.
  *
  * It avoids `useAudioRecorderState`, whose implementation polls the recorder's
- * SYNCHRONOUS native getStatus() on a setInterval. Sheets in this app stay mounted
- * (see CLAUDE.md), so that poll never stops -- it keeps calling into a native audio
- * object for the rest of the session, and once that object is no longer valid the
- * sync getter faults and takes the whole process down with EXC_BAD_ACCESS. That
- * crashed an iOS TestFlight build immediately after a successful transcription.
+ * SYNCHRONOUS native getStatus() on a setInterval. That poll outlives the recorder
+ * it reads, and once the native object is gone the sync getter faults and takes the
+ * whole process down with EXC_BAD_ACCESS. That crashed an iOS TestFlight build
+ * immediately after a successful transcription.
  *
  * It also survives stopping: the recorder zeroes its own duration on stop, which is
  * why the timer used to snap back to 0:00 the moment the user finished speaking.
@@ -161,20 +160,29 @@ export function useDictationRecorder({ maxSeconds }: Options) {
     }
   }, [state, durationMs, maxSeconds, stop]);
 
-  // Sheets in this app stay mounted, so this rarely fires -- but a real unmount must
-  // not leave the microphone open or the ticker running.
+  // Registered sheets UNMOUNT on hide, so this runs every time the sheet is closed.
+  //
+  // It must not touch `recorder`. expo-audio's useAudioRecorder is the first hook
+  // here, so its useReleasingSharedObject cleanup runs BEFORE this one and has
+  // already called release(), detaching the JS object from its native counterpart.
+  // Reading even `recorder.isRecording` at this point throws
+  // NativeSharedObjectNotFoundException on iOS / InvalidSharedObjectIdException on
+  // Android, and sheets render outside the app's ErrorBoundary, so the throw reaches
+  // React Native's global handler as a fatal and kills the app.
+  //
+  // Nothing is leaked by staying away from it: release() already stops a running
+  // recorder (iOS sharedObjectWillRelease, Android sharedObjectDidRelease -> reset).
+  // setAudioModeAsync is a module function rather than a method on the released
+  // object, so deactivating the recording session here is still safe.
   useEffect(
     () => () => {
       generationRef.current += 1;
       if (tickRef.current) {
         clearInterval(tickRef.current);
       }
-      if (recorder.isRecording) {
-        recorder.stop().catch(() => undefined);
-      }
       setAudioModeAsync({ allowsRecording: false }).catch(() => undefined);
     },
-    [recorder],
+    [],
   );
 
   return { state, seconds, durationMs, result, start, stop, reset };


### PR DESCRIPTION
Closes #3466

Tapping **Done** in the dictation sheet closed the sheet and killed the app.

## What was happening

Registered sheets unmount on hide (`SheetProvider` renders `!visible ? null : <Sheet/>`), so `useDictationRecorder`'s unmount cleanup runs on every close, not "rarely" as its comment claimed.

`useAudioRecorder` is the first hook in `useDictationRecorder`, so its internal `useReleasingSharedObject` cleanup runs first and calls `recorder.release()`, detaching the JS object from its native counterpart. The cleanup declared after it then read `recorder.isRecording`, which throws `NativeSharedObjectNotFoundException` on iOS and `InvalidSharedObjectIdException` on Android.

Sheets render as siblings of `<Application/>` (`src/index.tsx`), so they sit outside the app's `ErrorBoundary`. The throw reached React Native's global handler as a fatal.

## Change

- The unmount cleanup no longer touches `recorder`. It clears the ticker and deactivates the recording session, nothing else.
- Dropping the `recorder.stop()` leaks nothing: `release()` already stops a running recorder on both platforms (iOS `sharedObjectWillRelease`, Android `sharedObjectDidRelease` -> `reset`).
- Side benefit: `setAudioModeAsync({ allowsRecording: false })` used to be skipped because the throw happened on the line above it, leaving the iOS session active in `.playAndRecord` after dictation. It now runs.
- Corrects the "sheets stay mounted" claim in `CLAUDE.md` and the comments written against it, and documents that sheets sit outside the `ErrorBoundary`.

## Test plan

- New `src/hooks/useDictationRecorder.test.tsx` mounts the hook against a mock mirroring expo-audio's real hook ordering, where the recorder throws on any member access after release. Verified it **fails** on the pre-fix code with `Unable to find the native shared object associated with given JavaScript object (isRecording)` and passes after.
- `yarn test:ci` green: 738 passed, 1 skipped.
- `tsc --noEmit` clean, eslint clean on changed files.
- Device check worth doing: dictate, tap Done, and confirm no crash; then confirm the same for backdrop tap, back press, and opening then closing without recording, which all took the same path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dictation cleanup when closing the recording modal.
  * Prevented crashes caused by accessing released recording resources during unmount.
  * Ensured recording sessions are safely deactivated and pending status checks are cancelled.

* **Documentation**
  * Clarified modal mounting, unmounting, state reset, error handling, and native-resource cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->